### PR TITLE
Initialize maskOwner to nullptr in Layer class.

### DIFF
--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -449,7 +449,7 @@ class Layer {
  protected:
   std::weak_ptr<Layer> weakThis;
 
-  Layer* maskOwner;
+  Layer* maskOwner = nullptr;
 
   Layer();
 


### PR DESCRIPTION
触发了前端的bug，getBounds返回0：

<img width="618" alt="Clipboard_Screenshot_1732261640" src="https://github.com/user-attachments/assets/df3d8366-a0c2-4495-8c8c-7f69faa91a94">
