### PR TITLE
Fix PNG decoder error handling

### DIFF
--- a/src/codecs/png/PngCodec.cpp
+++ b/src/codecs/png/PngCodec.cpp
@@ -179,6 +179,9 @@ bool PngCodec::readPixels(const ImageInfo& dstInfo, void* dstPixels) const {
   if (readInfo->rowPtrs == nullptr) {
     return false;
   }
+  if (setjmp(png_jmpbuf(readInfo->p))) {
+    return false;
+  }
   if (dstInfo.colorType() == ColorType::RGBA_8888 &&
       dstInfo.alphaType() == AlphaType::Unpremultiplied) {
     for (size_t i = 0; i < static_cast<size_t>(h); i++) {


### PR DESCRIPTION
If the PNG file is corrupted (but the file header is intact), tgfx will crash.
This pr complete the error handling in 'src/codecs/png/PngCodec.cpp'