### PR TITLE
Add the mssing clear op in the PictureImage class.

### DIFF
--- a/src/core/images/PictureImage.cpp
+++ b/src/core/images/PictureImage.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<TextureProxy> PictureImage::onLockTextureProxy(const TPArgs& arg
   textureProxy =
       proxyProvider->createTextureProxy(args.uniqueKey, _width, _height, format, args.mipmapped,
                                         ImageOrigin::TopLeft, args.renderFlags);
-  auto renderTarget = proxyProvider->createRenderTargetProxy(textureProxy, format);
+  auto renderTarget = proxyProvider->createRenderTargetProxy(textureProxy, format, 1, true);
   if (renderTarget == nullptr) {
     return nullptr;
   }

--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<OpsRenderTask> DrawingManager::addOpsTask(
   checkIfResolveNeeded(renderTargetProxy);
   auto opsTask = std::make_shared<OpsRenderTask>(renderTargetProxy);
   addRenderTask(opsTask);
-  activeOpsTask = opsTask.get();
+  activeOpsTask = opsTask;
   return opsTask;
 }
 

--- a/src/gpu/DrawingManager.h
+++ b/src/gpu/DrawingManager.h
@@ -56,7 +56,7 @@ class DrawingManager {
   std::unordered_set<std::shared_ptr<RenderTargetProxy>> needResolveTargets = {};
   std::vector<std::shared_ptr<ResourceTask>> resourceTasks = {};
   std::vector<std::shared_ptr<RenderTask>> renderTasks = {};
-  OpsRenderTask* activeOpsTask = nullptr;
+  std::shared_ptr<OpsRenderTask> activeOpsTask = nullptr;
 
   void addRenderTask(std::shared_ptr<RenderTask> renderTask);
   void checkIfResolveNeeded(std::shared_ptr<RenderTargetProxy> renderTargetProxy);

--- a/src/gpu/ProxyProvider.h
+++ b/src/gpu/ProxyProvider.h
@@ -105,10 +105,12 @@ class ProxyProvider {
                                                    bool adopted = false);
   /**
    * Creates an empty RenderTargetProxy with specified width, height, format, sample count,
-   * mipmap state and origin.
+   * mipmap state and origin. If clearAll is true, the entire render target will be cleared
+   * to transparent black.
    */
   std::shared_ptr<RenderTargetProxy> createRenderTargetProxy(
-      std::shared_ptr<TextureProxy> textureProxy, PixelFormat format, int sampleCount = 1);
+      std::shared_ptr<TextureProxy> textureProxy, PixelFormat format, int sampleCount = 1,
+      bool clearAll = false);
 
   /**
    * Creates a render target proxy for the given BackendRenderTarget.

--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -83,13 +83,9 @@ Rect RenderContext::clipLocalBounds(const Rect& localBounds, const MCState& stat
 }
 
 void RenderContext::clear() {
-  FillStyle style = {};
-  style.color = Color::Transparent();
-  style.blendMode = BlendMode::Src;
   auto renderTarget = opContext->renderTarget();
   auto rect = Rect::MakeWH(renderTarget->width(), renderTarget->height());
-  MCState state = {};
-  drawAsClear(rect, state, style);
+  addOp(ClearOp::Make(Color::Transparent(), rect), [] { return true; });
 }
 
 void RenderContext::drawRect(const Rect& rect, const MCState& state, const FillStyle& style) {
@@ -399,14 +395,12 @@ std::shared_ptr<TextureProxy> RenderContext::getClipTexture(const Path& clip) {
     auto drawOp =
         TriangulatingPathOp::Make(Color::White(), clip, rasterizeMatrix, nullptr, renderFlags);
     drawOp->setAA(AAType::Coverage);
-    auto renderTarget = RenderTargetProxy::MakeFallback(getContext(), width, height, true);
+    auto renderTarget = RenderTargetProxy::MakeFallback(getContext(), width, height, true, 1, false,
+                                                        ImageOrigin::TopLeft, true);
     if (renderTarget == nullptr) {
       return nullptr;
     }
     OpContext context(renderTarget);
-    // Since the clip may not coverage the entire render target, we need to clear the render target
-    // to transparent. Otherwise, the associated texture will have undefined pixels outside the clip.
-    context.addOp(ClearOp::Make(Color::Transparent(), Rect::MakeWH(width, height)));
     context.addOp(std::move(drawOp));
     clipTexture = renderTarget->getTextureProxy();
   } else {

--- a/src/gpu/Surface.cpp
+++ b/src/gpu/Surface.cpp
@@ -33,13 +33,9 @@ std::shared_ptr<Surface> Surface::Make(Context* context, int width, int height, 
 std::shared_ptr<Surface> Surface::Make(Context* context, int width, int height, ColorType colorType,
                                        int sampleCount, bool mipmapped, uint32_t renderFlags) {
   auto pixelFormat = ColorTypeToPixelFormat(colorType);
-  auto proxy = RenderTargetProxy::Make(context, width, height, pixelFormat, sampleCount, mipmapped);
-  auto surface = MakeFrom(std::move(proxy), renderFlags);
-  if (surface != nullptr) {
-    // Clear the surface by default for internally created RenderTarget.
-    surface->getCanvas()->clear();
-  }
-  return surface;
+  auto proxy = RenderTargetProxy::Make(context, width, height, pixelFormat, sampleCount, mipmapped,
+                                       ImageOrigin::TopLeft, true);
+  return MakeFrom(std::move(proxy), renderFlags);
 }
 
 std::shared_ptr<Surface> Surface::MakeFrom(Context* context,

--- a/src/gpu/proxies/RenderTargetProxy.h
+++ b/src/gpu/proxies/RenderTargetProxy.h
@@ -54,34 +54,26 @@ class RenderTargetProxy : public ResourceProxy {
 
   /**
    * Creates a new RenderTargetProxy instance with specified context, with, height, format, sample
-   * count, mipmap state and origin.
+   * count, mipmap state and origin. If clearAll is true, the entire render target will be cleared
+   * to transparent black.
    */
   static std::shared_ptr<RenderTargetProxy> Make(Context* context, int width, int height,
                                                  PixelFormat format = PixelFormat::RGBA_8888,
                                                  int sampleCount = 1, bool mipmapped = false,
-                                                 ImageOrigin origin = ImageOrigin::TopLeft);
-
-  /**
-   * Creates a new RenderTargetProxy instance with specified context, with, height, formats, sample
-   * count, mipmap state and origin. If the first format is not supported, it will try the next one
-   * in the format list.
-   */
-  static std::shared_ptr<RenderTargetProxy> MakeFallback(Context* context, int width, int height,
-                                                         std::vector<PixelFormat> formats,
-                                                         int sampleCount = 1,
-                                                         bool mipmapped = false,
-                                                         ImageOrigin origin = ImageOrigin::TopLeft);
+                                                 ImageOrigin origin = ImageOrigin::TopLeft,
+                                                 bool clearAll = false);
 
   /**
    * Creates a new RenderTargetProxy instance with the specified context, width, height, sample
    * count, mipmap state, and origin. If `isAlphaOnly` is true, it will try to use the ALPHA_8
    * format and fall back to RGBA_8888 if not supported. Otherwise, it will use the RGBA_8888
-   * format.
+   * format. If clearAll is true, the entire render target will be cleared to transparent black.
    */
   static std::shared_ptr<RenderTargetProxy> MakeFallback(Context* context, int width, int height,
                                                          bool isAlphaOnly, int sampleCount = 1,
                                                          bool mipmapped = false,
-                                                         ImageOrigin origin = ImageOrigin::TopLeft);
+                                                         ImageOrigin origin = ImageOrigin::TopLeft,
+                                                         bool clearAll = false);
 
   /**
    * Returns the width of the render target.
@@ -158,17 +150,20 @@ class RenderTargetProxy : public ResourceProxy {
   std::shared_ptr<TextureProxy> makeTextureProxy(int width, int height) const;
 
   /**
-   * Creates a compatible RenderTargetProxy instance matches the properties of this one.
+   * Creates a compatible RenderTargetProxy instance matches the properties of this one. If clearAll
+   * is true, the returned render target will be cleared to transparent black.
    */
