### PR TITLE
fix compile error in SVG

### DIFF
--- a/src/svg/SVGNodeConstructor.cpp
+++ b/src/svg/SVGNodeConstructor.cpp
@@ -435,6 +435,7 @@ std::shared_ptr<SVGNode> SVGNodeConstructor::ConstructSVGNode(const Construction
     }
     //can't find the element factory
     DEBUG_ASSERT(false);
+    return nullptr;
   };
 
   auto node = makeNode(context, elementName);


### PR DESCRIPTION
解决一个lambda函数中分支没有返回值导致的编译问题