### PR TITLE
Allow disabling anti-aliasing when rasterizing paths and texts.

### DIFF
--- a/include/tgfx/core/Mask.h
+++ b/include/tgfx/core/Mask.h
@@ -60,6 +60,20 @@ class Mask {
   virtual bool isHardwareBacked() const = 0;
 
   /**
+   * Returns true if the Mask is anti-aliased. The default value is true.
+   */
+  bool isAntiAlias() const {
+    return antiAlias;
+  }
+
+  /**
+   * Sets whether the Mask should be anti-aliased. The default value is true.
+   */
+  void setAntiAlias(bool value) {
+    antiAlias = value;
+  }
+
+  /**
    * Returns the current total matrix.
    */
   Matrix getMatrix() const {
@@ -114,16 +128,18 @@ class Mask {
   virtual std::shared_ptr<ImageStream> getImageStream() const = 0;
 
   void onFillPath(const Path& path, const Matrix& m) {
-    onFillPath(path, m, false);
+    onFillPath(path, m, antiAlias, false);
   }
 
-  virtual void onFillPath(const Path& path, const Matrix& m, bool needsGammaCorrection) = 0;
+  virtual void onFillPath(const Path& path, const Matrix& m, bool antiAlias,
+                          bool needsGammaCorrection) = 0;
 
   virtual bool onFillText(const GlyphRunList* glyphRunList, const Stroke* stroke,
-                          const Matrix& matrix);
+                          const Matrix& matrix, bool antiAlias);
 
  private:
   Matrix matrix = Matrix::I();
+  bool antiAlias = true;
 
   bool fillText(const GlyphRunList* glyphRunList, const Stroke* stroke = nullptr);
 

--- a/src/core/Mask.cpp
+++ b/src/core/Mask.cpp
@@ -49,18 +49,18 @@ bool Mask::fillText(const GlyphRunList* glyphRunList, const Stroke* stroke) {
   if (glyphRunList->hasColor()) {
     return false;
   }
-  if (onFillText(glyphRunList, stroke, matrix)) {
+  if (onFillText(glyphRunList, stroke, matrix, antiAlias)) {
     return true;
   }
   Path path = {};
   if (!glyphRunList->getPath(&path, matrix, stroke)) {
     return false;
   }
-  onFillPath(path, Matrix::I(), true);
+  onFillPath(path, Matrix::I(), antiAlias, true);
   return true;
 }
 
-bool Mask::onFillText(const GlyphRunList*, const Stroke*, const Matrix&) {
+bool Mask::onFillText(const GlyphRunList*, const Stroke*, const Matrix&, bool) {
   return false;
 }
 }  // namespace tgfx

--- a/src/core/Rasterizer.h
+++ b/src/core/Rasterizer.h
@@ -34,13 +34,14 @@ class Rasterizer : public ImageGenerator {
    */
   static std::shared_ptr<Rasterizer> MakeFrom(std::shared_ptr<GlyphRunList> glyphRunList,
                                               const ISize& clipSize, const Matrix& matrix,
-                                              const Stroke* stroke = nullptr);
+                                              bool antiAlias, const Stroke* stroke = nullptr);
 
   /**
    * Creates a Rasterizer from a Path.
    */
   static std::shared_ptr<Rasterizer> MakeFrom(Path path, const ISize& clipSize,
-                                              const Matrix& matrix, const Stroke* stroke = nullptr);
+                                              const Matrix& matrix, bool antiAlias,
+                                              const Stroke* stroke = nullptr);
 
   virtual ~Rasterizer();
 
@@ -51,7 +52,7 @@ class Rasterizer : public ImageGenerator {
   bool asyncSupport() const override;
 
  protected:
-  Rasterizer(const ISize& clipSize, const Matrix& matrix, const Stroke* stroke);
+  Rasterizer(const ISize& clipSize, const Matrix& matrix, bool antiAlias, const Stroke* stroke);
 
   std::shared_ptr<ImageBuffer> onMakeBuffer(bool tryHardware) const override;
 
@@ -59,6 +60,7 @@ class Rasterizer : public ImageGenerator {
 
  private:
   Matrix matrix = Matrix::I();
+  bool antiAlias = true;
   Stroke* stroke = nullptr;
 };
 }  // namespace tgfx

--- a/src/core/images/PictureImage.cpp
+++ b/src/core/images/PictureImage.cpp
@@ -116,7 +116,8 @@ static std::shared_ptr<Rasterizer> GetEquivalentRasterizer(const Record* record,
       return nullptr;
     }
     return Rasterizer::MakeFrom(pathRecord->path, ISize::Make(width, height),
-                                GetMaskMatrix(pathRecord->state, matrix));
+                                GetMaskMatrix(pathRecord->state, matrix),
+                                pathRecord->style.antiAlias);
   }
   if (record->type() == RecordType::StrokePath) {
     auto strokeRecord = static_cast<const StrokePath*>(record);
@@ -124,7 +125,8 @@ static std::shared_ptr<Rasterizer> GetEquivalentRasterizer(const Record* record,
       return nullptr;
     }
     return Rasterizer::MakeFrom(strokeRecord->path, ISize::Make(width, height),
-                                GetMaskMatrix(strokeRecord->state, matrix), &strokeRecord->stroke);
+                                GetMaskMatrix(strokeRecord->state, matrix),
+                                strokeRecord->style.antiAlias, &strokeRecord->stroke);
   }
   if (record->type() == RecordType::DrawGlyphRunList) {
     auto glyphRecord = static_cast<const DrawGlyphRunList*>(record);
@@ -132,7 +134,8 @@ static std::shared_ptr<Rasterizer> GetEquivalentRasterizer(const Record* record,
       return nullptr;
     }
     return Rasterizer::MakeFrom(glyphRecord->glyphRunList, ISize::Make(width, height),
-                                GetMaskMatrix(glyphRecord->state, matrix));
+                                GetMaskMatrix(glyphRecord->state, matrix),
+                                glyphRecord->style.antiAlias);
   }
   if (record->type() == RecordType::StrokeGlyphRunList) {
     auto strokeGlyphRecord = static_cast<const StrokeGlyphRunList*>(record);
@@ -142,7 +145,7 @@ static std::shared_ptr<Rasterizer> GetEquivalentRasterizer(const Record* record,
     }
     return Rasterizer::MakeFrom(strokeGlyphRecord->glyphRunList, ISize::Make(width, height),
                                 GetMaskMatrix(strokeGlyphRecord->state, matrix),
-                                &strokeGlyphRecord->stroke);
+                                strokeGlyphRecord->style.antiAlias, &strokeGlyphRecord->stroke);
   }
   return nullptr;
 }

