### PR TITLE
Fix image decoding color space issue on Android

### DIFF
--- a/src/platform/android/NativeCodec.cpp
+++ b/src/platform/android/NativeCodec.cpp
@@ -25,6 +25,10 @@
 #include "tgfx/platform/android/AndroidBitmap.h"
 
 namespace tgfx {
+static Global<jclass> ColorSpaceClass;
+static jmethodID ColorSpace_get;
+static Global<jclass> ColorSpaceNamedClass;
+static jfieldID ColorSpaceNamed_SRGB;
 static Global<jclass> BitmapFactoryOptionsClass;
 static jmethodID BitmapFactoryOptions_Constructor;
 static jfieldID BitmapFactoryOptions_inJustDecodeBounds;
@@ -32,6 +36,7 @@ static jfieldID BitmapFactoryOptions_inPreferredConfig;
 static jfieldID BitmapFactoryOptions_inPremultiplied;
 static jfieldID BitmapFactoryOptions_outWidth;
 static jfieldID BitmapFactoryOptions_outHeight;
+static jfieldID BitmapFactoryOptions_inPreferredColorSpace;
 static Global<jclass> BitmapFactoryClass;
 static jmethodID BitmapFactory_decodeFile;
 static jmethodID BitmapFactory_decodeByteArray;
@@ -68,6 +73,20 @@ void NativeCodec::JNIInit(JNIEnv* env) {
   BitmapFactoryOptions_outWidth = env->GetFieldID(BitmapFactoryOptionsClass.get(), "outWidth", "I");
   BitmapFactoryOptions_outHeight =
       env->GetFieldID(BitmapFactoryOptionsClass.get(), "outHeight", "I");
+  // for color space conversion
+  ColorSpaceClass = env->FindClass("android/graphics/ColorSpace");
+  ColorSpace_get =
+      env->GetStaticMethodID(ColorSpaceClass.get(), "get",
+                             "(Landroid/graphics/ColorSpace$Named;)Landroid/graphics/ColorSpace;");
+  ColorSpaceNamedClass = env->FindClass("android/graphics/ColorSpace$Named");
+  ColorSpaceNamed_SRGB = env->GetStaticFieldID(ColorSpaceNamedClass.get(), "SRGB",
+                                               "Landroid/graphics/ColorSpace$Named;");
+  BitmapFactoryOptions_inPreferredColorSpace = env->GetFieldID(
+      BitmapFactoryOptionsClass.get(), "inPreferredColorSpace", "Landroid/graphics/ColorSpace;");
+  if (env->ExceptionCheck()) {
+    env->ExceptionClear();
+    BitmapFactoryOptions_inPreferredColorSpace = nullptr;
+  }
   ByteArrayInputStreamClass = env->FindClass("java/io/ByteArrayInputStream");
   ByteArrayInputStream_Constructor =
       env->GetMethodID(ByteArrayInputStreamClass.get(), "<init>", "([B)V");
@@ -350,6 +369,13 @@ jobject NativeCodec::decodeBitmap(JNIEnv* env, ColorType colorType, AlphaType al
   env->SetObjectField(options, BitmapFactoryOptions_inPreferredConfig, config);
   if (alphaType == AlphaType::Unpremultiplied) {
     env->SetBooleanField(options, BitmapFactoryOptions_inPremultiplied, false);
+  }
+
+  if (BitmapFactoryOptions_inPreferredColorSpace != nullptr) {
+    auto sRGBObj = env->GetStaticObjectField(ColorSpaceNamedClass.get(), ColorSpaceNamed_SRGB);
+    auto colorSpaceObject =
+        env->CallStaticObjectMethod(ColorSpaceClass.get(), ColorSpace_get, sRGBObj);
+    env->SetObjectField(options, BitmapFactoryOptions_inPreferredColorSpace, colorSpaceObject);
   }
 
   if (!imagePath.empty()) {


### PR DESCRIPTION
If we use `BitmapFactory` for image decoding on the Android platform and do not set `inPreferredColorSpace`, the decoded color space will remain unchanged. If the original image is in the Display P3 color space and is used directly as a texture, it may result in color deviation. so it is necessary to set `inPreferredColorSpace` to perform color space conversion (to sRGB).

Ref: https://developer.android.com/reference/kotlin/android/graphics/BitmapFactory.Options#inpreferredcolorspace