### PR TITLE
Upgrade libwebp to version 1.3.2 to fix CVE-2023-4863 vulnerability.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -32,7 +32,7 @@
       },
       {
         "url": "https://github.com/webmproject/libwebp.git",
-        "commit": "9ce5843dbabcfd3f7c39ec7ceba9cbeb213cbfdf",
+        "commit": "233960a0ad8c640acd458a6966dea09e12c1325a",
         "dir": "third_party/libwebp"
       },
       {

--- a/vendor.json
+++ b/vendor.json
@@ -35,7 +35,8 @@
       "cmake": {
         "targets": [
           "webp",
-          "webpdemux"
+          "webpdemux",
+          "sharpyuv"
         ]
       }
     },


### PR DESCRIPTION
Co-authored-by: kevingpqi <kevingpqi@tencent.com>