### PR TITLE
Fix the iterator call in the Path::decompose method

### DIFF
--- a/src/core/Path.cpp
+++ b/src/core/Path.cpp
@@ -538,8 +538,8 @@ void Path::decompose(const PathIterator& iterator, void* info) const {
       case SkPath::kConic_Verb:
         // approximate with 2^1=2 quads.
         SkPath::ConvertConicToQuads(points[0], points[1], points[2], iter.conicWeight(), quads, 1);
-        iterator(PathVerb::Quad, reinterpret_cast<Point*>(quads), info);
-        iterator(PathVerb::Quad, reinterpret_cast<Point*>(quads) + 2, info);
+        iterator(PathVerb::Quad, reinterpret_cast<Point*>(quads) + 1, info);
+        iterator(PathVerb::Quad, reinterpret_cast<Point*>(quads) + 3, info);
         break;
       case SkPath::kCubic_Verb:
         iterator(PathVerb::Cubic, reinterpret_cast<Point*>(points), info);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -18,6 +18,7 @@
         "Path_addArc_reversed6": "4802e56",
         "Path_addArc_reversed7": "4802e56",
         "Path_addArc_reversed8": "4802e56",
+        "Path_decompose": "2bf38d0",
         "Picture": "d069eb4",
         "PictureImage": "8a2ac4d",
         "PictureImage_Path": "2212c4e",
@@ -49,8 +50,7 @@
         "text_shape": "74f94c4",
         "tile_mode_normal": "8cb853c",
         "tile_mode_rgbaaa": "8cb853c",
-        "tile_mode_subset": "8cb853c",
-        "Path_decompose": "2bf38d0"
+        "tile_mode_subset": "8cb853c"
     },
     "DrawersTest": {
         "ConicGradient": "5a1fb11",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -49,7 +49,8 @@
         "text_shape": "74f94c4",
         "tile_mode_normal": "8cb853c",
         "tile_mode_rgbaaa": "8cb853c",
-        "tile_mode_subset": "8cb853c"
+        "tile_mode_subset": "8cb853c",
+        "Path_decompose": "2bf38d0"
     },
     "DrawersTest": {
         "ConicGradient": "5a1fb11",


### PR DESCRIPTION
Fix the iterator call in the Path::decompose method to correctly handle conic convert to quad Bezier curves;
ref:https://fiddle.skia.org/c/@Path_ConvertConicToQuads