### PR TITLE
Fix Surface::makeImageSnapshot() for surfaces with MSAA enabled.

### DIFF
--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -47,22 +47,19 @@ class AutoLayerForImageFilter {
 };
 
 static FillStyle CreateFillStyle(const Paint& paint) {
-
-  FillStyle style = {};
   auto shader = paint.getShader();
   Color color = {};
   if (shader && shader->asColor(&color)) {
     color.alpha *= paint.getAlpha();
-    style.color = color;
     shader = nullptr;
   } else {
-    style.color = paint.getColor();
+    color = paint.getColor();
   }
+  FillStyle style = {color, paint.getBlendMode()};
   style.shader = shader;
   style.antiAlias = paint.isAntiAlias();
   style.colorFilter = paint.getColorFilter();
   style.maskFilter = paint.getMaskFilter();
-  style.blendMode = paint.getBlendMode();
   return style;
 }
 

--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -20,6 +20,7 @@
 #include "gpu/Gpu.h"
 #include "gpu/proxies/RenderTargetProxy.h"
 #include "gpu/proxies/TextureProxy.h"
+#include "gpu/tasks/RenderTargetCopyTask.h"
 #include "gpu/tasks/RuntimeDrawTask.h"
 #include "gpu/tasks/TextureResolveTask.h"
 
@@ -87,6 +88,16 @@ void DrawingManager::addTextureFlattenTask(std::unique_ptr<TextureFlattenTask> f
     return;
   }
   flattenTasks.push_back(std::move(flattenTask));
