### PR TITLE
Pass uvMatrix to QuadPerEdgeAAGeometryProcessor and use a PlacementArray to store PlacementPtrs.

### DIFF
--- a/src/core/utils/BlockBuffer.h
+++ b/src/core/utils/BlockBuffer.h
@@ -103,7 +103,7 @@ class BlockBuffer {
     auto byteSize = sizeof(PlacementPtr<T>) * count;
     void* memory = allocate(byteSize);
     memcpy(memory, elements, byteSize);
-    memset(elements, 0, byteSize);
+    memset(static_cast<void*>(elements), 0, byteSize);
     return PlacementArray<T>(reinterpret_cast<PlacementPtr<T>*>(memory), count);
   }
 

--- a/src/core/utils/PlacementArray.h
+++ b/src/core/utils/PlacementArray.h
@@ -1,0 +1,184 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstddef>
+
+namespace tgfx {
+/**
+ * PlacementArray is a simple array-like container that uses placement new to construct objects in
+ * pre-allocated memory. It is similar to std::array, but does not manage the memory itself.
+ */
+template <typename T>
+class PlacementArray {
+ public:
+  /**
+   * Constructs an empty PlacementArray.
+   */
+  PlacementArray() = default;
+
+  ~PlacementArray() {
+    clear();
+  }
+
+  PlacementArray(const PlacementArray&) = delete;
+
+  PlacementArray& operator=(const PlacementArray&) = delete;
+
+  /**
+   * Constructs a PlacementArray by moving from another PlacementArray.
+   */
+  PlacementArray(PlacementArray&& other) noexcept : data(other.data), _size(other._size) {
+    other.data = nullptr;
+    other._size = 0;
+  }
+
+  /**
+   * Constructs a PlacementArray from another PlacementArray of a different type.
+   */
+  template <typename U>
+  PlacementArray(PlacementArray<U>&& other) noexcept : data(other.data), _size(other.size) {
+    other.data = nullptr;
+    other._size = 0;
+  }
+
+  /**
+   * Assigns a PlacementArray by moving from another PlacementArray.
+   */
+  PlacementArray& operator=(PlacementArray&& other) noexcept {
+    if (this != &other) {
+      clear();
+      data = other.data;
+      _size = other._size;
+      other.data = nullptr;
+      other._size = 0;
+    }
+    return *this;
+  }
+
+  /**
+   * Returns the number of elements in the PlacementArray.
+   */
+  size_t size() const {
+    return _size;
+  }
+
+  /**
+   * Returns true if the PlacementArray is empty.
+   */
+  bool empty() const {
+    return _size == 0;
+  }
+
+  /**
+   * Clears the PlacementArray, destroying all elements.
+   */
+  void clear() {
+    if (_size > 0) {
+      for (size_t i = 0; i < _size; ++i) {
+        data[i]->~T();
+      }
+      data = nullptr;
+      _size = 0;
+    }
+  }
+
+  /**
+   * Returns a pointer to the element at the specified index.
+   */
+  T* operator[](size_t index) const {
+    return data[index];
+  }
+
+  /**
+   * Returns a pointer to the element at the front of the PlacementArray.
+   */
+  T* front() const {
+    return data[0];
+  }
+
+  /**
+   * Returns a pointer to the element at the back of the PlacementArray.
+   */
+  T* back() const {
+    return data[_size - 1];
+  }
+
+  /**
+   * The iterator class for the PlacementArray.
+   */
+  class Iterator {
+   public:
+    Iterator(T** data, size_t index) : data(data), index(index) {
+    }
+
+    /**
+     * Dereferences the iterator to get the element at the current index.
+     */
+    T*& operator*() const {
+      return data[index];
+    }
+
+    /**
+     * Increments the iterator to the next element.
+     */
+    const Iterator& operator++() {
+      ++index;
+      return *this;
+    }
+
+    /**
+     * Compares two iterators for equality.
+     */
+    bool operator!=(const Iterator& other) const {
+      return index != other.index;
+    }
+
+   private:
+    T** data;
+    size_t index;
+  };
+
+  /**
+   * Returns an iterator to the beginning of the PlacementArray.
+   */
+  Iterator begin() const {
+    return Iterator(data, 0);
+  }
+
+  /**
+   * Returns an iterator to the end of the PlacementArray.
+   */
+  Iterator end() const {
+    return Iterator(data, _size);
+  }
+
+ private:
+  T** data = nullptr;
+  size_t _size = 0;
+
+  /**
+   * Constructs a PlacementArray with the specified data and size.
+   */
+  PlacementArray(T** data, size_t size) : data(data), _size(size) {
+  }
+
+  friend class BlockBuffer;
+};
+}  // namespace tgfx

--- a/src/core/utils/PlacementPtr.h
+++ b/src/core/utils/PlacementPtr.h
@@ -155,6 +155,15 @@ class PlacementPtr {
     pointer = ptr;
   }
 
+  /**
+   * Releases the ownership of the pointer and returns the raw pointer.
+   */
+  T* release() {
+    T* temp = pointer;
+    pointer = nullptr;
+    return temp;
+  }
+
   T& operator*() const {
     return *pointer;
   }

--- a/src/core/utils/PlacementPtr.h
+++ b/src/core/utils/PlacementPtr.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 namespace tgfx {
 /**
@@ -70,6 +71,7 @@ class PlacementPtr {
    */
   template <typename U>
   PlacementPtr(PlacementPtr<U>&& other) noexcept : pointer(other.pointer) {
+    static_assert(std::is_base_of_v<T, U>, "U must be derived from T!");
     other.pointer = nullptr;
   }
 

--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -35,8 +35,7 @@ bool DrawingManager::fillRTWithFP(std::shared_ptr<RenderTargetProxy> renderTarge
     return false;
   }
   auto bounds = Rect::MakeWH(renderTarget->width(), renderTarget->height());
-  auto rect = drawingBuffer->make<RectPaint>(bounds, Matrix::I());
-  auto provider = RectsVertexProvider::MakeFrom(std::move(rect), AAType::None);
+  auto provider = RectsVertexProvider::MakeFrom(context->drawingBuffer(), bounds, AAType::None);
   auto op = RectDrawOp::Make(renderTarget->getContext(), std::move(provider), renderFlags);
   op->addColorFP(std::move(processor));
   op->setBlendMode(BlendMode::Src);

--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -35,11 +35,9 @@ bool DrawingManager::fillRTWithFP(std::shared_ptr<RenderTargetProxy> renderTarge
     return false;
   }
   auto bounds = Rect::MakeWH(renderTarget->width(), renderTarget->height());
-  auto rectPaint = drawingBuffer->make<RectPaint>(bounds, Matrix::I());
-  std::vector<PlacementPtr<RectPaint>> rects = {};
-  rects.emplace_back(std::move(rectPaint));
-  auto op = RectDrawOp::Make(renderTarget->getContext(), std::move(rects), true, AAType::None,
-                             renderFlags);
+  auto rect = drawingBuffer->make<RectPaint>(bounds, Matrix::I());
+  auto provider = RectsVertexProvider::MakeFrom(std::move(rect), AAType::None);
+  auto op = RectDrawOp::Make(renderTarget->getContext(), std::move(provider), renderFlags);
   op->addColorFP(std::move(processor));
   op->setBlendMode(BlendMode::Src);
   std::vector<PlacementPtr<Op>> ops = {};

--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -35,12 +35,11 @@ bool DrawingManager::fillRTWithFP(std::shared_ptr<RenderTargetProxy> renderTarge
     return false;
   }
   auto bounds = Rect::MakeWH(renderTarget->width(), renderTarget->height());
-  auto provider = RectsVertexProvider::MakeFrom(context->drawingBuffer(), bounds, AAType::None);
+  auto provider = RectsVertexProvider::MakeFrom(drawingBuffer, bounds, AAType::None);
   auto op = RectDrawOp::Make(renderTarget->getContext(), std::move(provider), renderFlags);
   op->addColorFP(std::move(processor));
   op->setBlendMode(BlendMode::Src);
-  std::vector<PlacementPtr<Op>> ops = {};
-  ops.emplace_back(std::move(op));
+  auto ops = drawingBuffer->makeArray<Op>(&op, 1);
   auto task = drawingBuffer->make<OpsRenderTask>(renderTarget, std::move(ops));
   renderTasks.emplace_back(std::move(task));
   addTextureResolveTask(std::move(renderTarget));
@@ -56,7 +55,7 @@ std::shared_ptr<OpsCompositor> DrawingManager::addOpsCompositor(
 }
 
 void DrawingManager::addOpsRenderTask(std::shared_ptr<RenderTargetProxy> renderTarget,
-                                      std::vector<PlacementPtr<Op>> ops) {
+                                      PlacementArray<Op> ops) {
   if (renderTarget == nullptr || ops.empty()) {
     return;
   }

--- a/src/gpu/DrawingManager.h
+++ b/src/gpu/DrawingManager.h
@@ -41,8 +41,7 @@ class DrawingManager {
   std::shared_ptr<OpsCompositor> addOpsCompositor(std::shared_ptr<RenderTargetProxy> renderTarget,
                                                   uint32_t renderFlags);
 
-  void addOpsRenderTask(std::shared_ptr<RenderTargetProxy> renderTarget,
-                        std::vector<PlacementPtr<Op>> ops);
+  void addOpsRenderTask(std::shared_ptr<RenderTargetProxy> renderTarget, PlacementArray<Op> ops);
 
   void addRuntimeDrawTask(std::shared_ptr<RenderTargetProxy> renderTarget,
                           std::vector<std::shared_ptr<TextureProxy>> inputs,

--- a/src/gpu/OpsCompositor.cpp
+++ b/src/gpu/OpsCompositor.cpp
@@ -253,10 +253,8 @@ void OpsCompositor::flushPendingOps(PendingOpType type, Path clip, Fill fill) {
           deviceBounds.join(rect);
         }
       }
-      auto capacity = pendingRects.size();
-      auto provider =
-          RectsVertexProvider::MakeFrom(std::move(pendingRects), aaType, needLocalBounds);
-      pendingRects.reserve(capacity);
+      auto provider = RectsVertexProvider::MakeFrom(drawingBuffer(), std::move(pendingRects),
+                                                    aaType, needLocalBounds);
       drawOp = RectDrawOp::Make(context, std::move(provider), renderFlags);
     } break;
     case PendingOpType::RRect: {
@@ -270,10 +268,8 @@ void OpsCompositor::flushPendingOps(PendingOpType type, Path clip, Fill fill) {
           localBounds = Rect::MakeEmpty();
         }
       }
-      auto capacity = pendingRRects.size();
-      auto provider =
-          RRectsVertexProvider::MakeFrom(std::move(pendingRRects), aaType, RRectUseScale(context));
-      pendingRRects.reserve(capacity);
+      auto provider = RRectsVertexProvider::MakeFrom(drawingBuffer(), std::move(pendingRRects),
+                                                     aaType, RRectUseScale(context));
       drawOp = RRectDrawOp::Make(context, std::move(provider), renderFlags);
     } break;
     default:

--- a/src/gpu/OpsCompositor.cpp
+++ b/src/gpu/OpsCompositor.cpp
@@ -343,7 +343,8 @@ void OpsCompositor::makeClosed() {
   }
   flushPendingOps();
   auto drawingManager = context->drawingManager();
-  drawingManager->addOpsRenderTask(std::move(renderTarget), std::move(ops));
+  auto opArray = drawingBuffer()->makeArray(std::move(ops));
+  drawingManager->addOpsRenderTask(std::move(renderTarget), std::move(opArray));
   // Remove the compositor from the list, so it won't be flushed again.
   drawingManager->compositors.erase(cachedPosition);
 }
