### PR TITLE
Fix the issue of time consumption when reading invisible characters on the web platform

### DIFF
--- a/web/src/core/scaler-context.ts
+++ b/web/src/core/scaler-context.ts
@@ -25,6 +25,7 @@ import type {Rect} from '../types';
 export class ScalerContext {
     public static canvas: HTMLCanvasElement | OffscreenCanvas;
     public static context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    private static hasMeasureBoundsAPI: boolean | undefined = undefined;
 
     public static setCanvas(canvas: HTMLCanvasElement | OffscreenCanvas) {
         ScalerContext.canvas = canvas;
@@ -54,6 +55,14 @@ export class ScalerContext {
         return emojiRegExp.test(text);
     }
 
+    private static measureDirectly(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D): boolean {
+        if (ScalerContext.hasMeasureBoundsAPI === undefined) {
+            const metrics = ctx.measureText('x');
+            ScalerContext.hasMeasureBoundsAPI = metrics && metrics.actualBoundingBoxAscent > 0;
+        }
+        return ScalerContext.hasMeasureBoundsAPI;
+    }
+
     private readonly fontName: string;
     private readonly fontStyle: string;
     private readonly size: number;
@@ -63,8 +72,6 @@ export class ScalerContext {
         xHeight: number;
         capHeight: number;
     };
-    private static hasTestedMeasureApi: boolean = false;
-    private static directMeasurementEnabled: boolean = false;
 
     private fontBoundingBoxMap: { key: string; value: Rect }[] = [];
 
@@ -157,17 +164,6 @@ export class ScalerContext {
             );
         }
     }
-
-
-    private static measureDirectly(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D) {
-        if (!this.hasTestedMeasureApi) {
-            const metrics = ctx.measureText('x');
-            this.directMeasurementEnabled = metrics && metrics.actualBoundingBoxAscent > 0;
-            this.hasTestedMeasureApi = true;
-        }
-        return this.directMeasurementEnabled;
-    }
-
 
     private measureText(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, text: string): TextMetrics {
         if (ScalerContext.measureDirectly(ctx)) {

--- a/web/src/core/scaler-context.ts
+++ b/web/src/core/scaler-context.ts
@@ -63,6 +63,8 @@ export class ScalerContext {
         xHeight: number;
         capHeight: number;
     };
+    private static hasTestedMeasureApi: boolean = false;
+    private static directMeasurementEnabled: boolean = false;
 
     private fontBoundingBoxMap: { key: string; value: Rect }[] = [];
 
@@ -156,10 +158,20 @@ export class ScalerContext {
         }
     }
 
+
+    private static measureDirectly(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D) {
+        if (!this.hasTestedMeasureApi) {
+            const metrics = ctx.measureText('x');
+            this.directMeasurementEnabled = metrics && metrics.actualBoundingBoxAscent > 0;
+            this.hasTestedMeasureApi = true;
+        }
+        return this.directMeasurementEnabled;
+    }
+
+
     private measureText(ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D, text: string): TextMetrics {
-        const metrics = ctx.measureText(text);
-        if (metrics && (metrics.actualBoundingBoxAscent > 0 || metrics.width === 0)) {
-            return metrics;
+        if (ScalerContext.measureDirectly(ctx)) {
+            return ctx.measureText(text);
         }
         ctx.canvas.width = this.size * 1.5;
         ctx.canvas.height = this.size * 1.5;
@@ -192,4 +204,5 @@ export class ScalerContext {
             width: fontMeasure.right - fontMeasure.left,
         };
     }
+
 }


### PR DESCRIPTION
添加static方法判断浏览器是否能直接检测文字大小，防止不可见的文字多次进入离屏渲染