-  std::shared_ptr<RenderTargetProxy> makeRenderTargetProxy() const {
-    return makeRenderTargetProxy(width(), height());
+  std::shared_ptr<RenderTargetProxy> makeRenderTargetProxy(bool clearAll = false) const {
+    return makeRenderTargetProxy(width(), height(), clearAll);
   }
 
   /**
    * Creates a compatible RenderTargetProxy instance of the specified size that matches the
-   * properties of this one.
+   * properties of this one. If clearAll is true, the returned render target will be cleared to
+   * transparent black.
    */
-  std::shared_ptr<RenderTargetProxy> makeRenderTargetProxy(int width, int height) const;
+  std::shared_ptr<RenderTargetProxy> makeRenderTargetProxy(int width, int height,
+                                                           bool clearAll = false) const;
 
  protected:
   RenderTargetProxy(UniqueKey uniqueKey, int width, int height, PixelFormat format, int sampleCount,
@@ -183,7 +178,8 @@ class RenderTargetProxy : public ResourceProxy {
 
   static std::shared_ptr<RenderTargetProxy> Create(Context* context, int width, int height,
                                                    PixelFormat format, int sampleCount,
-                                                   bool mipmapped, ImageOrigin origin);
+                                                   bool mipmapped, ImageOrigin origin,
+                                                   bool clearAll);
 
   friend class ProxyProvider;
 };

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -114,6 +114,8 @@ TGFX_TEST(CanvasTest, merge_draw_call_rect) {
   int width = 72;
   int height = 72;
   auto surface = Surface::Make(context, width, height);
+  // clear the pending ClearOp.
+  context->flush();
   auto canvas = surface->getCanvas();
   canvas->clearRect(Rect::MakeWH(surface->width(), surface->height()), Color::White());
   Paint paint;
@@ -156,7 +158,7 @@ TGFX_TEST(CanvasTest, merge_draw_call_rect) {
   auto* drawingManager = context->drawingManager();
   EXPECT_TRUE(drawingManager->renderTasks.size() == 1);
   auto task = std::static_pointer_cast<OpsRenderTask>(drawingManager->renderTasks[0]);
-  EXPECT_TRUE(task->ops.size() == 2);
+  ASSERT_TRUE(task->ops.size() == 2);
   EXPECT_EQ(static_cast<FillRectOp*>(task->ops[1].get())->rectPaints.size(), drawCallCount);
   context->flush();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/merge_draw_call_rect"));
@@ -171,6 +173,8 @@ TGFX_TEST(CanvasTest, merge_draw_call_rrect) {
   int width = 72;
   int height = 72;
   auto surface = Surface::Make(context, width, height);
+  // clear the pending ClearOp.
+  context->flush();
   auto canvas = surface->getCanvas();
   canvas->clearRect(Rect::MakeWH(width, height), Color::White());
   Paint paint;
@@ -197,7 +201,7 @@ TGFX_TEST(CanvasTest, merge_draw_call_rrect) {
   auto* drawingManager = context->drawingManager();
   EXPECT_TRUE(drawingManager->renderTasks.size() == 1);
   auto task = std::static_pointer_cast<OpsRenderTask>(drawingManager->renderTasks[0]);
-  EXPECT_TRUE(task->ops.size() == 2);
+  ASSERT_TRUE(task->ops.size() == 2);
   EXPECT_EQ(static_cast<RRectOp*>(task->ops[1].get())->rRectPaints.size(), drawCallCount);
   context->flush();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/merge_draw_call_rrect"));
@@ -212,6 +216,8 @@ TGFX_TEST(CanvasTest, merge_draw_clear_op) {
   int width = 72;
   int height = 72;
   auto surface = Surface::Make(context, width, height);
+  // clear the pending ClearOp.
+  context->flush();
   auto canvas = surface->getCanvas();
   canvas->clearRect(Rect::MakeWH(width, height), Color::White());
   canvas->save();


### PR DESCRIPTION
整理了所有内部创建的 RenderTargetProxy 需要清屏的情况，统一改为使用 ProxyProvider 上的 clearAll 参数清屏。