@@ -428,9 +429,9 @@ std::shared_ptr<TextureProxy> OpsCompositor::getClipTexture(const Path& clip, AA
     }
     clipTexture = clipRenderTarget->getTextureProxy();
     auto clearOp = ClearOp::Make(context, Color::Transparent(), clipRenderTarget->bounds());
-    std::vector<PlacementPtr<Op>> opList = {};
-    opList.emplace_back(std::move(clearOp));
-    opList.emplace_back(std::move(drawOp));
+    auto opList = drawingBuffer()->makeArray<Op>(2);
+    opList[0] = std::move(clearOp);
+    opList[1] = std::move(drawOp);
     context->drawingManager()->addOpsRenderTask(std::move(clipRenderTarget), std::move(opList));
   } else {
     auto rasterizer =

--- a/src/gpu/ProxyProvider.cpp
+++ b/src/gpu/ProxyProvider.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<GpuBufferProxy> ProxyProvider::createGpuBufferProxy(
 }
 
 std::pair<std::shared_ptr<GpuBufferProxy>, size_t> ProxyProvider::createSharedVertexBuffer(
-    std::unique_ptr<VertexProvider> provider, uint32_t renderFlags) {
+    PlacementPtr<VertexProvider> provider, uint32_t renderFlags) {
   if (provider == nullptr) {
     return {nullptr, 0};
   }

--- a/src/gpu/ProxyProvider.h
+++ b/src/gpu/ProxyProvider.h
@@ -72,7 +72,7 @@ class ProxyProvider {
    * buffer where the vertices are stored.
    */
   std::pair<std::shared_ptr<GpuBufferProxy>, size_t> createSharedVertexBuffer(
-      std::unique_ptr<VertexProvider> provider, uint32_t renderFlags = 0);
+      PlacementPtr<VertexProvider> provider, uint32_t renderFlags = 0);
 
   /**
    * Creates a GpuShapeProxy for the given Shape. The shape will be released after being uploaded to

--- a/src/gpu/RRectsVertexProvider.cpp
+++ b/src/gpu/RRectsVertexProvider.cpp
@@ -1,0 +1,189 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "RRectsVertexProvider.h"
+#include "core/utils/MathExtra.h"
+
+namespace tgfx {
+// We have three possible cases for geometry for a round rect.
+//
+// In the case of a normal fill or a stroke, we draw the round rect as a 9-patch:
+//    ____________
+//   |_|________|_|
+//   | |        | |
+//   | |        | |
+//   | |        | |
+//   |_|________|_|
+//   |_|________|_|
+//
+// For strokes, we don't draw the center quad.
+//
+// For circular round rects, in the case where the stroke width is greater than twice
+// the corner radius (over stroke), we add additional geometry to mark out the rectangle
+// in the center. The shared vertices are duplicated, so we can set a different outer radius
+// for the fill calculation.
+//    ____________
+//   |_|________|_|
+//   | |\ ____ /| |
+//   | | |    | | |
+//   | | |____| | |
+//   |_|/______\|_|
+//   |_|________|_|
+//
+// We don't draw the center quad from the fill rect in this case.
+//
+// For filled rrects that need to provide a distance vector we reuse the overstroke
+// geometry but make the inner rect degenerate (either a point or a horizontal or
+// vertical line).
+
+std::unique_ptr<RRectsVertexProvider> RRectsVertexProvider::MakeFrom(
+    std::vector<PlacementPtr<RRectPaint>> rects, AAType aaType, bool useScale) {
+  if (rects.empty()) {
+    return nullptr;
+  }
+  return std::unique_ptr<RRectsVertexProvider>(
+      new RRectsVertexProvider(std::move(rects), aaType, useScale));
+}
+
+static void WriteUByte4Color(float* vertices, int& index, const Color& color) {
+  auto bytes = reinterpret_cast<uint8_t*>(&vertices[index++]);
+  bytes[0] = static_cast<uint8_t>(color.red * 255);
+  bytes[1] = static_cast<uint8_t>(color.green * 255);
+  bytes[2] = static_cast<uint8_t>(color.blue * 255);
+  bytes[3] = static_cast<uint8_t>(color.alpha * 255);
+}
+
+RRectsVertexProvider::RRectsVertexProvider(std::vector<PlacementPtr<RRectPaint>> rects,
+                                           AAType aaType, bool useScale)
+    : rects(std::move(rects)) {
+  bitFields.aaType = static_cast<uint8_t>(aaType);
+  bitFields.useScale = useScale;
+}
+
+size_t RRectsVertexProvider::vertexCount() const {
+  auto floatCount = rects.size() * 4 * 36;
+  if (bitFields.useScale) {
+    floatCount += rects.size() * 4 * 4;
+  }
+  return floatCount;
+}
+
+void RRectsVertexProvider::getVertices(float* vertices) const {
+  auto index = 0;
+  auto aaType = static_cast<AAType>(bitFields.aaType);
+  for (auto& rRectPaint : rects) {
+    auto viewMatrix = rRectPaint->viewMatrix;
+    auto rRect = rRectPaint->rRect;
+    auto& color = rRectPaint->color;
+    auto scales = viewMatrix.getAxisScales();
+    rRect.scale(scales.x, scales.y);
+    viewMatrix.preScale(1 / scales.x, 1 / scales.y);
+    float reciprocalRadii[4] = {1e6f, 1e6f, 1e6f, 1e6f};
+    if (rRect.radii.x > 0) {
+      reciprocalRadii[0] = 1.f / rRect.radii.x;
+    }
+    if (rRect.radii.y > 0) {
+      reciprocalRadii[1] = 1.f / rRect.radii.y;
+    }
+    // On MSAA, bloat enough to guarantee any pixel that might be touched by the rRect has
+    // full sample coverage.
+    float aaBloat = aaType == AAType::MSAA ? FLOAT_SQRT2 : .5f;
+    // Extend out the radii to antialias.
+    float xOuterRadius = rRect.radii.x + aaBloat;
+    float yOuterRadius = rRect.radii.y + aaBloat;
+
+    float xMaxOffset = xOuterRadius;
+    float yMaxOffset = yOuterRadius;
+    //  if (!stroked) {
+    // For filled rRectPaints we map a unit circle in the vertex attributes rather than
+    // computing an ellipse and modifying that distance, so we normalize to 1.
+    xMaxOffset /= rRect.radii.x;
+    yMaxOffset /= rRect.radii.y;
+    //  }
+    auto bounds = rRect.rect.makeOutset(aaBloat, aaBloat);
+    float yCoords[4] = {bounds.top, bounds.top + yOuterRadius, bounds.bottom - yOuterRadius,
+                        bounds.bottom};
+    float yOuterOffsets[4] = {
+        yMaxOffset,
+        FLOAT_NEARLY_ZERO,  // we're using inversesqrt() in shader, so can't be exactly 0
+        FLOAT_NEARLY_ZERO, yMaxOffset};
+    auto maxRadius = std::max(rRect.radii.x, rRect.radii.y);
+    for (int i = 0; i < 4; ++i) {
+      auto point = Point::Make(bounds.left, yCoords[i]);
+      viewMatrix.mapPoints(&point, 1);
+      vertices[index++] = point.x;
+      vertices[index++] = point.y;
+      WriteUByte4Color(vertices, index, color);
+      vertices[index++] = xMaxOffset;
+      vertices[index++] = yOuterOffsets[i];
+      if (bitFields.useScale) {
+        vertices[index++] = maxRadius;
+      }
+      vertices[index++] = reciprocalRadii[0];
+      vertices[index++] = reciprocalRadii[1];
+      vertices[index++] = reciprocalRadii[2];
+      vertices[index++] = reciprocalRadii[3];
+
+      point = Point::Make(bounds.left + xOuterRadius, yCoords[i]);
+      viewMatrix.mapPoints(&point, 1);
+      vertices[index++] = point.x;
+      vertices[index++] = point.y;
+      WriteUByte4Color(vertices, index, color);
+      vertices[index++] = FLOAT_NEARLY_ZERO;
+      vertices[index++] = yOuterOffsets[i];
+      if (bitFields.useScale) {
+        vertices[index++] = maxRadius;
+      }
+      vertices[index++] = reciprocalRadii[0];
+      vertices[index++] = reciprocalRadii[1];
+      vertices[index++] = reciprocalRadii[2];
+      vertices[index++] = reciprocalRadii[3];
+
+      point = Point::Make(bounds.right - xOuterRadius, yCoords[i]);
+      viewMatrix.mapPoints(&point, 1);
+      vertices[index++] = point.x;
+      vertices[index++] = point.y;
+      WriteUByte4Color(vertices, index, color);
+      vertices[index++] = FLOAT_NEARLY_ZERO;
+      vertices[index++] = yOuterOffsets[i];
+      if (bitFields.useScale) {
+        vertices[index++] = maxRadius;
+      }
+      vertices[index++] = reciprocalRadii[0];
+      vertices[index++] = reciprocalRadii[1];
+      vertices[index++] = reciprocalRadii[2];
+      vertices[index++] = reciprocalRadii[3];
+
+      point = Point::Make(bounds.right, yCoords[i]);
+      viewMatrix.mapPoints(&point, 1);
+      vertices[index++] = point.x;
+      vertices[index++] = point.y;
+      WriteUByte4Color(vertices, index, color);
+      vertices[index++] = xMaxOffset;
+      vertices[index++] = yOuterOffsets[i];
+      if (bitFields.useScale) {
+        vertices[index++] = maxRadius;
+      }
+      vertices[index++] = reciprocalRadii[0];
+      vertices[index++] = reciprocalRadii[1];
+      vertices[index++] = reciprocalRadii[2];
+      vertices[index++] = reciprocalRadii[3];
+    }
+  }
+}
+}  // namespace tgfx

--- a/src/gpu/RRectsVertexProvider.cpp
+++ b/src/gpu/RRectsVertexProvider.cpp
@@ -51,13 +51,14 @@ namespace tgfx {
 // geometry but make the inner rect degenerate (either a point or a horizontal or
 // vertical line).
 
-std::unique_ptr<RRectsVertexProvider> RRectsVertexProvider::MakeFrom(
-    std::vector<PlacementPtr<RRectPaint>> rects, AAType aaType, bool useScale) {
+PlacementPtr<RRectsVertexProvider> RRectsVertexProvider::MakeFrom(
+    BlockBuffer* buffer, std::vector<PlacementPtr<RRectPaint>>&& rects, AAType aaType,
+    bool useScale) {
   if (rects.empty()) {
     return nullptr;
   }
-  return std::unique_ptr<RRectsVertexProvider>(
-      new RRectsVertexProvider(std::move(rects), aaType, useScale));
+  auto array = buffer->makeArray(std::move(rects));
+  return buffer->make<RRectsVertexProvider>(std::move(array), aaType, useScale);
 }
 
 static void WriteUByte4Color(float* vertices, int& index, const Color& color) {
@@ -68,8 +69,8 @@ static void WriteUByte4Color(float* vertices, int& index, const Color& color) {
   bytes[3] = static_cast<uint8_t>(color.alpha * 255);
 }
 
-RRectsVertexProvider::RRectsVertexProvider(std::vector<PlacementPtr<RRectPaint>> rects,
-                                           AAType aaType, bool useScale)
+RRectsVertexProvider::RRectsVertexProvider(PlacementArray<RRectPaint>&& rects, AAType aaType,
+                                           bool useScale)
     : rects(std::move(rects)) {
   bitFields.aaType = static_cast<uint8_t>(aaType);
   bitFields.useScale = useScale;

--- a/src/gpu/RRectsVertexProvider.h
+++ b/src/gpu/RRectsVertexProvider.h
@@ -1,0 +1,80 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "core/utils/PlacementPtr.h"
+#include "gpu/AAType.h"
+#include "gpu/VertexProvider.h"
+#include "tgfx/core/Color.h"
+#include "tgfx/core/RRect.h"
+
+namespace tgfx {
+struct RRectPaint {
+  RRectPaint(const RRect& rRect, const Matrix& viewMatrix, Color color = Color::White())
+      : rRect(rRect), viewMatrix(viewMatrix), color(color) {
+  }
+
+  RRect rRect;
+  Matrix viewMatrix;
+  Color color;
+};
+
+/**
+ * RRectsVertexProvider is a VertexProvider that provides vertices for drawing round rectangles.
+ */
+class RRectsVertexProvider : public VertexProvider {
+ public:
+  /**
+   * Creates a new RRectsVertexProvider from a list of RRectPaint records.
+   */
+  static std::unique_ptr<RRectsVertexProvider> MakeFrom(std::vector<PlacementPtr<RRectPaint>> rects,
+                                                        AAType aaType, bool useScale);
+
+  /**
+   * Returns the number of round rects in the provider.
+   */
+  size_t rectCount() const {
+    return rects.size();
+  }
+
+  /**
+   * Returns the AAType of the provider.
+   */
+  AAType aaType() const {
+    return static_cast<AAType>(bitFields.aaType);
+  }
+
+  bool useScale() const {
+    return bitFields.useScale;
+  }
+
+  size_t vertexCount() const override;
+
+  void getVertices(float* vertices) const override;
+
+ private:
+  std::vector<PlacementPtr<RRectPaint>> rects = {};
+  struct {
+    uint8_t aaType : 2;
+    bool useScale : 1;
+  } bitFields = {};
+
+  RRectsVertexProvider(std::vector<PlacementPtr<RRectPaint>> rects, AAType aaType, bool useScale);
+};
+}  // namespace tgfx

--- a/src/gpu/RRectsVertexProvider.h
+++ b/src/gpu/RRectsVertexProvider.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "core/utils/PlacementPtr.h"
+#include "core/utils/BlockBuffer.h"
 #include "gpu/AAType.h"
 #include "gpu/VertexProvider.h"
 #include "tgfx/core/Color.h"
@@ -43,8 +43,9 @@ class RRectsVertexProvider : public VertexProvider {
   /**
    * Creates a new RRectsVertexProvider from a list of RRectPaint records.
    */
-  static std::unique_ptr<RRectsVertexProvider> MakeFrom(std::vector<PlacementPtr<RRectPaint>> rects,
-                                                        AAType aaType, bool useScale);
+  static PlacementPtr<RRectsVertexProvider> MakeFrom(BlockBuffer* blockBuffer,
+                                                     std::vector<PlacementPtr<RRectPaint>>&& rects,
+                                                     AAType aaType, bool useScale);
 
   /**
    * Returns the number of round rects in the provider.
@@ -69,12 +70,14 @@ class RRectsVertexProvider : public VertexProvider {
   void getVertices(float* vertices) const override;
 
  private:
-  std::vector<PlacementPtr<RRectPaint>> rects = {};
+  PlacementArray<RRectPaint> rects = {};
   struct {
     uint8_t aaType : 2;
     bool useScale : 1;
   } bitFields = {};
 
-  RRectsVertexProvider(std::vector<PlacementPtr<RRectPaint>> rects, AAType aaType, bool useScale);
+  RRectsVertexProvider(PlacementArray<RRectPaint>&& rects, AAType aaType, bool useScale);
+
+  friend class BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/RectsVertexProvider.cpp
+++ b/src/gpu/RectsVertexProvider.cpp
@@ -124,7 +124,7 @@ PlacementPtr<RectsVertexProvider> RectsVertexProvider::MakeFrom(BlockBuffer* buf
     return nullptr;
   }
   auto rectPaint = buffer->make<RectPaint>(rect, Matrix::I());
-  auto array = buffer->makeArray(&rectPaint, 1);
+  auto array = buffer->makeArray<RectPaint>(&rectPaint, 1);
   if (aaType == AAType::Coverage) {
     return buffer->make<AARectsVertexProvider>(std::move(array), aaType, false, false);
   }

--- a/src/gpu/RectsVertexProvider.cpp
+++ b/src/gpu/RectsVertexProvider.cpp
@@ -1,0 +1,157 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "RectsVertexProvider.h"
+#include "core/utils/Log.h"
+#include "gpu/Quad.h"
+
+namespace tgfx {
+static void WriteUByte4Color(float* vertices, int& index, const Color& color) {
+  auto bytes = reinterpret_cast<uint8_t*>(&vertices[index++]);
+  bytes[0] = static_cast<uint8_t>(color.red * 255);
+  bytes[1] = static_cast<uint8_t>(color.green * 255);
+  bytes[2] = static_cast<uint8_t>(color.blue * 255);
+  bytes[3] = static_cast<uint8_t>(color.alpha * 255);
+}
+
+class AARectsVertexProvider : public RectsVertexProvider {
+ public:
+  AARectsVertexProvider(std::vector<PlacementPtr<RectPaint>> rects, AAType aaType, bool hasUVCoord,
+                        bool hasColor)
+      : RectsVertexProvider(std::move(rects), aaType, hasUVCoord, hasColor) {
+  }
+
+  size_t vertexCount() const override {
+    size_t perVertexCount = bitFields.hasUVCoord ? 5 : 3;
+    if (bitFields.hasColor) {
+      perVertexCount += 1;
+    }
+    return rects.size() * 2 * 4 * perVertexCount;
+  }
+
+  void getVertices(float* vertices) const override {
+    auto index = 0;
+    for (auto& rectPaint : rects) {
+      auto& viewMatrix = rectPaint->viewMatrix;
+      auto& rect = rectPaint->rect;
+      auto scale = sqrtf(viewMatrix.getScaleX() * viewMatrix.getScaleX() +
+                         viewMatrix.getSkewY() * viewMatrix.getSkewY());
+      // we want the new edge to be .5px away from the old line.
+      auto padding = 0.5f / scale;
+      auto insetBounds = rect.makeInset(padding, padding);
+      auto insetQuad = Quad::MakeFrom(insetBounds, &viewMatrix);
+      auto outsetBounds = rect.makeOutset(padding, padding);
+      auto outsetQuad = Quad::MakeFrom(outsetBounds, &viewMatrix);
+      auto uvInsetQuad = Quad::MakeFrom(insetBounds);
+      auto uvOutsetQuad = Quad::MakeFrom(outsetBounds);
+
+      for (int j = 0; j < 2; ++j) {
+        auto& quad = j == 0 ? insetQuad : outsetQuad;
+        auto& uvQuad = j == 0 ? uvInsetQuad : uvOutsetQuad;
+        auto coverage = j == 0 ? 1.0f : 0.0f;
+        for (size_t k = 0; k < 4; ++k) {
+          vertices[index++] = quad.point(k).x;
+          vertices[index++] = quad.point(k).y;
+          vertices[index++] = coverage;
+          if (bitFields.hasUVCoord) {
+            vertices[index++] = uvQuad.point(k).x;
+            vertices[index++] = uvQuad.point(k).y;
+          }
+          if (bitFields.hasColor) {
+            WriteUByte4Color(vertices, index, rectPaint->color);
+          }
+        }
+      }
+    }
+  }
+};
+
+class NonAARectVertexProvider : public RectsVertexProvider {
+ public:
+  NonAARectVertexProvider(std::vector<PlacementPtr<RectPaint>> rects, AAType aaType,
+                          bool hasUVCoord, bool hasColor)
+      : RectsVertexProvider(std::move(rects), aaType, hasUVCoord, hasColor) {
+  }
+
+  size_t vertexCount() const override {
+    size_t perVertexCount = bitFields.hasUVCoord ? 4 : 2;
+    if (bitFields.hasColor) {
+      perVertexCount += 1;
+    }
+    return rects.size() * 4 * perVertexCount;
+  }
+
+  void getVertices(float* vertices) const override {
+    auto index = 0;
+    for (auto& rectPaint : rects) {
+      auto& viewMatrix = rectPaint->viewMatrix;
+      auto& rect = rectPaint->rect;
+      auto quad = Quad::MakeFrom(rect, &viewMatrix);
+      auto uvQuad = Quad::MakeFrom(rect);
+      for (size_t j = 4; j >= 1; --j) {
+        vertices[index++] = quad.point(j - 1).x;
+        vertices[index++] = quad.point(j - 1).y;
+        if (bitFields.hasUVCoord) {
+          vertices[index++] = uvQuad.point(j - 1).x;
+          vertices[index++] = uvQuad.point(j - 1).y;
+        }
+        if (bitFields.hasColor) {
+          WriteUByte4Color(vertices, index, rectPaint->color);
+        }
+      }
+    }
+  }
+};
+
+std::unique_ptr<RectsVertexProvider> RectsVertexProvider::MakeFrom(
+    PlacementPtr<tgfx::RectPaint> rect, AAType aaType) {
+  if (rect == nullptr) {
+    return nullptr;
+  }
+  auto rects = std::vector<PlacementPtr<RectPaint>>{};
+  rects.push_back(std::move(rect));
+  return MakeFrom(std::move(rects), aaType, false);
+}
+
+std::unique_ptr<RectsVertexProvider> RectsVertexProvider::MakeFrom(
+    std::vector<PlacementPtr<RectPaint>> rects, AAType aaType, bool needUVCoord) {
+  if (rects.empty()) {
+    return nullptr;
+  }
+  auto hasColor = false;
+  auto& firstColor = rects.front()->color;
+  for (auto& rectPaint : rects) {
+    if (rectPaint->color != firstColor) {
+      hasColor = true;
+      break;
+    }
+  }
+  if (aaType == AAType::Coverage) {
+    return std::make_unique<AARectsVertexProvider>(std::move(rects), aaType, needUVCoord, hasColor);
+  }
+  return std::make_unique<NonAARectVertexProvider>(std::move(rects), aaType, needUVCoord, hasColor);
+}
+
+RectsVertexProvider::RectsVertexProvider(std::vector<PlacementPtr<RectPaint>> rects, AAType aaType,
+                                         bool hasUVCoord, bool hasColor)
+    : rects(std::move(rects)) {
+  bitFields.aaType = static_cast<uint8_t>(aaType);
+  bitFields.hasUVCoord = hasUVCoord;
+  bitFields.hasColor = hasColor;
+}
+}  // namespace tgfx

--- a/src/gpu/RectsVertexProvider.h
+++ b/src/gpu/RectsVertexProvider.h
@@ -1,0 +1,115 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 THL A29 Limited, a Tencent company. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "core/utils/PlacementPtr.h"
+#include "gpu/AAType.h"
+#include "gpu/VertexProvider.h"
+#include "tgfx/core/Color.h"
+#include "tgfx/core/Matrix.h"
+
+namespace tgfx {
+struct RectPaint {
+  RectPaint(const Rect& rect, const Matrix& viewMatrix, const Color& color = Color::White())
+      : rect(rect), viewMatrix(viewMatrix), color(color) {
+  }
+
+  Rect rect;
+  Matrix viewMatrix;
+  Color color;
+};
+
+/**
+ * RectsVertexProvider is a VertexProvider that provides vertices for drawing rectangles.
+ */
+class RectsVertexProvider : public VertexProvider {
+ public:
+  /**
+   * Creates a new RectsVertexProvider from a single rect record.
+   */
+  static std::unique_ptr<RectsVertexProvider> MakeFrom(PlacementPtr<RectPaint> rect, AAType aaType);
+
+  /**
+   * Creates a new RectsVertexProvider from a list of rect records.
+   */
+  static std::unique_ptr<RectsVertexProvider> MakeFrom(std::vector<PlacementPtr<RectPaint>> rects,
+                                                       AAType aaType, bool needUVCoord);
+
+  /**
+   * Returns the number of rects in the provider.
+   */
+  size_t rectCount() const {
+    return rects.size();
+  }
+
+  /**
+   * Returns the AAType of the provider.
+   */
+  AAType aaType() const {
+    return static_cast<AAType>(bitFields.aaType);
+  }
+
+  /**
+   * Returns true if the provider generates UV coordinates.
+   */
+  bool hasUVCoord() const {
+    return bitFields.hasUVCoord;
+  }
+
+  /**
+   * Returns true if the provider generates colors.
+   */
+  bool hasColor() const {
+    return bitFields.hasColor;
+  }
+
+  /**
+   * Returns the first rect in the provider.
+   */
+  const Rect& firstRect() const {
+    return rects.front()->rect;
+  }
+
+  /**
+   * Returns the first matrix in the provider. If no matrix record exists, a identity matrix is
+   * returned.
+   */
+  const Matrix& firstMatrix() const {
+    return rects.front()->viewMatrix;
+  }
+
+  /**
+   * Returns the first color in the provider. If no color record exists, a white color is returned.
+   */
+  const Color& firstColor() const {
+    return rects.front()->color;
+  }
+
+ protected:
+  std::vector<PlacementPtr<RectPaint>> rects = {};
+  struct {
+    uint8_t aaType : 2;
+    bool hasUVCoord : 1;
+    bool hasColor : 1;
+  } bitFields = {};
+
+  RectsVertexProvider(std::vector<PlacementPtr<RectPaint>> rects, AAType aaType, bool hasUVCoord,
+                      bool hasColor);
+};
+}  // namespace tgfx

--- a/src/gpu/RectsVertexProvider.h
+++ b/src/gpu/RectsVertexProvider.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "core/utils/PlacementPtr.h"
+#include "core/utils/BlockBuffer.h"
 #include "gpu/AAType.h"
 #include "gpu/VertexProvider.h"
 #include "tgfx/core/Color.h"
@@ -41,15 +41,17 @@ struct RectPaint {
 class RectsVertexProvider : public VertexProvider {
  public:
   /**
-   * Creates a new RectsVertexProvider from a single rect record.
+   * Creates a new RectsVertexProvider from a single rect.
    */
-  static std::unique_ptr<RectsVertexProvider> MakeFrom(PlacementPtr<RectPaint> rect, AAType aaType);
+  static PlacementPtr<RectsVertexProvider> MakeFrom(BlockBuffer* buffer, const Rect& rect,
+                                                    AAType aaType);
 
   /**
    * Creates a new RectsVertexProvider from a list of rect records.
    */
-  static std::unique_ptr<RectsVertexProvider> MakeFrom(std::vector<PlacementPtr<RectPaint>> rects,
-                                                       AAType aaType, bool needUVCoord);
+  static PlacementPtr<RectsVertexProvider> MakeFrom(BlockBuffer* buffer,
+                                                    std::vector<PlacementPtr<RectPaint>>&& rects,
+                                                    AAType aaType, bool needUVCoord);
 
   /**
    * Returns the number of rects in the provider.
@@ -102,14 +104,14 @@ class RectsVertexProvider : public VertexProvider {
   }
 
  protected:
-  std::vector<PlacementPtr<RectPaint>> rects = {};
+  PlacementArray<RectPaint> rects = {};
   struct {
     uint8_t aaType : 2;
     bool hasUVCoord : 1;
     bool hasColor : 1;
   } bitFields = {};
 
-  RectsVertexProvider(std::vector<PlacementPtr<RectPaint>> rects, AAType aaType, bool hasUVCoord,
+  RectsVertexProvider(PlacementArray<RectPaint>&& rects, AAType aaType, bool hasUVCoord,
                       bool hasColor);
 };
 }  // namespace tgfx

--- a/src/gpu/VertexProvider.h
+++ b/src/gpu/VertexProvider.h
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include "core/DataSource.h"
+#include "core/utils/PlacementPtr.h"
 #include "tgfx/core/Data.h"
 
 namespace tgfx {
@@ -43,7 +44,7 @@ class VertexProvider {
 
 class VertexProviderTask : public Task {
  public:
-  VertexProviderTask(std::unique_ptr<VertexProvider> provider, float* vertices)
+  VertexProviderTask(PlacementPtr<VertexProvider> provider, float* vertices)
       : provider(std::move(provider)), vertices(vertices) {
   }
 
@@ -53,7 +54,7 @@ class VertexProviderTask : public Task {
   }
 
  private:
-  std::unique_ptr<VertexProvider> provider = nullptr;
+  PlacementPtr<VertexProvider> provider = nullptr;
   float* vertices = nullptr;
 };
 

--- a/src/gpu/opengl/processors/GLQuadPerEdgeAAGeometryProcessor.h
+++ b/src/gpu/opengl/processors/GLQuadPerEdgeAAGeometryProcessor.h
@@ -25,7 +25,8 @@ namespace tgfx {
 class GLQuadPerEdgeAAGeometryProcessor : public QuadPerEdgeAAGeometryProcessor {
  public:
   GLQuadPerEdgeAAGeometryProcessor(int width, int height, AAType aa,
-                                   std::optional<Color> uniformColor, bool useUVCoord);
+                                   std::optional<Color> commonColor,
+                                   std::optional<Matrix> uvMatrix);
 
   void emitCode(EmitArgs& args) const override;
 

--- a/src/gpu/ops/ClearOp.h
+++ b/src/gpu/ops/ClearOp.h
@@ -26,13 +26,15 @@ class ClearOp : public Op {
  public:
   static PlacementPtr<ClearOp> Make(Context* context, Color color, const Rect& scissor);
 
-  ClearOp(Color color, const Rect& scissor) : color(color), scissor(scissor) {
-  }
-
   void execute(RenderPass* renderPass) override;
 
  private:
   Color color = Color::Transparent();
   Rect scissor = Rect::MakeEmpty();
+
+  ClearOp(Color color, const Rect& scissor) : color(color), scissor(scissor) {
+  }
+
+  friend class BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/ops/DstTextureCopyOp.h
+++ b/src/gpu/ops/DstTextureCopyOp.h
@@ -30,13 +30,15 @@ class DstTextureCopyOp : public Op {
   static PlacementPtr<DstTextureCopyOp> Make(std::shared_ptr<TextureProxy> textureProxy, int srcX,
                                              int srcY);
 
-  DstTextureCopyOp(std::shared_ptr<TextureProxy> textureProxy, int srcX, int srcY);
-
   void execute(RenderPass* renderPass) override;
 
  private:
   std::shared_ptr<TextureProxy> textureProxy = nullptr;
   int srcX = 0;
   int srcY = 0;
+
+  DstTextureCopyOp(std::shared_ptr<TextureProxy> textureProxy, int srcX, int srcY);
+
+  friend class BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/ops/RRectDrawOp.cpp
+++ b/src/gpu/ops/RRectDrawOp.cpp
@@ -26,7 +26,7 @@
 
 namespace tgfx {
 PlacementPtr<RRectDrawOp> RRectDrawOp::Make(Context* context,
-                                            std::unique_ptr<RRectsVertexProvider> provider,
+                                            PlacementPtr<RRectsVertexProvider> provider,
                                             uint32_t renderFlags) {
   if (provider == nullptr) {
     return nullptr;

--- a/src/gpu/ops/RRectDrawOp.cpp
+++ b/src/gpu/ops/RRectDrawOp.cpp
@@ -18,205 +18,34 @@
 
 #include "RRectDrawOp.h"
 #include "core/DataSource.h"
-#include "core/utils/MathExtra.h"
 #include "gpu/GpuBuffer.h"
 #include "gpu/ProxyProvider.h"
 #include "gpu/ResourceProvider.h"
-#include "gpu/VertexProvider.h"
 #include "gpu/processors/EllipseGeometryProcessor.h"
 #include "tgfx/core/RenderFlags.h"
 
 namespace tgfx {
-// We have three possible cases for geometry for a round rect.
-//
-// In the case of a normal fill or a stroke, we draw the round rect as a 9-patch:
-//    ____________
-//   |_|________|_|
-//   | |        | |
-//   | |        | |
-//   | |        | |
-//   |_|________|_|
-//   |_|________|_|
-//
-// For strokes, we don't draw the center quad.
-//
-// For circular round rects, in the case where the stroke width is greater than twice
-// the corner radius (over stroke), we add additional geometry to mark out the rectangle
-// in the center. The shared vertices are duplicated, so we can set a different outer radius
-// for the fill calculation.
-//    ____________
-//   |_|________|_|
-//   | |\ ____ /| |
-//   | | |    | | |
-//   | | |____| | |
-//   |_|/______\|_|
-//   |_|________|_|
-//
-// We don't draw the center quad from the fill rect in this case.
-//
-// For filled rrects that need to provide a distance vector we reuse the overstroke
-// geometry but make the inner rect degenerate (either a point or a horizontal or
-// vertical line).
-
-static void WriteUByte4Color(float* vertices, int& index, const Color& color) {
-  auto bytes = reinterpret_cast<uint8_t*>(&vertices[index++]);
-  bytes[0] = static_cast<uint8_t>(color.red * 255);
-  bytes[1] = static_cast<uint8_t>(color.green * 255);
-  bytes[2] = static_cast<uint8_t>(color.blue * 255);
-  bytes[3] = static_cast<uint8_t>(color.alpha * 255);
-}
-
-class RRectVertexProvider : public VertexProvider {
- public:
-  RRectVertexProvider(std::vector<PlacementPtr<RRectPaint>> rRectPaints, AAType aaType,
-                      bool useScale)
-      : rRectPaints(std::move(rRectPaints)), aaType(aaType), useScale(useScale) {
-  }
-
-  size_t vertexCount() const override {
-    auto floatCount = rRectPaints.size() * 4 * 36;
-    if (useScale) {
-      floatCount += rRectPaints.size() * 4 * 4;
-    }
-    return floatCount;
-  }
-
-  void getVertices(float* vertices) const override {
-    auto index = 0;
-    for (auto& rRectPaint : rRectPaints) {
-      auto viewMatrix = rRectPaint->viewMatrix;
-      auto rRect = rRectPaint->rRect;
-      auto& color = rRectPaint->color;
-      auto scales = viewMatrix.getAxisScales();
-      rRect.scale(scales.x, scales.y);
-      viewMatrix.preScale(1 / scales.x, 1 / scales.y);
-      float reciprocalRadii[4] = {1e6f, 1e6f, 1e6f, 1e6f};
-      if (rRect.radii.x > 0) {
-        reciprocalRadii[0] = 1.f / rRect.radii.x;
-      }
-      if (rRect.radii.y > 0) {
-        reciprocalRadii[1] = 1.f / rRect.radii.y;
-      }
-      // On MSAA, bloat enough to guarantee any pixel that might be touched by the rRect has
-      // full sample coverage.
-      float aaBloat = aaType == AAType::MSAA ? FLOAT_SQRT2 : .5f;
-      // Extend out the radii to antialias.
-      float xOuterRadius = rRect.radii.x + aaBloat;
-      float yOuterRadius = rRect.radii.y + aaBloat;
-
-      float xMaxOffset = xOuterRadius;
-      float yMaxOffset = yOuterRadius;
-      //  if (!stroked) {
-      // For filled rRectPaints we map a unit circle in the vertex attributes rather than
-      // computing an ellipse and modifying that distance, so we normalize to 1.
-      xMaxOffset /= rRect.radii.x;
-      yMaxOffset /= rRect.radii.y;
-      //  }
-      auto bounds = rRect.rect.makeOutset(aaBloat, aaBloat);
-      float yCoords[4] = {bounds.top, bounds.top + yOuterRadius, bounds.bottom - yOuterRadius,
-                          bounds.bottom};
-      float yOuterOffsets[4] = {
-          yMaxOffset,
-          FLOAT_NEARLY_ZERO,  // we're using inversesqrt() in shader, so can't be exactly 0
-          FLOAT_NEARLY_ZERO, yMaxOffset};
-      auto maxRadius = std::max(rRect.radii.x, rRect.radii.y);
-      for (int i = 0; i < 4; ++i) {
-        auto point = Point::Make(bounds.left, yCoords[i]);
-        viewMatrix.mapPoints(&point, 1);
-        vertices[index++] = point.x;
-        vertices[index++] = point.y;
-        WriteUByte4Color(vertices, index, color);
-        vertices[index++] = xMaxOffset;
-        vertices[index++] = yOuterOffsets[i];
-        if (useScale) {
-          vertices[index++] = maxRadius;
-        }
-        vertices[index++] = reciprocalRadii[0];
-        vertices[index++] = reciprocalRadii[1];
-        vertices[index++] = reciprocalRadii[2];
-        vertices[index++] = reciprocalRadii[3];
-
-        point = Point::Make(bounds.left + xOuterRadius, yCoords[i]);
-        viewMatrix.mapPoints(&point, 1);
-        vertices[index++] = point.x;
-        vertices[index++] = point.y;
-        WriteUByte4Color(vertices, index, color);
-        vertices[index++] = FLOAT_NEARLY_ZERO;
-        vertices[index++] = yOuterOffsets[i];
-        if (useScale) {
-          vertices[index++] = maxRadius;
-        }
-        vertices[index++] = reciprocalRadii[0];
-        vertices[index++] = reciprocalRadii[1];
-        vertices[index++] = reciprocalRadii[2];
-        vertices[index++] = reciprocalRadii[3];
-
-        point = Point::Make(bounds.right - xOuterRadius, yCoords[i]);
-        viewMatrix.mapPoints(&point, 1);
-        vertices[index++] = point.x;
-        vertices[index++] = point.y;
-        WriteUByte4Color(vertices, index, color);
-        vertices[index++] = FLOAT_NEARLY_ZERO;
-        vertices[index++] = yOuterOffsets[i];
-        if (useScale) {
-          vertices[index++] = maxRadius;
-        }
-        vertices[index++] = reciprocalRadii[0];
-        vertices[index++] = reciprocalRadii[1];
-        vertices[index++] = reciprocalRadii[2];
-        vertices[index++] = reciprocalRadii[3];
-
-        point = Point::Make(bounds.right, yCoords[i]);
-        viewMatrix.mapPoints(&point, 1);
-        vertices[index++] = point.x;
-        vertices[index++] = point.y;
-        WriteUByte4Color(vertices, index, color);
-        vertices[index++] = xMaxOffset;
-        vertices[index++] = yOuterOffsets[i];
-        if (useScale) {
-          vertices[index++] = maxRadius;
-        }
-        vertices[index++] = reciprocalRadii[0];
-        vertices[index++] = reciprocalRadii[1];
-        vertices[index++] = reciprocalRadii[2];
-        vertices[index++] = reciprocalRadii[3];
-      }
-    }
-  }
-
- private:
-  std::vector<PlacementPtr<RRectPaint>> rRectPaints = {};
-  AAType aaType = AAType::None;
-  bool useScale = false;
-};
-
-static bool UseScale(Context* context) {
-  return !context->caps()->floatIs32Bits;
-}
-
 PlacementPtr<RRectDrawOp> RRectDrawOp::Make(Context* context,
-                                            std::vector<PlacementPtr<RRectPaint>> rects,
-                                            AAType aaType, uint32_t renderFlags) {
-  if (rects.empty()) {
+                                            std::unique_ptr<RRectsVertexProvider> provider,
+                                            uint32_t renderFlags) {
+  if (provider == nullptr) {
     return nullptr;
   }
-  auto rectSize = rects.size();
-  auto drawOp = context->drawingBuffer()->make<RRectDrawOp>(aaType, rectSize);
+  auto drawOp = context->drawingBuffer()->make<RRectDrawOp>(provider.get());
   drawOp->indexBufferProxy = context->resourceProvider()->rRectIndexBuffer();
-  auto useScale = UseScale(context);
-  auto vertexProvider = std::make_unique<RRectVertexProvider>(std::move(rects), aaType, useScale);
-  if (rectSize <= 1) {
+  if (provider->rectCount() <= 1) {
     // If we only have one rect, it is not worth the async task overhead.
     renderFlags |= RenderFlags::DisableAsyncTask;
   }
   auto sharedVertexBuffer =
-      context->proxyProvider()->createSharedVertexBuffer(std::move(vertexProvider), renderFlags);
+      context->proxyProvider()->createSharedVertexBuffer(std::move(provider), renderFlags);
   drawOp->vertexBufferProxy = sharedVertexBuffer.first;
   drawOp->vertexBufferOffset = sharedVertexBuffer.second;
   return drawOp;
 }
 
-RRectDrawOp::RRectDrawOp(AAType aaType, size_t rectCount) : DrawOp(aaType), rectCount(rectCount) {
+RRectDrawOp::RRectDrawOp(RRectsVertexProvider* provider)
+    : DrawOp(provider->aaType()), rectCount(provider->rectCount()), useScale(provider->useScale()) {
 }
 
 void RRectDrawOp::execute(RenderPass* renderPass) {
@@ -234,9 +63,8 @@ void RRectDrawOp::execute(RenderPass* renderPass) {
   }
   auto renderTarget = renderPass->renderTarget();
   auto drawingBuffer = renderPass->getContext()->drawingBuffer();
-  auto gp =
-      EllipseGeometryProcessor::Make(drawingBuffer, renderTarget->width(), renderTarget->height(),
-                                     false, UseScale(renderPass->getContext()));
+  auto gp = EllipseGeometryProcessor::Make(drawingBuffer, renderTarget->width(),
+                                           renderTarget->height(), false, useScale);
   auto pipeline = createPipeline(renderPass, std::move(gp));
   renderPass->bindProgramAndScissorClip(pipeline.get(), scissorRect());
   renderPass->bindBuffers(indexBuffer, vertexBuffer, vertexBufferOffset);

--- a/src/gpu/ops/RRectDrawOp.h
+++ b/src/gpu/ops/RRectDrawOp.h
@@ -47,8 +47,6 @@ class RRectDrawOp : public DrawOp {
                                         std::vector<PlacementPtr<RRectPaint>> rects, AAType aaType,
                                         uint32_t renderFlags);
 
-  RRectDrawOp(AAType aaType, size_t rectCount);
-
   void execute(RenderPass* renderPass) override;
 
  private:
@@ -56,5 +54,9 @@ class RRectDrawOp : public DrawOp {
   std::shared_ptr<GpuBufferProxy> indexBufferProxy = nullptr;
   std::shared_ptr<GpuBufferProxy> vertexBufferProxy = nullptr;
   size_t vertexBufferOffset = 0;
+
+  RRectDrawOp(AAType aaType, size_t rectCount);
+
+  friend class BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/ops/RRectDrawOp.h
+++ b/src/gpu/ops/RRectDrawOp.h
@@ -34,7 +34,7 @@ class RRectDrawOp : public DrawOp {
    * the device space.
    */
   static PlacementPtr<RRectDrawOp> Make(Context* context,
-                                        std::unique_ptr<RRectsVertexProvider> provider,
+                                        PlacementPtr<RRectsVertexProvider> provider,
                                         uint32_t renderFlags);
 
   void execute(RenderPass* renderPass) override;

--- a/src/gpu/ops/RRectDrawOp.h
+++ b/src/gpu/ops/RRectDrawOp.h
@@ -19,19 +19,9 @@
 #pragma once
 
 #include "DrawOp.h"
-#include "tgfx/core/Path.h"
+#include "gpu/RRectsVertexProvider.h"
 
 namespace tgfx {
-struct RRectPaint {
-  RRectPaint(const RRect& rRect, const Matrix& viewMatrix, Color color = Color::White())
-      : rRect(rRect), viewMatrix(viewMatrix), color(color) {
-  }
-
-  RRect rRect;
-  Matrix viewMatrix;
-  Color color;
-};
-
 class RRectDrawOp : public DrawOp {
  public:
   /**
@@ -44,18 +34,19 @@ class RRectDrawOp : public DrawOp {
    * the device space.
    */
   static PlacementPtr<RRectDrawOp> Make(Context* context,
-                                        std::vector<PlacementPtr<RRectPaint>> rects, AAType aaType,
+                                        std::unique_ptr<RRectsVertexProvider> provider,
                                         uint32_t renderFlags);
 
   void execute(RenderPass* renderPass) override;
 
  private:
   size_t rectCount = 0;
+  bool useScale = false;
   std::shared_ptr<GpuBufferProxy> indexBufferProxy = nullptr;
   std::shared_ptr<GpuBufferProxy> vertexBufferProxy = nullptr;
   size_t vertexBufferOffset = 0;
 
-  RRectDrawOp(AAType aaType, size_t rectCount);
+  explicit RRectDrawOp(RRectsVertexProvider* provider);
 
   friend class BlockBuffer;
 };

--- a/src/gpu/ops/RectDrawOp.cpp
+++ b/src/gpu/ops/RectDrawOp.cpp
@@ -17,157 +17,26 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "RectDrawOp.h"
-#include "core/DataSource.h"
 #include "gpu/ProxyProvider.h"
 #include "gpu/Quad.h"
 #include "gpu/ResourceProvider.h"
-#include "gpu/VertexProvider.h"
 #include "gpu/processors/QuadPerEdgeAAGeometryProcessor.h"
 #include "tgfx/core/RenderFlags.h"
 
 namespace tgfx {
-static void WriteUByte4Color(float* vertices, int& index, const Color& color) {
-  auto bytes = reinterpret_cast<uint8_t*>(&vertices[index++]);
-  bytes[0] = static_cast<uint8_t>(color.red * 255);
-  bytes[1] = static_cast<uint8_t>(color.green * 255);
-  bytes[2] = static_cast<uint8_t>(color.blue * 255);
-  bytes[3] = static_cast<uint8_t>(color.alpha * 255);
-}
-
-class RectCoverageVertexProvider : public VertexProvider {
- public:
-  RectCoverageVertexProvider(std::vector<PlacementPtr<RectPaint>> rectPaints, bool hasColor,
-                             bool useUVCoord)
-      : rectPaints(std::move(rectPaints)), hasColor(hasColor), useUVCoord(useUVCoord) {
-  }
-
-  size_t vertexCount() const override {
-    size_t perVertexCount = useUVCoord ? 5 : 3;
-    if (hasColor) {
-      perVertexCount += 1;
-    }
-    return rectPaints.size() * 2 * 4 * perVertexCount;
-  }
-
-  void getVertices(float* vertices) const override {
-    auto index = 0;
-    for (auto& rectPaint : rectPaints) {
-      auto& viewMatrix = rectPaint->viewMatrix;
-      auto& rect = rectPaint->rect;
-      auto scale = sqrtf(viewMatrix.getScaleX() * viewMatrix.getScaleX() +
-                         viewMatrix.getSkewY() * viewMatrix.getSkewY());
-      // we want the new edge to be .5px away from the old line.
-      auto padding = 0.5f / scale;
-      auto insetBounds = rect.makeInset(padding, padding);
-      auto insetQuad = Quad::MakeFrom(insetBounds, &viewMatrix);
-      auto outsetBounds = rect.makeOutset(padding, padding);
-      auto outsetQuad = Quad::MakeFrom(outsetBounds, &viewMatrix);
-      auto uvInsetQuad = Quad::MakeFrom(insetBounds);
-      auto uvOutsetQuad = Quad::MakeFrom(outsetBounds);
-
-      for (int j = 0; j < 2; ++j) {
-        auto& quad = j == 0 ? insetQuad : outsetQuad;
-        auto& uvQuad = j == 0 ? uvInsetQuad : uvOutsetQuad;
-        auto coverage = j == 0 ? 1.0f : 0.0f;
-        for (size_t k = 0; k < 4; ++k) {
-          vertices[index++] = quad.point(k).x;
-          vertices[index++] = quad.point(k).y;
-          vertices[index++] = coverage;
-          if (useUVCoord) {
-            vertices[index++] = uvQuad.point(k).x;
-            vertices[index++] = uvQuad.point(k).y;
-          }
-          if (hasColor) {
-            WriteUByte4Color(vertices, index, rectPaint->color);
-          }
-        }
-      }
-    }
-  }
-
- private:
-  std::vector<PlacementPtr<RectPaint>> rectPaints = {};
-  bool hasColor = false;
-  bool useUVCoord = false;
-};
-
-class RectNonCoverageVertexProvider : public VertexProvider {
- public:
-  RectNonCoverageVertexProvider(std::vector<PlacementPtr<RectPaint>> rectPaints, bool hasColor,
-                                bool useUVCoord)
-      : rectPaints(std::move(rectPaints)), hasColor(hasColor), useUVCoord(useUVCoord) {
-  }
-
-  size_t vertexCount() const override {
-    size_t perVertexCount = useUVCoord ? 4 : 2;
-    if (hasColor) {
-      perVertexCount += 1;
-    }
-    return rectPaints.size() * 4 * perVertexCount;
-  }
-
-  void getVertices(float* vertices) const override {
-    auto index = 0;
-    for (auto& rectPaint : rectPaints) {
-      auto& viewMatrix = rectPaint->viewMatrix;
-      auto& rect = rectPaint->rect;
-      auto quad = Quad::MakeFrom(rect, &viewMatrix);
-      auto uvQuad = Quad::MakeFrom(rect);
-      for (size_t j = 4; j >= 1; --j) {
-        vertices[index++] = quad.point(j - 1).x;
-        vertices[index++] = quad.point(j - 1).y;
-        if (useUVCoord) {
-          vertices[index++] = uvQuad.point(j - 1).x;
-          vertices[index++] = uvQuad.point(j - 1).y;
-        }
-        if (hasColor) {
-          WriteUByte4Color(vertices, index, rectPaint->color);
-        }
-      }
-    }
-  }
-
- private:
-  std::vector<PlacementPtr<RectPaint>> rectPaints = {};
-  bool hasColor = false;
-  bool useUVCoord = false;
-};
-
 PlacementPtr<RectDrawOp> RectDrawOp::Make(Context* context,
-                                          std::vector<PlacementPtr<RectPaint>> rects,
-                                          bool needUVCoord, AAType aaType, uint32_t renderFlags) {
-  if (rects.empty()) {
+                                          std::unique_ptr<RectsVertexProvider> provider,
+                                          uint32_t renderFlags) {
+  if (provider == nullptr) {
     return nullptr;
   }
-  auto rectSize = rects.size();
-  auto drawingBuffer = context->drawingBuffer();
-  auto drawOp = drawingBuffer->make<RectDrawOp>(aaType, rectSize);
-  auto& firstColor = rects.front()->color;
-  std::optional<Color> uniformColor = firstColor;
-  for (auto& rectPaint : rects) {
-    if (rectPaint->color != firstColor) {
-      uniformColor = std::nullopt;
-      break;
-    }
-  }
-  drawOp->commonColor = uniformColor;
-  if (!needUVCoord) {
-    drawOp->uvMatrix = Matrix::I();
-  }
-  if (aaType == AAType::Coverage) {
+  auto drawOp = context->drawingBuffer()->make<RectDrawOp>(provider.get());
+  if (provider->aaType() == AAType::Coverage) {
     drawOp->indexBufferProxy = context->resourceProvider()->aaQuadIndexBuffer();
-  } else if (rectSize > 1) {
+  } else if (provider->rectCount() > 1) {
     drawOp->indexBufferProxy = context->resourceProvider()->nonAAQuadIndexBuffer();
   }
-  std::unique_ptr<VertexProvider> provider = nullptr;
-  if (aaType == AAType::Coverage) {
-    provider = std::make_unique<RectCoverageVertexProvider>(std::move(rects),
-                                                            !uniformColor.has_value(), needUVCoord);
-  } else {
-    provider = std::make_unique<RectNonCoverageVertexProvider>(
-        std::move(rects), !uniformColor.has_value(), needUVCoord);
-  }
-  if (rectSize <= 1) {
+  if (provider->rectCount() <= 1) {
     // If we only have one rect, it is not worth the async task overhead.
     renderFlags |= RenderFlags::DisableAsyncTask;
   }
@@ -178,7 +47,16 @@ PlacementPtr<RectDrawOp> RectDrawOp::Make(Context* context,
   return drawOp;
 }
 
-RectDrawOp::RectDrawOp(AAType aaType, size_t rectCount) : DrawOp(aaType), rectCount(rectCount) {
+RectDrawOp::RectDrawOp(RectsVertexProvider* provider)
+    : DrawOp(provider->aaType()), rectCount(provider->rectCount()) {
+  if (!provider->hasUVCoord()) {
+    auto matrix = provider->firstMatrix();
+    matrix.invert(&matrix);
+    uvMatrix = matrix;
+  }
+  if (!provider->hasColor()) {
+    commonColor = provider->firstColor();
+  }
 }
 
 void RectDrawOp::execute(RenderPass* renderPass) {

--- a/src/gpu/ops/RectDrawOp.cpp
+++ b/src/gpu/ops/RectDrawOp.cpp
@@ -25,7 +25,7 @@
 
 namespace tgfx {
 PlacementPtr<RectDrawOp> RectDrawOp::Make(Context* context,
-                                          std::unique_ptr<RectsVertexProvider> provider,
+                                          PlacementPtr<RectsVertexProvider> provider,
                                           uint32_t renderFlags) {
   if (provider == nullptr) {
     return nullptr;

--- a/src/gpu/ops/RectDrawOp.h
+++ b/src/gpu/ops/RectDrawOp.h
@@ -33,8 +33,7 @@ class RectDrawOp : public DrawOp {
   /**
    * Create a new RectDrawOp for the specified vertex provider.
    */
-  static PlacementPtr<RectDrawOp> Make(Context* context,
-                                       std::unique_ptr<RectsVertexProvider> provider,
+  static PlacementPtr<RectDrawOp> Make(Context* context, PlacementPtr<RectsVertexProvider> provider,
                                        uint32_t renderFlags);
 
   void execute(RenderPass* renderPass) override;

--- a/src/gpu/ops/RectDrawOp.h
+++ b/src/gpu/ops/RectDrawOp.h
@@ -19,19 +19,10 @@
 #pragma once
 
 #include <optional>
+#include "gpu/RectsVertexProvider.h"
 #include "gpu/ops/DrawOp.h"
 
 namespace tgfx {
-struct RectPaint {
-  RectPaint(const Rect& rect, const Matrix& viewMatrix, const Color& color = Color::White())
-      : rect(rect), viewMatrix(viewMatrix), color(color) {
-  }
-
-  Rect rect;
-  Matrix viewMatrix;
-  Color color;
-};
-
 class RectDrawOp : public DrawOp {
  public:
   /**
@@ -40,11 +31,11 @@ class RectDrawOp : public DrawOp {
   static constexpr uint16_t MaxNumRects = 2048;
 
   /**
-   * Create a new RectDrawOp for a list of RectPaints. The returned RectDrawOp is in the local space
-   * of each rect.
+   * Create a new RectDrawOp for the specified vertex provider.
    */
-  static PlacementPtr<RectDrawOp> Make(Context* context, std::vector<PlacementPtr<RectPaint>> rects,
-                                       bool needUVCoord, AAType aaType, uint32_t renderFlags);
+  static PlacementPtr<RectDrawOp> Make(Context* context,
+                                       std::unique_ptr<RectsVertexProvider> provider,
+                                       uint32_t renderFlags);
 
   void execute(RenderPass* renderPass) override;
 
@@ -56,7 +47,7 @@ class RectDrawOp : public DrawOp {
   std::shared_ptr<GpuBufferProxy> vertexBufferProxy = nullptr;
   size_t vertexBufferOffset = 0;
 
-  RectDrawOp(AAType aaType, size_t rectCount);
+  explicit RectDrawOp(RectsVertexProvider* provider);
 
   friend class BlockBuffer;
 };

--- a/src/gpu/ops/RectDrawOp.h
+++ b/src/gpu/ops/RectDrawOp.h
@@ -44,18 +44,20 @@ class RectDrawOp : public DrawOp {
    * of each rect.
    */
   static PlacementPtr<RectDrawOp> Make(Context* context, std::vector<PlacementPtr<RectPaint>> rects,
-                                       bool useUVCoord, AAType aaType, uint32_t renderFlags);
-
-  RectDrawOp(AAType aaType, size_t rectCount, bool useUVCoord);
+                                       bool needUVCoord, AAType aaType, uint32_t renderFlags);
 
   void execute(RenderPass* renderPass) override;
 
  private:
   size_t rectCount = 0;
-  std::optional<Color> uniformColor = std::nullopt;
-  bool useUVCoord = false;
+  std::optional<Color> commonColor = std::nullopt;
+  std::optional<Matrix> uvMatrix = std::nullopt;
   std::shared_ptr<GpuBufferProxy> indexBufferProxy = nullptr;
   std::shared_ptr<GpuBufferProxy> vertexBufferProxy = nullptr;
   size_t vertexBufferOffset = 0;
+
+  RectDrawOp(AAType aaType, size_t rectCount);
+
+  friend class BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/ops/ResolveOp.h
+++ b/src/gpu/ops/ResolveOp.h
@@ -25,12 +25,14 @@ class ResolveOp : public Op {
  public:
   static PlacementPtr<ResolveOp> Make(Context* context, const Rect& bounds);
 
-  explicit ResolveOp(const Rect& bounds) : bounds(bounds) {
-  }
-
   void execute(RenderPass* renderPass) override;
 
  private:
   Rect bounds = Rect::MakeEmpty();
+
+  explicit ResolveOp(const Rect& bounds) : bounds(bounds) {
+  }
+
+  friend BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/ops/ShapeDrawOp.h
+++ b/src/gpu/ops/ShapeDrawOp.h
@@ -28,9 +28,6 @@ class ShapeDrawOp : public DrawOp {
   static PlacementPtr<ShapeDrawOp> Make(std::shared_ptr<GpuShapeProxy> shapeProxy, Color color,
                                         const Matrix& uvMatrix, AAType aaType);
 
-  ShapeDrawOp(std::shared_ptr<GpuShapeProxy> shapeProxy, Color color, const Matrix& uvMatrix,
-              AAType aaType);
-
   void execute(RenderPass* renderPass) override;
 
  private:
@@ -38,5 +35,10 @@ class ShapeDrawOp : public DrawOp {
   Color color = Color::Transparent();
   Matrix uvMatrix = Matrix::I();
   std::vector<float> maskVertices = {};
+
+  ShapeDrawOp(std::shared_ptr<GpuShapeProxy> shapeProxy, Color color, const Matrix& uvMatrix,
+              AAType aaType);
+
+  friend class BlockBuffer;
 };
 }  // namespace tgfx

--- a/src/gpu/processors/DefaultGeometryProcessor.cpp
+++ b/src/gpu/processors/DefaultGeometryProcessor.cpp
@@ -24,12 +24,10 @@ DefaultGeometryProcessor::DefaultGeometryProcessor(Color color, int width, int h
     : GeometryProcessor(ClassID()), color(color), width(width), height(height), aa(aa),
       viewMatrix(viewMatrix), uvMatrix(uvMatrix) {
   position = {"aPosition", SLType::Float2};
-  int attributeCount = 1;
   if (aa == AAType::Coverage) {
-    attributeCount = 2;
     coverage = {"inCoverage", SLType::Float};
   }
-  setVertexAttributes(&position, attributeCount);
+  setVertexAttributes(&position, 2);
 }
 
 void DefaultGeometryProcessor::onComputeProcessorKey(BytesKey* bytesKey) const {

--- a/src/gpu/processors/QuadPerEdgeAAGeometryProcessor.cpp
+++ b/src/gpu/processors/QuadPerEdgeAAGeometryProcessor.cpp
@@ -21,30 +21,27 @@
 
 namespace tgfx {
 QuadPerEdgeAAGeometryProcessor::QuadPerEdgeAAGeometryProcessor(int width, int height, AAType aa,
-                                                               std::optional<Color> uniformColor,
-                                                               bool useUVCoord)
-    : GeometryProcessor(ClassID()), width(width), height(height), aa(aa),
-      uniformColor(uniformColor), useUVCoord(useUVCoord) {
+                                                               std::optional<Color> commonColor,
+                                                               std::optional<Matrix> uvMatrix)
+    : GeometryProcessor(ClassID()), width(width), height(height), aa(aa), commonColor(commonColor),
+      uvMatrix(uvMatrix) {
+  position = {"aPosition", SLType::Float2};
   if (aa == AAType::Coverage) {
-    position = {"aPositionWithCoverage", SLType::Float3};
-  } else {
-    position = {"aPosition", SLType::Float2};
+    coverage = {"inCoverage", SLType::Float};
   }
-  if (useUVCoord) {
+  if (!uvMatrix.has_value()) {
     uvCoord = {"uvCoord", SLType::Float2};
   }
-  int attributeCount = 2;
-  if (!uniformColor.has_value()) {
-    attributeCount++;
+  if (!commonColor.has_value()) {
     color = {"inColor", SLType::UByte4Color};
   }
-  setVertexAttributes(&position, attributeCount);
+  setVertexAttributes(&position, 4);
 }
 
 void QuadPerEdgeAAGeometryProcessor::onComputeProcessorKey(BytesKey* bytesKey) const {
   uint32_t flags = aa == AAType::Coverage ? 1 : 0;
-  flags |= uniformColor.has_value() ? 2 : 0;
-  flags |= useUVCoord ? 4 : 0;
+  flags |= commonColor.has_value() ? 2 : 0;
+  flags |= uvMatrix.has_value() ? 4 : 0;
   bytesKey->write(flags);
 }
 }  // namespace tgfx

--- a/src/gpu/processors/QuadPerEdgeAAGeometryProcessor.h
+++ b/src/gpu/processors/QuadPerEdgeAAGeometryProcessor.h
@@ -28,8 +28,8 @@ class QuadPerEdgeAAGeometryProcessor : public GeometryProcessor {
  public:
   static PlacementPtr<QuadPerEdgeAAGeometryProcessor> Make(BlockBuffer* buffer, int width,
                                                            int height, AAType aa,
-                                                           std::optional<Color> uniformColor,
-                                                           bool useUVCoord);
+                                                           std::optional<Color> commonColor,
+                                                           std::optional<Matrix> uvMatrix);
 
   std::string name() const override {
     return "QuadPerEdgeAAGeometryProcessor";
@@ -38,19 +38,20 @@ class QuadPerEdgeAAGeometryProcessor : public GeometryProcessor {
  protected:
   DEFINE_PROCESSOR_CLASS_ID
 
-  QuadPerEdgeAAGeometryProcessor(int width, int height, AAType aa,
-                                 std::optional<Color> uniformColor, bool useUVCoord);
+  QuadPerEdgeAAGeometryProcessor(int width, int height, AAType aa, std::optional<Color> commonColor,
+                                 std::optional<Matrix> uvMatrix);
 
   void onComputeProcessorKey(BytesKey* bytesKey) const override;
 
   Attribute position;  // May contain coverage as last channel
+  Attribute coverage;
   Attribute uvCoord;
   Attribute color;
 
   int width = 1;
   int height = 1;
   AAType aa = AAType::None;
-  std::optional<Color> uniformColor = std::nullopt;
-  bool useUVCoord = false;
+  std::optional<Color> commonColor = std::nullopt;
+  std::optional<Matrix> uvMatrix = std::nullopt;
 };
 }  // namespace tgfx

--- a/src/gpu/tasks/OpsRenderTask.h
+++ b/src/gpu/tasks/OpsRenderTask.h
@@ -18,21 +18,20 @@
 
 #pragma once
 
-#include "core/utils/PlacementPtr.h"
+#include "core/utils/PlacementArray.h"
 #include "gpu/ops/DrawOp.h"
 #include "gpu/tasks/RenderTask.h"
 
 namespace tgfx {
 class OpsRenderTask : public RenderTask {
  public:
-  OpsRenderTask(std::shared_ptr<RenderTargetProxy> renderTargetProxy,
-                std::vector<PlacementPtr<Op>> ops)
+  OpsRenderTask(std::shared_ptr<RenderTargetProxy> renderTargetProxy, PlacementArray<Op>&& ops)
       : RenderTask(std::move(renderTargetProxy)), ops(std::move(ops)) {
   }
 
   bool execute(RenderPass* renderPass) override;
 
  private:
-  std::vector<PlacementPtr<Op>> ops = {};
+  PlacementArray<Op> ops = {};
 };
 }  // namespace tgfx


### PR DESCRIPTION
1.允许QuadPerEdgeAAGeometryProcessor传递uvMatrix
2.从RectDrawOp和RRectDrawOp拆解出顶点数据相关的类RectsVertexProvider和RRectsVertexProvider
3.增加一个PlacementArray数组类存储PlacementPtr指针列表。