### PR TITLE
Update tracy third-party, delete functions that depend on higher versions of Windows SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           cd web
           emsdk/emsdk_env
-          npm run build
+          npm run build:mt:debug
 
       - name: Save Environment Cache
         if: ${{ (github.event_name == 'push') && (steps.environment-cache.outputs.cache-hit != 'true') }}
@@ -247,7 +247,7 @@ jobs:
 
       - name: Build Windows
         run: |
-          node build_tgfx -s ./win Hello2D -o ./out/release/win -a x64
+          node build_tgfx -s ./win Hello2D -o ./out/release/win -a x64 -b
 
       - name: Save Third-Party Cache
         if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,7 @@ jobs:
 
       - name: Build Linux
         run: |
-          node build_tgfx -s ./linux Hello2D -o ./out/release/linux -a x64
+          node build_tgfx -s ./linux Hello2D -o ./out/release/linux -a x64 -d
 
       - name: Save Third-Party Cache
         if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Build Windows
         run: |
-          node build_tgfx -s ./win Hello2D -o ./out/release/win -a x64 -b
+          node build_tgfx -s ./win Hello2D -o ./out/release/win -a x64 -d
 
       - name: Save Third-Party Cache
         if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}

--- a/DEPS
+++ b/DEPS
@@ -67,7 +67,7 @@
       },
       {
         "url": "https://github.com/libpag/tracy.git",
-        "commit": "93fdee0238f74b95fdf18b7cc712e423c71497a3",
+        "commit": "a1f92cc0b00799e3dfe3eee6654bd4779094febf",
         "dir": "third_party/tracy"
       }
     ]

--- a/DEPS
+++ b/DEPS
@@ -67,7 +67,7 @@
       },
       {
         "url": "https://github.com/libpag/tracy.git",
-        "commit": "a1f92cc0b00799e3dfe3eee6654bd4779094febf",
+        "commit": "3e416aba1e4eb4d90314ee0ff93424f4d9609d97",
         "dir": "third_party/tracy"
       }
     ]


### PR DESCRIPTION
更新tracy第三方库，删除依赖高版本Windows SDK的函数