--- a/src/core/vectors/coregraphics/CGMask.h
+++ b/src/core/vectors/coregraphics/CGMask.h
@@ -27,9 +27,10 @@ class CGMask : public PixelRefMask {
   }
 
  protected:
-  void onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) override;
+  void onFillPath(const Path& path, const Matrix& matrix, bool antiAlias,
+                  bool needsGammaCorrection) override;
 
-  bool onFillText(const GlyphRunList* glyphRunList, const Stroke* stroke,
-                  const Matrix& matrix) override;
+  bool onFillText(const GlyphRunList* glyphRunList, const Stroke* stroke, const Matrix& matrix,
+                  bool antiAlias) override;
 };
 }  // namespace tgfx

--- a/src/core/vectors/freetype/FTMask.cpp
+++ b/src/core/vectors/freetype/FTMask.cpp
@@ -89,7 +89,8 @@ static void SpanFunc(int y, int, const FT_Span* spans, void* user) {
   }
 }
 
-void FTMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) {
+void FTMask::onFillPath(const Path& path, const Matrix& matrix, bool antiAlias,
+                        bool needsGammaCorrection) {
   if (path.isEmpty()) {
     return;
   }
@@ -133,7 +134,10 @@ void FTMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaC
   target.pitch = pitch;
   target.gammaTable = PixelRefMask::GammaTable().data();
   FT_Raster_Params params;
-  params.flags = FT_RASTER_FLAG_AA | FT_RASTER_FLAG_DIRECT | FT_RASTER_FLAG_CLIP;
+  params.flags = FT_RASTER_FLAG_DIRECT | FT_RASTER_FLAG_CLIP;
+  if (antiAlias) {
+    params.flags |= FT_RASTER_FLAG_AA;
+  }
   params.gray_spans = SpanFunc;
   params.user = &target;
   auto& clip = params.clip_box;

--- a/src/core/vectors/freetype/FTMask.h
+++ b/src/core/vectors/freetype/FTMask.h
@@ -27,6 +27,7 @@ class FTMask : public PixelRefMask {
   }
 
  protected:
-  void onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) override;
+  void onFillPath(const Path& path, const Matrix& matrix, bool antiAlias,
+                  bool needsGammaCorrection) override;
 };
 }  // namespace tgfx

