### PR TITLE
Improve picture recorder performance by using BlockBuffer for memory allocation.

### DIFF
--- a/include/tgfx/core/Picture.h
+++ b/include/tgfx/core/Picture.h
@@ -67,7 +67,7 @@ class Picture {
 
  private:
   std::shared_ptr<BlockData> blockData = nullptr;
-  std::vector<PlacementPtr<Record>> records = {};
+  std::vector<PlacementPtr<Record>> records;
   size_t drawCount = 0;
   bool _hasUnboundedFill = false;
 

--- a/src/core/Picture.cpp
+++ b/src/core/Picture.cpp
@@ -20,19 +20,29 @@
 #include "core/MeasureContext.h"
 #include "core/Records.h"
 #include "core/TransformContext.h"
+#include "core/utils/BlockBuffer.h"
 #include "core/utils/Log.h"
 #include "tgfx/core/Canvas.h"
-#include "tgfx/core/Surface.h"
+#include "tgfx/core/Image.h"
 
 namespace tgfx {
-Picture::Picture(std::vector<Record*> records, bool hasUnboundedFill)
-    : records(std::move(records)), _hasUnboundedFill(hasUnboundedFill) {
+Picture::Picture(std::shared_ptr<BlockData> data, std::vector<PlacementPtr<Record>> recordList,
+                 size_t drawCount)
+    : blockData(std::move(data)), records(std::move(recordList)), drawCount(drawCount) {
+  DEBUG_ASSERT(blockData != nullptr);
+  DEBUG_ASSERT(!records.empty());
+  bool hasInverseClip = true;
+  for (auto& record : records) {
+    if (record->hasUnboundedFill(hasInverseClip)) {
+      _hasUnboundedFill = true;
+      break;
+    }
+  }
 }
 
 Picture::~Picture() {
-  for (auto& record : records) {
-    delete record;
-  }
+  // Make sure the records are cleared before the block data is destroyed.
+  records.clear();
 }
 
 Rect Picture::getBounds(const Matrix* matrix) const {
@@ -43,22 +53,23 @@ Rect Picture::getBounds(const Matrix* matrix) const {
 }
 
 void Picture::playback(Canvas* canvas) const {
-  if (canvas == nullptr) {
-    return;
+  if (canvas != nullptr) {
+    playback(canvas->drawContext, *canvas->mcState);
   }
-  playback(canvas->drawContext, *canvas->mcState);
 }
 
 void Picture::playback(DrawContext* drawContext, const MCState& state) const {
   DEBUG_ASSERT(drawContext != nullptr);
-  auto transformContext = TransformContext::Make(drawContext, state.matrix, state.clip);
-  if (transformContext) {
-    drawContext = transformContext.get();
-  } else if (state.clip.isEmpty() && !state.clip.isInverseFillType()) {
+  if (state.clip.isEmpty() && !state.clip.isInverseFillType()) {
     return;
   }
+  TransformContext transformContext(drawContext, state);
+  if (transformContext.type() != TransformContext::Type::None) {
+    drawContext = &transformContext;
+  }
+  PlaybackContext playbackContext = {};
   for (auto& record : records) {
-    record->playback(drawContext);
+    record->playback(drawContext, &playbackContext);
   }
 }
 
@@ -86,15 +97,19 @@ static bool GetClipRect(const Path& clip, const Matrix* matrix, Rect* clipRect) 
 
 std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
                                         const ISize* clipSize) const {
-  if (records.size() != 1) {
+  if (drawCount != 1) {
     return nullptr;
   }
-  auto record = records[0];
+  MCState state = {};
+  Fill fill = {};
+  auto record = firstDrawRecord(&state, &fill);
+  if (record == nullptr) {
+    return nullptr;
+  }
   if (record->type() != RecordType::DrawImage && record->type() != RecordType::DrawImageRect) {
     return nullptr;
   }
   auto imageRecord = static_cast<const DrawImage*>(record);
-  auto& fill = imageRecord->fill;
   if (fill.maskFilter || fill.colorFilter) {
     return nullptr;
   }
@@ -104,7 +119,7 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
       return nullptr;
     }
   }
-  auto imageMatrix = imageRecord->state.matrix;
+  auto imageMatrix = state.matrix;
   if (matrix) {
     imageMatrix.postConcat(*matrix);
   }
@@ -112,7 +127,7 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
     return nullptr;
   }
   auto clipRect = Rect::MakeEmpty();
-  if (!GetClipRect(imageRecord->state.clip, matrix, &clipRect)) {
+  if (!GetClipRect(state.clip, matrix, &clipRect)) {
     return nullptr;
   }
   auto subset = Rect::MakeEmpty();
@@ -125,7 +140,7 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
     subset = clipRect;
   }
   if (record->type() == RecordType::DrawImageRect) {
-    image = image->makeSubset(static_cast<const DrawImageRect*>(imageRecord)->rect);
+    image = image->makeSubset(static_cast<const DrawImageRect*>(record)->rect);
     DEBUG_ASSERT(image != nullptr);
   }
   auto offsetX = imageMatrix.getTranslateX();
@@ -148,6 +163,39 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
     offset->set(offsetX, offsetY);
   }
   return image;
+}
+
+const Record* Picture::firstDrawRecord(tgfx::MCState* state, tgfx::Fill* fill) const {
+  for (auto& record : records) {
+    if (record->type() > RecordType::SetFill) {
+      return record.get();
+    }
+    switch (record->type()) {
+      case RecordType::SetMatrix:
+        if (state) {
+          state->matrix = static_cast<SetMatrix*>(record.get())->matrix;
+        }
+        break;
+      case RecordType::SetClip:
+        if (state) {
+          state->clip = static_cast<SetClip*>(record.get())->clip;
+        }
+        break;
+      case RecordType::SetColor:
+        if (fill) {
+          fill->color = static_cast<SetColor*>(record.get())->color;
+        }
+        break;
+      case RecordType::SetFill:
+        if (fill) {
+          *fill = static_cast<SetFill*>(record.get())->fill;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  return nullptr;
 }
 
 }  // namespace tgfx

--- a/src/core/Recorder.cpp
+++ b/src/core/Recorder.cpp
@@ -29,13 +29,11 @@ Canvas* Recorder::beginRecording() {
   if (canvas == nullptr) {
     recordingContext = new RecordingContext();
     canvas = new Canvas(recordingContext);
-  }
-  if (activelyRecording) {
+  } else {
     canvas->resetStateStack();
     recordingContext->clear();
-  } else {
-    activelyRecording = true;
   }
+  activelyRecording = true;
   return getRecordingCanvas();
 }
 
@@ -44,11 +42,10 @@ Canvas* Recorder::getRecordingCanvas() const {
 }
 
 std::shared_ptr<Picture> Recorder::finishRecordingAsPicture() {
-  if (!activelyRecording || recordingContext == nullptr) {
+  if (!activelyRecording) {
     return nullptr;
   }
   activelyRecording = false;
-  canvas->resetStateStack();
   return recordingContext->finishRecordingAsPicture();
 }
 }  // namespace tgfx

--- a/src/core/RecordingContext.h
+++ b/src/core/RecordingContext.h
@@ -21,13 +21,16 @@
 #include <functional>
 #include "core/DrawContext.h"
 #include "core/Records.h"
+#include "core/utils/BlockBuffer.h"
 
 namespace tgfx {
 class RecordingContext : public DrawContext {
  public:
-  std::shared_ptr<Picture> finishRecordingAsPicture();
+  ~RecordingContext() override;
 
   void clear();
+
+  std::shared_ptr<Picture> finishRecordingAsPicture();
 
   void drawFill(const MCState& state, const Fill& fill) override;
 
@@ -53,6 +56,13 @@ class RecordingContext : public DrawContext {
                  const MCState& state, const Fill& fill) override;
 
  private:
-  std::vector<Record*> records = {};
+  BlockBuffer blockBuffer = {};
+  std::vector<PlacementPtr<Record>> records = {};
+  size_t drawCount = 0;
+  MCState lastState = {};
+  Fill lastFill = {};
+
+  void recordState(const MCState& state);
+  void recordStateAndFill(const MCState& state, const Fill& fill);
 };
 }  // namespace tgfx

--- a/src/core/TransformContext.h
+++ b/src/core/TransformContext.h
@@ -26,21 +26,12 @@ namespace tgfx {
  */
 class TransformContext : public DrawContext {
  public:
-  /**
-   * Creates a new transform context that applies the given matrix to the state. Returns nullptr if
-   * the matrix is identity or the drawContext is nullptr.
-   */
-  static std::unique_ptr<TransformContext> Make(DrawContext* drawContext, const Matrix& matrix);
+  enum class Type { None, Matrix, Clip, Both };
 
-  /**
-   * Creates a new transform context that applies the given matrix and clip to the state. Returns
-   * nullptr if the matrix is identity and the clip is wide open, or the drawContext is nullptr, or
-   * the clip is empty.
-   */
-  static std::unique_ptr<TransformContext> Make(DrawContext* drawContext, const Matrix& matrix,
-                                                const Path& clip);
+  TransformContext(DrawContext* drawContext, const MCState& state);
 
-  explicit TransformContext(DrawContext* drawContext) : drawContext(drawContext) {
+  Type type() const {
+    return _type;
   }
 
   void drawFill(const MCState& state, const Fill& fill) override {
@@ -84,10 +75,13 @@ class TransformContext : public DrawContext {
     drawContext->drawLayer(std::move(picture), std::move(filter), transform(state), fill);
   }
 
- protected:
-  virtual MCState transform(const MCState& state) = 0;
-
  private:
+  Type _type = Type::None;
   DrawContext* drawContext = nullptr;
+  MCState initState = {};
+  Path lastClip = {};
+  Path lastIntersectedClip = {};
+
+  MCState transform(const MCState& state);
 };
 }  // namespace tgfx

--- a/src/core/images/PictureImage.cpp
+++ b/src/core/images/PictureImage.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<Image> Image::MakeFrom(std::shared_ptr<Picture> picture, int wid
   if (matrix && !matrix->invertible()) {
     return nullptr;
   }
-  if (picture->records.size() == 1) {
+  if (picture->drawCount == 1) {
     ISize clipSize = {width, height};
     auto image = picture->asImage(nullptr, matrix, &clipSize);
     if (image) {

--- a/src/core/utils/BlockBuffer.h
+++ b/src/core/utils/BlockBuffer.h
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <vector>
 #include "core/utils/PlacementPtr.h"
 

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -745,7 +745,7 @@ std::shared_ptr<MaskFilter> Layer::getMaskFilter(const DrawArgs& args, float sca
     return nullptr;
   }
   auto maskImageOffset = Point::Zero();
-  auto maskContentImage = CreatePictureImage(maskPicture, &maskImageOffset);
+  auto maskContentImage = CreatePictureImage(std::move(maskPicture), &maskImageOffset);
   if (maskContentImage == nullptr) {
     return nullptr;
   }
@@ -892,7 +892,7 @@ std::unique_ptr<LayerStyleSource> Layer::getLayerStyleSource(const DrawArgs& arg
   DrawArgs drawArgs(nullptr, false, bitFields.excludeChildEffectsInLayerStyle);
   auto contentPicture = CreatePicture(drawArgs, contentScale, drawLayerContents);
   auto contentOffset = Point::Zero();
-  auto content = CreatePictureImage(contentPicture, &contentOffset);
+  auto content = CreatePictureImage(std::move(contentPicture), &contentOffset);
   if (content == nullptr) {
     return nullptr;
   }
@@ -910,7 +910,7 @@ std::unique_ptr<LayerStyleSource> Layer::getLayerStyleSource(const DrawArgs& arg
     drawArgs.excludeEffects = true;
     drawArgs.drawMode = DrawMode::Contour;
     auto contourPicture = CreatePicture(drawArgs, contentScale, drawLayerContents);
-    source->contour = CreatePictureImage(contourPicture, &source->contourOffset);
+    source->contour = CreatePictureImage(std::move(contourPicture), &source->contourOffset);
   }
 
   auto needBackground =
@@ -934,7 +934,8 @@ std::unique_ptr<LayerStyleSource> Layer::getLayerStyleSource(const DrawArgs& arg
       drawBackground(args, canvas);
     };
     auto backgroundPicture = CreatePicture(drawArgs, contentScale, backgroundDrawer);
-    source->background = CreatePictureImage(backgroundPicture, &source->backgroundOffset);
+    source->background =
+        CreatePictureImage(std::move(backgroundPicture), &source->backgroundOffset);
   }
   return source;
 }

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -1252,8 +1252,8 @@ TGFX_TEST(CanvasTest, Picture) {
   paint.setImageFilter(nullptr);
   auto imagePicture = recorder.finishRecordingAsPicture();
   ASSERT_TRUE(imagePicture != nullptr);
-  ASSERT_TRUE(imagePicture->records.size() == 1);
-  EXPECT_EQ(imagePicture->records[0]->type(), RecordType::DrawImage);
+  ASSERT_TRUE(imagePicture->drawCount == 1);
+  EXPECT_EQ(imagePicture->firstDrawRecord()->type(), RecordType::DrawImage);
 
   surface = Surface::Make(context, image->width() - 200, image->height() - 200);
   canvas = surface->getCanvas();


### PR DESCRIPTION
使用BlockBuffer集中分配Picture的内存，并去掉重复的MCState和Fill的记录。