### PR TITLE
Fix the issue that ScalerContext might be nullptr during Font initialization.

### DIFF
--- a/src/core/Font.cpp
+++ b/src/core/Font.cpp
@@ -20,7 +20,6 @@
 #include "ScalerContext.h"
 
 namespace tgfx {
-static auto EmptyContext = ScalerContext::MakeEmpty(0);
 
 class GlyphImageGenerator : public ImageGenerator {
  public:
@@ -43,7 +42,7 @@ class GlyphImageGenerator : public ImageGenerator {
   GlyphID glyphID = 0;
 };
 
-Font::Font() : scalerContext(EmptyContext) {
+Font::Font() : scalerContext(ScalerContext::MakeEmpty(0.0f)) {
 }
 
 Font::Font(std::shared_ptr<Typeface> tf, float textSize)

--- a/src/core/ScalerContext.cpp
+++ b/src/core/ScalerContext.cpp
@@ -57,6 +57,10 @@ std::shared_ptr<ScalerContext> ScalerContext::MakeEmpty(float size) {
   if (size < 0) {
     size = 0;
   }
+  if (size == 0) {
+    static auto EmptyContext = std::make_shared<EmptyScalerContext>(0.0f);
+    return EmptyContext;
+  }
   return std::make_shared<EmptyScalerContext>(size);
 }
 


### PR DESCRIPTION
修复Font初始化时，全局ScalerContext可能为nullptr导致后续crash的问题