### PR TITLE
Fix issue of the RenderDoc attachment failure

### DIFF
--- a/src/gpu/opengl/wgl/WGLInterface.cpp
+++ b/src/gpu/opengl/wgl/WGLInterface.cpp
@@ -61,19 +61,6 @@ static void DestroyTempWindow(HWND nativeWindow) {
   UnregisterClass(TEMP_CLASS, instance);
 }
 
-static bool GetGLVersion(int& glMajorMax, int& glMinorMax) {
-  const char* versionString = (const char*)glGetString(GL_VERSION);
-  if (versionString == nullptr) {
-    return false;
-  }
-  int n = sscanf_s(versionString, "%d.%d", &glMajorMax, &glMinorMax);
-  if (2 == n) {
-    return true;
-  }
-  n = sscanf_s(versionString, "OpenGL ES GLSL ES %d.%d", &glMajorMax, &glMinorMax);
-  return 2 == n;
-}
-
 void InitializeWGLExtensions(HDC deviceContext, WGLInterface& wglInterface) {
   if (deviceContext == nullptr) {
     LOGE("InitializeWGLExtensions() deviceContext is nullptr");
@@ -139,7 +126,6 @@ WGLInterface InitializeWGL() {
     GET_PROC(SwapInterval, EXT);
     GET_PROC(CreateContextAttribs, ARB);
     InitializeWGLExtensions(deviceContext, wglInterface);
-    GetGLVersion(wglInterface.glMajorMax, wglInterface.glMinorMax);
     wglMakeCurrent(deviceContext, nullptr);
     wglDeleteContext(glContext);
     DestroyTempWindow(nativeWindow);

--- a/src/gpu/opengl/wgl/WGLInterface.h
+++ b/src/gpu/opengl/wgl/WGLInterface.h
@@ -38,7 +38,6 @@ DECLARE_HANDLE(HPBUFFER);
 #define WGL_CONTEXT_MINOR_VERSION 0x2092
 #define WGL_CONTEXT_PROFILE_MASK 0x9126
 #define WGL_CONTEXT_CORE_PROFILE_BIT 0x00000001
-#define WGL_CONTEXT_COMPATIBILITY_PROFILE_BIT 0x00000002
 
 using GetExtensionsStringProc = const char*(WINAPI*)(HDC);
 using ChoosePixelFormatProc = BOOL(WINAPI*)(HDC, const int*, const FLOAT*, UINT, int*, UINT*);
@@ -60,9 +59,6 @@ class WGLInterface {
   bool pBufferSupport = false;
   bool swapIntervalSupport = false;
   bool createContextAttribsSupport = false;
-
-  int glMajorMax = 1;
-  int glMinorMax = 0;
 
   GetExtensionsStringProc wglGetExtensionsString = nullptr;
   ChoosePixelFormatProc wglChoosePixelFormat = nullptr;


### PR DESCRIPTION
1.根据renderdoc官方说明，抓帧需要core profile
2.我们默认还是需要配置compatibility profile最稳妥
所以renderdoc的问题还是单独处理吧，这样不影响之前的功能，也不影响性能。