+}
+
+void DrawingManager::addRenderTargetCopyTask(std::shared_ptr<RenderTargetProxy> source,
+                                             std::shared_ptr<TextureProxy> dest) {
+  if (source == nullptr || dest == nullptr) {
+    return;
+  }
+  DEBUG_ASSERT(source->width() == dest->width() && source->height() == dest->height());
+  auto task = std::make_unique<RenderTargetCopyTask>(std::move(source), std::move(dest));
+  renderTasks.push_back(std::move(task));
 }
 
 void DrawingManager::addResourceTask(std::unique_ptr<ResourceTask> resourceTask) {

--- a/src/gpu/DrawingManager.h
+++ b/src/gpu/DrawingManager.h
@@ -53,6 +53,9 @@ class DrawingManager {
 
   void addTextureFlattenTask(std::unique_ptr<TextureFlattenTask> flattenTask);
 
+  void addRenderTargetCopyTask(std::shared_ptr<RenderTargetProxy> source,
+                               std::shared_ptr<TextureProxy> dest);
+
   void addResourceTask(std::unique_ptr<ResourceTask> resourceTask);
 
   /**

--- a/src/gpu/Gpu.h
+++ b/src/gpu/Gpu.h
@@ -48,6 +48,9 @@ class Gpu {
   virtual void writePixels(const TextureSampler* sampler, Rect rect, const void* pixels,
                            size_t rowBytes) = 0;
 
+  virtual void copyRenderTargetToTexture(const RenderTarget* renderTarget, Texture* texture,
+                                         const Rect& srcRect, const Point& dstPoint) = 0;
+
   virtual void resolveRenderTarget(RenderTarget* renderTarget) = 0;
 
   virtual void regenerateMipmapLevels(const TextureSampler* sampler) = 0;

--- a/src/gpu/OpsCompositor.h
+++ b/src/gpu/OpsCompositor.h
@@ -67,12 +67,6 @@ class OpsCompositor {
   void fillShape(std::shared_ptr<Shape> shape, const MCState& state, const FillStyle& style);
 
   /**
-   * Copy the contents of the render target to the given texture.
-   */
-  void copyToTexture(std::shared_ptr<TextureProxy> textureProxy, const Rect& srcRect,
-                     const Point& dstPoint);
-
-  /**
    * Close the compositor and submit the composed render task to the render queue. After closing,
    * the compositor is no longer valid.
    */

--- a/src/gpu/RenderContext.h
+++ b/src/gpu/RenderContext.h
@@ -58,12 +58,6 @@ class RenderContext : public DrawContext {
                  const MCState& state, const FillStyle& style) override;
 
   /**
-   * Copies the contents of the render target to the given texture.
-   */
-  void copyToTexture(std::shared_ptr<TextureProxy> textureProxy, const Rect& srcRect,
-                     const Point& dstPoint);
-
-  /**
    * Flushes the render context, submitting all pending operations to the drawing manager. Returns
    * true if any operations were submitted.
    */
@@ -79,7 +73,9 @@ class RenderContext : public DrawContext {
   void drawColorGlyphs(std::shared_ptr<GlyphRunList> glyphRunList, const MCState& state,
                        const FillStyle& style);
   AAType getAAType(const FillStyle& style) const;
-  OpsCompositor* getOpsCompositor(bool readOnly = false, bool discardContent = false);
+  OpsCompositor* getOpsCompositor(bool discardContent = false);
+  void replaceRenderTarget(std::shared_ptr<RenderTargetProxy> newRenderTarget,
+                           std::shared_ptr<Image> oldContent);
 
   friend class Surface;
 };

--- a/src/gpu/RenderPass.cpp
+++ b/src/gpu/RenderPass.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "RenderPass.h"
+#include "gpu/Gpu.h"
 
 namespace tgfx {
 bool RenderPass::begin(std::shared_ptr<RenderTarget> renderTarget,
@@ -95,7 +96,14 @@ void RenderPass::clear(const Rect& scissor, Color color) {
 
 void RenderPass::copyTo(Texture* texture, const Rect& srcRect, const Point& dstPoint) {
   drawPipelineStatus = DrawPipelineStatus::NotConfigured;
-  onCopyTo(texture, srcRect, dstPoint);
+  auto gpu = context->gpu();
+  if (_renderTarget->sampleCount() > 1) {
+    gpu->resolveRenderTarget(_renderTarget.get());
+  } else {
+    gpu->copyRenderTargetToTexture(_renderTarget.get(), texture, srcRect, dstPoint);
+  }
+  // Reset the render target after the copy operation.
+  onBindRenderTarget();
 }
 
 }  // namespace tgfx

--- a/src/gpu/RenderPass.h
+++ b/src/gpu/RenderPass.h
@@ -72,7 +72,6 @@ class RenderPass {
   virtual void onDraw(PrimitiveType primitiveType, size_t baseVertex, size_t vertexCount) = 0;
   virtual void onDrawIndexed(PrimitiveType primitiveType, size_t baseIndex, size_t indexCount) = 0;
   virtual void onClear(const Rect& scissor, Color color) = 0;
-  virtual void onCopyTo(Texture* texture, const Rect& srcRect, const Point& dstPoint) = 0;
 
   Context* context = nullptr;
   std::shared_ptr<RenderTarget> _renderTarget = nullptr;

--- a/src/gpu/opengl/GLCaps.cpp
+++ b/src/gpu/opengl/GLCaps.cpp
@@ -415,13 +415,15 @@ static MSFBOType GetMSFBOType_GLES(uint32_t version, const GLInfo& glInterface) 
   // ES3 driver bugs on at least one device with a tiled GPU (N10).
   if (glInterface.hasExtension("GL_EXT_multisampled_render_to_texture")) {
     return MSFBOType::ES_EXT_MsToTexture;
-  } else if (glInterface.hasExtension("GL_IMG_multisampled_render_to_texture")) {
+  }
+  if (glInterface.hasExtension("GL_IMG_multisampled_render_to_texture")) {
     return MSFBOType::ES_IMG_MsToTexture;
-  } else if (version >= GL_VER(3, 0) ||
-             glInterface.hasExtension("GL_CHROMIUM_framebuffer_multisample") ||
-             glInterface.hasExtension("GL_ANGLE_framebuffer_multisample")) {
+  }
+  if (version >= GL_VER(3, 0) || glInterface.hasExtension("GL_CHROMIUM_framebuffer_multisample") ||
+      glInterface.hasExtension("GL_ANGLE_framebuffer_multisample")) {
     return MSFBOType::Standard;
-  } else if (glInterface.hasExtension("GL_APPLE_framebuffer_multisample")) {
+  }
+  if (glInterface.hasExtension("GL_APPLE_framebuffer_multisample")) {
     return MSFBOType::ES_Apple;
   }
   return MSFBOType::None;

--- a/src/gpu/opengl/GLGpu.cpp
+++ b/src/gpu/opengl/GLGpu.cpp
@@ -196,6 +196,22 @@ void GLGpu::bindTexture(int unitIndex, const TextureSampler* sampler, SamplerSta
                     FilterToGLMagFilter(samplerState.filterMode));
 }
 
+void GLGpu::copyRenderTargetToTexture(const RenderTarget* renderTarget, Texture* texture,
+                                      const Rect& srcRect, const Point& dstPoint) {
+  auto gl = GLFunctions::Get(context);
+  auto glRenderTarget = static_cast<const GLRenderTarget*>(renderTarget);
+  gl->bindFramebuffer(GL_FRAMEBUFFER, glRenderTarget->getFrameBufferID(false));
+  auto glSampler = static_cast<const GLSampler*>(texture->getSampler());
+  gl->bindTexture(glSampler->target, glSampler->id);
+  gl->copyTexSubImage2D(glSampler->target, 0, static_cast<int>(dstPoint.x),
+                        static_cast<int>(dstPoint.y), static_cast<int>(srcRect.x()),
+                        static_cast<int>(srcRect.y()), static_cast<int>(srcRect.width()),
+                        static_cast<int>(srcRect.height()));
+  if (glSampler->hasMipmaps() && glSampler->target == GL_TEXTURE_2D) {
+    gl->generateMipmap(glSampler->target);
+  }
+}
+
 void GLGpu::resolveRenderTarget(RenderTarget* renderTarget) {
   if (renderTarget->sampleCount() <= 1) {
     return;

--- a/src/gpu/opengl/GLGpu.h
+++ b/src/gpu/opengl/GLGpu.h
@@ -38,6 +38,9 @@ class GLGpu : public Gpu {
 
   void bindTexture(int unitIndex, const TextureSampler* sampler, SamplerState samplerState = {});
 
+  void copyRenderTargetToTexture(const RenderTarget* renderTarget, Texture* texture,
+                                 const Rect& srcRect, const Point& dstPoint) override;
+
   void resolveRenderTarget(RenderTarget* renderTarget) override;
 
   void regenerateMipmapLevels(const TextureSampler* sampler) override;

--- a/src/gpu/opengl/GLRenderPass.cpp
+++ b/src/gpu/opengl/GLRenderPass.cpp
@@ -178,26 +178,4 @@ void GLRenderPass::onClear(const Rect& scissor, Color color) {
   gl->clearColor(color.red, color.green, color.blue, color.alpha);
   gl->clear(GL_COLOR_BUFFER_BIT);
 }
-
-void GLRenderPass::onCopyTo(Texture* texture, const Rect& srcRect, const Point& dstPoint) {
-  auto gl = GLFunctions::Get(context);
-  auto glRT = static_cast<const GLRenderTarget*>(_renderTarget.get());
-  auto hasMSAA = glRT->sampleCount() > 1;
-  if (hasMSAA) {
-    gl->bindFramebuffer(GL_FRAMEBUFFER, glRT->getFrameBufferID(false));
-  }
-  auto glSampler = static_cast<const GLSampler*>(texture->getSampler());
-  gl->bindTexture(glSampler->target, glSampler->id);
-  gl->copyTexSubImage2D(glSampler->target, 0, static_cast<int>(dstPoint.x),
-                        static_cast<int>(dstPoint.y), static_cast<int>(srcRect.x()),
-                        static_cast<int>(srcRect.y()), static_cast<int>(srcRect.width()),
-                        static_cast<int>(srcRect.height()));
-  if (glSampler->hasMipmaps() && glSampler->target == GL_TEXTURE_2D) {
-    gl->generateMipmap(glSampler->target);
-  }
-  if (hasMSAA) {
-    gl->bindFramebuffer(GL_FRAMEBUFFER, glRT->getFrameBufferID(true));
-  }
-}
-
 }  // namespace tgfx

--- a/src/gpu/ops/SubTextureCopyOp.cpp
+++ b/src/gpu/ops/SubTextureCopyOp.cpp
@@ -16,26 +16,28 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "CopyOp.h"
+#include "SubTextureCopyOp.h"
 #include "core/utils/Log.h"
 #include "gpu/Gpu.h"
 #include "gpu/RenderPass.h"
 
 namespace tgfx {
-std::unique_ptr<CopyOp> CopyOp::Make(std::shared_ptr<TextureProxy> textureProxy,
-                                     const Rect& srcRect, const Point& dstPoint) {
+std::unique_ptr<SubTextureCopyOp> SubTextureCopyOp::Make(std::shared_ptr<TextureProxy> textureProxy,
+                                                         const Rect& srcRect,
+                                                         const Point& dstPoint) {
   if (textureProxy == nullptr || srcRect.isEmpty()) {
     return nullptr;
   }
-  return std::unique_ptr<CopyOp>(new CopyOp(std::move(textureProxy), srcRect, dstPoint));
+  return std::unique_ptr<SubTextureCopyOp>(
+      new SubTextureCopyOp(std::move(textureProxy), srcRect, dstPoint));
 }
 
-CopyOp::CopyOp(std::shared_ptr<TextureProxy> textureProxy, const Rect& srcRect,
-               const Point& dstPoint)
+SubTextureCopyOp::SubTextureCopyOp(std::shared_ptr<TextureProxy> textureProxy, const Rect& srcRect,
+                                   const Point& dstPoint)
     : textureProxy(std::move(textureProxy)), srcRect(srcRect), dstPoint(dstPoint) {
 }
 
-void CopyOp::execute(RenderPass* renderPass) {
+void SubTextureCopyOp::execute(RenderPass* renderPass) {
   auto texture = textureProxy->getTexture();
   if (texture == nullptr) {
     LOGE("CopyOp::execute() Failed to get the dest texture!");

--- a/src/gpu/ops/SubTextureCopyOp.h
+++ b/src/gpu/ops/SubTextureCopyOp.h
@@ -22,15 +22,19 @@
 #include "gpu/proxies/TextureProxy.h"
 
 namespace tgfx {
-class CopyOp : public Op {
+/**
+ * TextureCopyOp is an operation that copies a portion of a render target to the given texture.
+ */
+class SubTextureCopyOp : public Op {
  public:
-  static std::unique_ptr<CopyOp> Make(std::shared_ptr<TextureProxy> textureProxy,
-                                      const Rect& srcRect, const Point& dstPoint);
+  static std::unique_ptr<SubTextureCopyOp> Make(std::shared_ptr<TextureProxy> textureProxy,
+                                                const Rect& srcRect, const Point& dstPoint);
 
   void execute(RenderPass* renderPass) override;
 
  private:
-  CopyOp(std::shared_ptr<TextureProxy> textureProxy, const Rect& srcRect, const Point& dstPoint);
+  SubTextureCopyOp(std::shared_ptr<TextureProxy> textureProxy, const Rect& srcRect,
+                   const Point& dstPoint);
 
   std::shared_ptr<TextureProxy> textureProxy = nullptr;
   Rect srcRect = Rect::MakeEmpty();

--- a/src/gpu/tasks/RenderTargetCopyTask.cpp
+++ b/src/gpu/tasks/RenderTargetCopyTask.cpp
@@ -1,0 +1,43 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "RenderTargetCopyTask.h"
+
+namespace tgfx {
+RenderTargetCopyTask::RenderTargetCopyTask(std::shared_ptr<RenderTargetProxy> source,
+                                           std::shared_ptr<TextureProxy> dest)
+    : RenderTask(std::move(source)), dest(std::move(dest)) {
+}
+
+bool RenderTargetCopyTask::execute(Gpu* gpu) {
+  auto renderTarget = renderTargetProxy->getRenderTarget();
+  if (renderTarget == nullptr) {
+    LOGE("RenderTargetCopyTask::execute() Failed to get the source render target!");
+    return false;
+  }
+  auto texture = dest->getTexture();
+  if (texture == nullptr) {
+    LOGE("RenderTargetCopyTask::execute() Failed to get the dest texture!");
+    return false;
+  }
+  auto bounds = renderTargetProxy->bounds();
+  gpu->copyRenderTargetToTexture(renderTarget.get(), texture.get(), bounds, Point::Zero());
+  return true;
+}
+
+}  // namespace tgfx

--- a/src/gpu/tasks/RenderTargetCopyTask.h
+++ b/src/gpu/tasks/RenderTargetCopyTask.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making tgfx available.
 //
-//  Copyright (C) 2023 THL A29 Limited, a Tencent company. All rights reserved.
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at
@@ -18,29 +18,17 @@
 
 #pragma once
 
-#include "gpu/RenderPass.h"
-#include "gpu/opengl/GLBuffer.h"
-#include "gpu/opengl/GLVertexArray.h"
-#include "gpu/ops/Op.h"
+#include "RenderTask.h"
 
 namespace tgfx {
-
-class GLRenderPass : public RenderPass {
+class RenderTargetCopyTask : public RenderTask {
  public:
-  explicit GLRenderPass(Context* context);
+  RenderTargetCopyTask(std::shared_ptr<RenderTargetProxy> source,
+                       std::shared_ptr<TextureProxy> dest);
 
- protected:
-  void onBindRenderTarget() override;
-  bool onBindProgramAndScissorClip(const ProgramInfo* programInfo,
-                                   const Rect& scissorRect) override;
-  void onDraw(PrimitiveType primitiveType, size_t baseVertex, size_t vertexCount) override;
-  void onDrawIndexed(PrimitiveType primitiveType, size_t baseIndex, size_t indexCount) override;
-  void onClear(const Rect& scissor, Color color) override;
+  bool execute(Gpu* gpu) override;
 
  private:
-  std::shared_ptr<GLVertexArray> vertexArray = nullptr;
-  std::shared_ptr<GLBuffer> sharedVertexBuffer = nullptr;
-
-  void draw(const std::function<void()>& func);
+  std::shared_ptr<TextureProxy> dest = nullptr;
 };
 }  // namespace tgfx

--- a/test/src/SurfaceTest.cpp
+++ b/test/src/SurfaceTest.cpp
@@ -33,7 +33,7 @@ TGFX_TEST(SurfaceTest, ImageSnapshot) {
   auto height = 200;
   CreateGLTexture(context, width, height, &textureInfo);
   BackendTexture backendTexture = {textureInfo, width, height};
-  auto surface = Surface::MakeFrom(context, backendTexture, ImageOrigin::BottomLeft);
+  auto surface = Surface::MakeFrom(context, backendTexture, ImageOrigin::BottomLeft, 4);
   ASSERT_TRUE(surface != nullptr);
   auto image = MakeImage("resources/apitest/imageReplacement.png");
   ASSERT_TRUE(image != nullptr);
@@ -53,7 +53,7 @@ TGFX_TEST(SurfaceTest, ImageSnapshot) {
   compareCanvas->drawImage(snapshotImage);
   EXPECT_TRUE(Baseline::Compare(compareSurface, "SurfaceTest/ImageSnapshot1"));
 
-  surface = Surface::Make(context, width, height);
+  surface = Surface::Make(context, width, height, false, 4);
   canvas = surface->getCanvas();
   snapshotImage = surface->makeImageSnapshot();
   auto renderTargetProxy = surface->renderContext->renderTarget;


### PR DESCRIPTION
修复当Surface开启MSAA后，makeImageSnapshot()结果错误的问题。