### PR TITLE
Remove uniqueKey from TPArgs and fix caching issue with flattened FilterImage.

### DIFF
--- a/src/core/images/BufferImage.cpp
+++ b/src/core/images/BufferImage.cpp
@@ -34,9 +34,10 @@ BufferImage::BufferImage(UniqueKey uniqueKey, std::shared_ptr<ImageBuffer> buffe
     : ResourceImage(std::move(uniqueKey)), imageBuffer(std::move(buffer)) {
 }
 
-std::shared_ptr<TextureProxy> BufferImage::onLockTextureProxy(const TPArgs& args) const {
+std::shared_ptr<TextureProxy> BufferImage::onLockTextureProxy(const TPArgs& args,
+                                                              const UniqueKey& key) const {
   TRACE_EVENT;
-  return args.context->proxyProvider()->createTextureProxy(args.uniqueKey, imageBuffer,
-                                                           args.mipmapped, args.renderFlags);
+  return args.context->proxyProvider()->createTextureProxy(key, imageBuffer, args.mipmapped,
+                                                           args.renderFlags);
 }
 }  // namespace tgfx

--- a/src/core/images/BufferImage.h
+++ b/src/core/images/BufferImage.h
@@ -49,7 +49,8 @@ class BufferImage : public ResourceImage {
   }
 
  protected:
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override;
 
  private:
   std::shared_ptr<ImageBuffer> imageBuffer = nullptr;

--- a/src/core/images/DecoderImage.cpp
+++ b/src/core/images/DecoderImage.cpp
@@ -37,9 +37,10 @@ DecoderImage::DecoderImage(UniqueKey uniqueKey, std::shared_ptr<ImageDecoder> de
     : ResourceImage(std::move(uniqueKey)), decoder(std::move(decoder)) {
 }
 
-std::shared_ptr<TextureProxy> DecoderImage::onLockTextureProxy(const TPArgs& args) const {
+std::shared_ptr<TextureProxy> DecoderImage::onLockTextureProxy(const TPArgs& args,
+                                                               const UniqueKey& key) const {
   TRACE_EVENT;
-  return args.context->proxyProvider()->createTextureProxy(args.uniqueKey, decoder, args.mipmapped,
+  return args.context->proxyProvider()->createTextureProxy(key, decoder, args.mipmapped,
                                                            args.renderFlags);
 }
 }  // namespace tgfx

--- a/src/core/images/DecoderImage.h
+++ b/src/core/images/DecoderImage.h
@@ -51,7 +51,8 @@ class DecoderImage : public ResourceImage {
   }
 
  protected:
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override;
 
  private:
   std::shared_ptr<ImageDecoder> decoder = nullptr;

--- a/src/core/images/FlattenImage.h
+++ b/src/core/images/FlattenImage.h
@@ -52,7 +52,8 @@ class FlattenImage : public ResourceImage {
  protected:
   std::shared_ptr<Image> onMakeDecoded(Context* context, bool tryHardware) const override;
 
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override;
 
  private:
   std::shared_ptr<Image> source = nullptr;

--- a/src/core/images/GeneratorImage.cpp
+++ b/src/core/images/GeneratorImage.cpp
@@ -50,9 +50,10 @@ std::shared_ptr<Image> GeneratorImage::onMakeDecoded(Context* context, bool tryH
   return DecoderImage::MakeFrom(uniqueKey, std::move(decoder));
 }
 
-std::shared_ptr<TextureProxy> GeneratorImage::onLockTextureProxy(const TPArgs& args) const {
+std::shared_ptr<TextureProxy> GeneratorImage::onLockTextureProxy(const TPArgs& args,
+                                                                 const UniqueKey& key) const {
   TRACE_EVENT;
-  return args.context->proxyProvider()->createTextureProxy(args.uniqueKey, generator,
-                                                           args.mipmapped, args.renderFlags);
+  return args.context->proxyProvider()->createTextureProxy(key, generator, args.mipmapped,
+                                                           args.renderFlags);
 }
 }  // namespace tgfx

--- a/src/core/images/GeneratorImage.h
+++ b/src/core/images/GeneratorImage.h
@@ -55,7 +55,8 @@ class GeneratorImage : public ResourceImage {
  protected:
   std::shared_ptr<Image> onMakeDecoded(Context* context, bool tryHardware) const override;
 
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override;
 
  protected:
   std::shared_ptr<ImageGenerator> generator = nullptr;

--- a/src/core/images/MipmapImage.cpp
+++ b/src/core/images/MipmapImage.cpp
@@ -54,7 +54,8 @@ std::shared_ptr<Image> MipmapImage::onMakeMipmapped(bool enabled) const {
   return enabled ? weakThis.lock() : source;
 }
 
-std::shared_ptr<TextureProxy> MipmapImage::onLockTextureProxy(const TPArgs& args) const {
-  return source->onLockTextureProxy(args);
+std::shared_ptr<TextureProxy> MipmapImage::onLockTextureProxy(const TPArgs& args,
+                                                              const UniqueKey& key) const {
+  return source->onLockTextureProxy(args, key);
 }
 }  // namespace tgfx

--- a/src/core/images/MipmapImage.h
+++ b/src/core/images/MipmapImage.h
@@ -54,7 +54,8 @@ class MipmapImage : public ResourceImage {
 
   std::shared_ptr<Image> onMakeMipmapped(bool enabled) const override;
 
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override;
 
  private:
   std::shared_ptr<ResourceImage> source = nullptr;

--- a/src/core/images/OffscreenImage.cpp
+++ b/src/core/images/OffscreenImage.cpp
@@ -25,18 +25,18 @@ namespace tgfx {
 OffscreenImage::OffscreenImage(UniqueKey uniqueKey) : ResourceImage(std::move(uniqueKey)) {
 }
 
-std::shared_ptr<TextureProxy> OffscreenImage::onLockTextureProxy(const TPArgs& args) const {
+std::shared_ptr<TextureProxy> OffscreenImage::onLockTextureProxy(const TPArgs& args,
+                                                                 const UniqueKey& key) const {
   TRACE_EVENT;
   auto proxyProvider = args.context->proxyProvider();
-  auto textureProxy = proxyProvider->findOrWrapTextureProxy(args.uniqueKey);
+  auto textureProxy = proxyProvider->findOrWrapTextureProxy(key);
   if (textureProxy != nullptr) {
     return textureProxy;
   }
   auto alphaRenderable = args.context->caps()->isFormatRenderable(PixelFormat::ALPHA_8);
   auto format = isAlphaOnly() && alphaRenderable ? PixelFormat::ALPHA_8 : PixelFormat::RGBA_8888;
-  textureProxy =
-      proxyProvider->createTextureProxy(args.uniqueKey, width(), height(), format, args.mipmapped,
-                                        ImageOrigin::TopLeft, args.renderFlags);
+  textureProxy = proxyProvider->createTextureProxy(key, width(), height(), format, args.mipmapped,
+                                                   ImageOrigin::TopLeft, args.renderFlags);
   auto renderTarget = proxyProvider->createRenderTargetProxy(textureProxy, format, 1, true);
   if (renderTarget == nullptr) {
     return nullptr;

--- a/src/core/images/OffscreenImage.h
+++ b/src/core/images/OffscreenImage.h
@@ -38,7 +38,8 @@ class OffscreenImage : public ResourceImage {
   }
 
  protected:
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override final;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override final;
 
   virtual bool onDraw(std::shared_ptr<RenderTargetProxy> renderTarget,
                       uint32_t renderFlags) const = 0;

--- a/src/core/images/ResourceImage.cpp
+++ b/src/core/images/ResourceImage.cpp
@@ -27,12 +27,10 @@ ResourceImage::ResourceImage(UniqueKey uniqueKey) : uniqueKey(std::move(uniqueKe
 
 std::shared_ptr<TextureProxy> ResourceImage::lockTextureProxy(const TPArgs& args) const {
   TRACE_EVENT;
-  if (args.flattened && !isFlat()) {
-    return Image::lockTextureProxy(args);
-  }
-  // Some options in TPArgs are ignored for ResourceImage because it has preset properties.
-  TPArgs tpArgs(args.context, args.renderFlags, hasMipmaps(), args.flattened, uniqueKey);
-  return onLockTextureProxy(tpArgs);
+  auto newArgs = args;
+  // ResourceImage has preset mipmaps.
+  newArgs.mipmapped = hasMipmaps();
+  return onLockTextureProxy(newArgs, uniqueKey);
 }
 
 std::shared_ptr<Image> ResourceImage::onMakeMipmapped(bool enabled) const {
@@ -45,8 +43,8 @@ std::unique_ptr<FragmentProcessor> ResourceImage::asFragmentProcessor(
     const FPArgs& args, TileMode tileModeX, TileMode tileModeY, const SamplingOptions& sampling,
     const Matrix* uvMatrix) const {
   TRACE_EVENT;
-  TPArgs tpArgs(args.context, args.renderFlags, hasMipmaps(), false, uniqueKey);
-  auto proxy = onLockTextureProxy(tpArgs);
+  TPArgs tpArgs(args.context, args.renderFlags, hasMipmaps());
+  auto proxy = onLockTextureProxy(tpArgs, uniqueKey);
   return TiledTextureEffect::Make(std::move(proxy), tileModeX, tileModeY, sampling, uvMatrix,
                                   isAlphaOnly());
 }

--- a/src/core/images/ResourceImage.h
+++ b/src/core/images/ResourceImage.h
@@ -39,7 +39,8 @@ class ResourceImage : public Image {
 
   std::shared_ptr<TextureProxy> lockTextureProxy(const TPArgs& args) const override final;
 
-  virtual std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const = 0;
+  virtual std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                           const UniqueKey& key) const = 0;
 
   std::unique_ptr<FragmentProcessor> asFragmentProcessor(const FPArgs& args, TileMode tileModeX,
                                                          TileMode tileModeY,

--- a/src/core/images/TextureImage.cpp
+++ b/src/core/images/TextureImage.cpp
@@ -60,7 +60,8 @@ std::shared_ptr<Image> TextureImage::makeTextureImage(Context* context) const {
   return std::static_pointer_cast<Image>(weakThis.lock());
 }
 
-std::shared_ptr<TextureProxy> TextureImage::onLockTextureProxy(const TPArgs& args) const {
+std::shared_ptr<TextureProxy> TextureImage::onLockTextureProxy(const TPArgs& args,
+                                                               const UniqueKey&) const {
   TRACE_EVENT;
   if (args.context == nullptr || args.context->uniqueID() != contextID) {
     return nullptr;

--- a/src/core/images/TextureImage.h
+++ b/src/core/images/TextureImage.h
@@ -68,7 +68,8 @@ class TextureImage : public ResourceImage {
     return nullptr;
   }
 
-  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args) const override;
+  std::shared_ptr<TextureProxy> onLockTextureProxy(const TPArgs& args,
+                                                   const UniqueKey& key) const override;
 
  private:
   std::shared_ptr<TextureProxy> textureProxy = nullptr;

--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -73,12 +73,21 @@ void DrawingManager::addResourceTask(std::shared_ptr<ResourceTask> resourceTask)
   if (resourceTask == nullptr) {
     return;
   }
-#ifdef DEBUG
-  auto result = resourceTaskMap.find(resourceTask->uniqueKey);
-  DEBUG_ASSERT(result == resourceTaskMap.end());
+  DEBUG_ASSERT(resourceTaskMap.find(resourceTask->uniqueKey) == resourceTaskMap.end());
   resourceTaskMap[resourceTask->uniqueKey] = resourceTask.get();
-#endif
   resourceTasks.push_back(std::move(resourceTask));
+}
+
+bool DrawingManager::changeResourceTaskKey(const UniqueKey& oldKey, const UniqueKey& newKey) {
+  auto result = resourceTaskMap.find(oldKey);
+  if (result == resourceTaskMap.end()) {
+    return false;
+  }
+  auto task = result->second;
+  resourceTaskMap.erase(oldKey);
+  task->uniqueKey = newKey;
+  resourceTaskMap[newKey] = task;
+  return true;
 }
 
 bool DrawingManager::flush() {

--- a/src/gpu/DrawingManager.h
+++ b/src/gpu/DrawingManager.h
@@ -46,6 +46,8 @@ class DrawingManager {
 
   void addResourceTask(std::shared_ptr<ResourceTask> resourceTask);
 
+  bool changeResourceTaskKey(const UniqueKey& oldKey, const UniqueKey& newKey);
+
   /**
    * Returns true if any render tasks were executed.
    */
@@ -57,9 +59,7 @@ class DrawingManager {
   std::vector<std::shared_ptr<ResourceTask>> resourceTasks = {};
   std::vector<std::shared_ptr<RenderTask>> renderTasks = {};
   std::shared_ptr<OpsRenderTask> activeOpsTask = nullptr;
-#ifdef DEBUG
   ResourceKeyMap<ResourceTask*> resourceTaskMap = {};
-#endif
 
   void addRenderTask(std::shared_ptr<RenderTask> renderTask);
   void checkIfResolveNeeded(std::shared_ptr<RenderTargetProxy> renderTargetProxy);

--- a/src/gpu/ProxyProvider.h
+++ b/src/gpu/ProxyProvider.h
@@ -128,10 +128,12 @@ class ProxyProvider {
       const BackendRenderTarget& backendRenderTarget, ImageOrigin origin = ImageOrigin::TopLeft);
 
   /**
-   * Changes the key of the given proxy to the new key. So that the proxy can be found with the new
-   * key. This does not change the key of the resource that the proxy wraps.
+   * Changes the UniqueKey of the given proxy to the new UniqueKey. So that the proxy can be found
+   * with the new key. This also updates the UniqueKey of the target resource if it has been
+   * instantiated, otherwise it updates the UniqueKey of associated resource task.
    */
-  void changeProxyKey(std::shared_ptr<ResourceProxy> proxy, const UniqueKey& newKey);
+  void changeUniqueKey(std::shared_ptr<ResourceProxy> proxy, const UniqueKey& newKey,
+                       uint32_t renderFlags);
 
   /*
    * Purges all unreferenced proxies.

--- a/src/gpu/TPArgs.h
+++ b/src/gpu/TPArgs.h
@@ -29,10 +29,8 @@ class TPArgs {
  public:
   TPArgs() = default;
 
-  TPArgs(Context* context, uint32_t renderFlags, bool mipmapped, bool flattened = false,
-         UniqueKey uniqueKey = {})
-      : context(context), renderFlags(renderFlags), mipmapped(mipmapped), flattened(flattened),
-        uniqueKey(std::move(uniqueKey)) {
+  TPArgs(Context* context, uint32_t renderFlags, bool mipmapped)
+      : context(context), renderFlags(renderFlags), mipmapped(mipmapped) {
   }
 
   /**
@@ -50,16 +48,5 @@ class TPArgs {
    * image already has preset mipmaps.
    */
   bool mipmapped = false;
-
-  /**
-   * Specifies whether the texture proxy should be flattened.
-   */
-  bool flattened = false;
-
-  /**
-   * The unique key assigned to the texture proxy. This may be ignored if the associated image
-   * already has a unique key.
-   */
-  UniqueKey uniqueKey = {};
 };
 }  // namespace tgfx

--- a/src/gpu/tasks/RenderTargetCreateTask.cpp
+++ b/src/gpu/tasks/RenderTargetCreateTask.cpp
@@ -23,25 +23,24 @@
 #include "gpu/Texture.h"
 
 namespace tgfx {
-std::shared_ptr<RenderTargetCreateTask> RenderTargetCreateTask::MakeFrom(UniqueKey uniqueKey,
-                                                                         UniqueKey textureKey,
-                                                                         PixelFormat pixelFormat,
-                                                                         int sampleCount,
-                                                                         bool clearAll) {
+std::shared_ptr<RenderTargetCreateTask> RenderTargetCreateTask::MakeFrom(
+    UniqueKey uniqueKey, std::shared_ptr<TextureProxy> textureProxy, PixelFormat pixelFormat,
+    int sampleCount, bool clearAll) {
   return std::shared_ptr<RenderTargetCreateTask>(new RenderTargetCreateTask(
-      std::move(uniqueKey), std::move(textureKey), pixelFormat, sampleCount, clearAll));
+      std::move(uniqueKey), std::move(textureProxy), pixelFormat, sampleCount, clearAll));
 }
 
-RenderTargetCreateTask::RenderTargetCreateTask(UniqueKey uniqueKey, UniqueKey textureKey,
+RenderTargetCreateTask::RenderTargetCreateTask(UniqueKey uniqueKey,
+                                               std::shared_ptr<TextureProxy> textureProxy,
                                                PixelFormat pixelFormat, int sampleCount,
                                                bool clearAll)
-    : ResourceTask(std::move(uniqueKey)), textureKey(std::move(textureKey)),
+    : ResourceTask(std::move(uniqueKey)), textureProxy(std::move(textureProxy)),
       pixelFormat(pixelFormat), sampleCount(sampleCount), clearAll(clearAll) {
 }
 
-std::shared_ptr<Resource> RenderTargetCreateTask::onMakeResource(Context* context) {
+std::shared_ptr<Resource> RenderTargetCreateTask::onMakeResource(Context*) {
   TRACE_EVENT;
-  auto texture = Resource::Find<Texture>(context, textureKey);
+  auto texture = textureProxy->getTexture();
   if (texture == nullptr) {
     LOGE("RenderTargetCreateTask::onMakeResource() Failed to get the associated texture!");
     return nullptr;

--- a/src/gpu/tasks/RenderTargetCreateTask.h
+++ b/src/gpu/tasks/RenderTargetCreateTask.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "ResourceTask.h"
+#include "gpu/proxies/TextureProxy.h"
 
 namespace tgfx {
 class RenderTargetCreateTask : public ResourceTask {
@@ -26,21 +27,20 @@ class RenderTargetCreateTask : public ResourceTask {
   /**
    * Create a new RenderTargetCreateTask to generate a RenderTarget with the given properties.
    */
-  static std::shared_ptr<RenderTargetCreateTask> MakeFrom(UniqueKey uniqueKey, UniqueKey textureKey,
-                                                          PixelFormat pixelFormat,
-                                                          int sampleCount = 1,
-                                                          bool clearAll = false);
+  static std::shared_ptr<RenderTargetCreateTask> MakeFrom(
+      UniqueKey uniqueKey, std::shared_ptr<TextureProxy> textureProxy, PixelFormat pixelFormat,
+      int sampleCount = 1, bool clearAll = false);
 
  protected:
   std::shared_ptr<Resource> onMakeResource(Context* context) override;
 
  private:
-  UniqueKey textureKey = {};
+  std::shared_ptr<TextureProxy> textureProxy = nullptr;
   PixelFormat pixelFormat = PixelFormat::RGBA_8888;
   int sampleCount = 1;
   bool clearAll = false;
 
-  RenderTargetCreateTask(UniqueKey uniqueKey, UniqueKey textureKey, PixelFormat pixelFormat,
-                         int sampleCount, bool clearAll);
+  RenderTargetCreateTask(UniqueKey uniqueKey, std::shared_ptr<TextureProxy> textureProxy,
+                         PixelFormat pixelFormat, int sampleCount, bool clearAll);
 };
 }  // namespace tgfx


### PR DESCRIPTION
重构了Image::lockTextureProxy()方法，允许先请求TextureProxy再设置UniqueKey，同时修复之前FilterImage没有处理TPArgs.uniqueKey导致缓存没有生效的问题。