### PR TITLE
Added a return value to the render method of DisplayList

### DIFF
--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -41,11 +41,12 @@ class DisplayList {
 
   /**
    * Draws the display list to the given surface.
+   * Returns false if the surface is a nullptr or if the surface does not require an update.
    * @param surface The surface to draw the display list to.
    * @param replaceAll If true, the surface will be cleared before drawing the display list.
    * Otherwise, the display list will be drawn on top of the existing content.
    */
-  void render(Surface* surface, bool replaceAll = true);
+  bool render(Surface* surface, bool replaceAll = true);
 
  private:
   std::shared_ptr<Layer> _root = nullptr;

--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -40,11 +40,11 @@ class DisplayList {
   Layer* root() const;
 
   /**
-   * Draws the display list to the given surface.
-   * Returns false if the surface is a nullptr or if the surface does not require an update.
-   * @param surface The surface to draw the display list to.
-   * @param replaceAll If true, the surface will be cleared before drawing the display list.
-   * Otherwise, the display list will be drawn on top of the existing content.
+   * Renders the display list onto the given surface.
+   * @param surface The surface to render the display list on.
+   * @param replaceAll If true, the surface will be cleared before rendering the display list.
+   * Otherwise, the display list will be rendered over the existing content.
+   * @return True if the surface content was updated, otherwise false.
    */
   bool render(Surface* surface, bool replaceAll = true);
 

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -29,10 +29,10 @@ Layer* DisplayList::root() const {
   return _root.get();
 }
 
-void DisplayList::render(Surface* surface, bool replaceAll) {
+bool DisplayList::render(Surface* surface, bool replaceAll) {
   if (!surface || (replaceAll && surface->_uniqueID == surfaceID &&
                    surface->contentVersion() == surfaceContentVersion && !_root->bitFields.dirty)) {
-    return;
+    return false;
   }
   auto canvas = surface->getCanvas();
   if (replaceAll) {
@@ -42,6 +42,7 @@ void DisplayList::render(Surface* surface, bool replaceAll) {
   _root->drawLayer(args, canvas, 1.0f, BlendMode::SrcOver);
   surfaceContentVersion = surface->contentVersion();
   surfaceID = surface->_uniqueID;
+  return true;
 }
 
 }  // namespace tgfx

--- a/src/layers/ImageLayer.cpp
+++ b/src/layers/ImageLayer.cpp
@@ -43,6 +43,9 @@ void ImageLayer::setImage(std::shared_ptr<Image> value) {
 }
 
 std::unique_ptr<LayerContent> ImageLayer::onUpdateContent() {
+  if (!_image) {
+    return nullptr;
+  }
   return std::make_unique<ImageContent>(_image, _sampling);
 }
 }  // namespace tgfx

--- a/src/layers/ShapeLayer.cpp
+++ b/src/layers/ShapeLayer.cpp
@@ -150,7 +150,7 @@ ShapeLayer::~ShapeLayer() {
 
 std::unique_ptr<LayerContent> ShapeLayer::onUpdateContent() {
   std::vector<std::unique_ptr<LayerContent>> contents = {};
-  auto path = _path.isEmpty() ? _pathProvider->getPath() : _path;
+  auto path = _pathProvider ? _pathProvider->getPath() : _path;
   if (_fillStyle) {
     auto content = std::make_unique<ShapeContent>(path, _fillStyle->getShader());
     contents.push_back(std::move(content));

--- a/src/layers/ShapeLayer.cpp
+++ b/src/layers/ShapeLayer.cpp
@@ -150,7 +150,10 @@ ShapeLayer::~ShapeLayer() {
 
 std::unique_ptr<LayerContent> ShapeLayer::onUpdateContent() {
   std::vector<std::unique_ptr<LayerContent>> contents = {};
-  auto path = _pathProvider ? _pathProvider->getPath() : _path;
+  if (_path.isEmpty() && _pathProvider == nullptr) {
+    return nullptr;
+  }
+  auto path = _path.isEmpty() ? _pathProvider->getPath() : _path;
   if (_fillStyle) {
     auto content = std::make_unique<ShapeContent>(path, _fillStyle->getShader());
     contents.push_back(std::move(content));


### PR DESCRIPTION
1. DisplayList的render方法添加返回值
2. 修复ShapeLayer中Path和PathProvider同时为空导致的crash