--- a/src/core/vectors/web/WebMask.cpp
+++ b/src/core/vectors/web/WebMask.cpp
@@ -80,7 +80,8 @@ static void Iterator(PathVerb verb, const Point points[4], void* info) {
   }
 }
 
-void WebMask::onFillPath(const Path& path, const Matrix& matrix, bool) {
+void WebMask::onFillPath(const Path& path, const Matrix& matrix, bool /*antiAlias*/, bool) {
+  // The antiAlias parameter is ignored because the canvas2d API does not support anti-aliasing.
   if (path.isEmpty()) {
     return;
   }
@@ -113,7 +114,7 @@ static void GetTextsAndPositions(const GlyphRun* glyphRun, std::vector<std::stri
 }
 
 bool WebMask::onFillText(const GlyphRunList* glyphRunList, const Stroke* stroke,
-                         const Matrix& matrix) {
+                         const Matrix& matrix, bool) {
   aboutToFill();
   auto bounds = glyphRunList->getBounds(matrix, stroke);
   if (bounds.isEmpty()) {

--- a/src/core/vectors/web/WebMask.h
+++ b/src/core/vectors/web/WebMask.h
@@ -51,10 +51,10 @@ class WebMask : public Mask {
     return stream;
   }
 
-  void onFillPath(const Path& path, const Matrix& matrix, bool) override;
+  void onFillPath(const Path& path, const Matrix& matrix, bool antiAlias, bool) override;
 
-  bool onFillText(const GlyphRunList* glyphRun, const Stroke* stroke,
-                  const Matrix& matrix) override;
+  bool onFillText(const GlyphRunList* glyphRun, const Stroke* stroke, const Matrix& matrix,
+                  bool antiAlias) override;
 
  private:
   std::shared_ptr<ImageBuffer> buffer = nullptr;

--- a/src/gpu/RenderContext.h
+++ b/src/gpu/RenderContext.h
@@ -53,7 +53,7 @@ class RenderContext : public DrawContext {
   void drawGlyphRunList(std::shared_ptr<GlyphRunList> glyphRunList, const MCState& state,
                         const FillStyle& style, const Stroke* stroke) override;
 
-  void drawPicture(std::shared_ptr<Picture> picture, const tgfx::MCState& state) override;
+  void drawPicture(std::shared_ptr<Picture> picture, const MCState& state) override;
 
   void drawLayer(std::shared_ptr<Picture> picture, const MCState& state, const FillStyle& style,
                  std::shared_ptr<ImageFilter> filter) override;
@@ -67,20 +67,22 @@ class RenderContext : public DrawContext {
 
   explicit RenderContext(Surface* surface);
   Context* getContext() const;
-  std::shared_ptr<TextureProxy> getClipTexture(const Path& clip);
+  std::shared_ptr<TextureProxy> getClipTexture(const Path& clip, AAType aaType);
   std::pair<std::optional<Rect>, bool> getClipRect(const Path& clip,
                                                    const Rect* drawBounds = nullptr);
   std::unique_ptr<FragmentProcessor> getClipMask(const Path& clip, const Rect& deviceBounds,
-                                                 const Matrix& viewMatrix, Rect* scissorRect);
+                                                 const Matrix& viewMatrix, AAType aaType,
+                                                 Rect* scissorRect);
   Rect clipLocalBounds(const Rect& localBounds, const MCState& state);
   std::unique_ptr<FragmentProcessor> makeTextureMask(const Path& path, const Matrix& viewMatrix,
-                                                     const Stroke* stroke = nullptr);
+                                                     AAType aaType, const Stroke* stroke = nullptr);
   bool drawAsClear(const Rect& rect, const MCState& state, const FillStyle& style);
   void drawColorGlyphs(std::shared_ptr<GlyphRunList> glyphRunList, const MCState& state,
                        const FillStyle& style);
   void addDrawOp(std::unique_ptr<DrawOp> op, const Rect& localBounds, const MCState& state,
                  const FillStyle& style);
   void addOp(std::unique_ptr<Op> op, const std::function<bool()>& willDiscardContent);
+  AAType getAAType(const FillStyle& style) const;
   void replaceRenderTarget(std::shared_ptr<RenderTargetProxy> newRenderTargetProxy);
   bool wouldOverwriteEntireRT(const Rect& localBounds, const MCState& state, const FillStyle& style,
                               bool isRectOp) const;


### PR DESCRIPTION
栅格化文本和矢量时允许传递参数下去关闭抗锯齿。