### PR TITLE
Specify the version number of gen-mapping. The latest version is not recommended for use.

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
   "license": "BSD-3-Clause",
   "author": "Tencent",
   "dependencies": {
+    "@jridgewell/gen-mapping": "^0.3.5",
     "express": "^4.21.1"
   }
 }


### PR DESCRIPTION
最新版本已废弃