### PR TITLE
Fixed in the SVGAttributeParser constructor where a temporary string was being assigned to a char pointer member variable.

### DIFF
--- a/src/svg/SVGAttributeParser.cpp
+++ b/src/svg/SVGAttributeParser.cpp
@@ -59,7 +59,7 @@ inline bool is_hex(char c) {
 
 namespace tgfx {
 
-SVGAttributeParser::SVGAttributeParser(std::string attributeString)
+SVGAttributeParser::SVGAttributeParser(const std::string& attributeString)
     : currentPos(attributeString.data()), endPos(currentPos + attributeString.size()) {
 }
 

--- a/src/svg/SVGAttributeParser.cpp
+++ b/src/svg/SVGAttributeParser.cpp
@@ -59,8 +59,8 @@ inline bool is_hex(char c) {
 
 namespace tgfx {
 
-SVGAttributeParser::SVGAttributeParser(const std::string& attributeString)
-    : currentPos(attributeString.data()), endPos(currentPos + attributeString.size()) {
+SVGAttributeParser::SVGAttributeParser(const char* str, size_t length)
+    : currentPos(str), endPos(str + length) {
 }
 
 template <typename F>

--- a/src/svg/SVGAttributeParser.h
+++ b/src/svg/SVGAttributeParser.h
@@ -32,7 +32,7 @@ namespace tgfx {
 
 class SVGAttributeParser {
  public:
-  explicit SVGAttributeParser(const std::string& attributeString);
+  explicit SVGAttributeParser(const char* str, size_t length);
 
   bool parseInteger(SVGIntegerType*);
   bool parseViewBox(SVGViewBoxType*);
@@ -49,7 +49,7 @@ class SVGAttributeParser {
   static ParseResult<T> parse(const std::string& value) {
     ParseResult<T> result;
     T parsedValue;
-    if (SVGAttributeParser(value).parse(&parsedValue)) {
+    if (SVGAttributeParser(value.c_str(), value.length()).parse(&parsedValue)) {
       result = parsedValue;
     }
     return result;

--- a/src/svg/SVGAttributeParser.h
+++ b/src/svg/SVGAttributeParser.h
@@ -32,7 +32,7 @@ namespace tgfx {
 
 class SVGAttributeParser {
  public:
-  explicit SVGAttributeParser(std::string);
+  explicit SVGAttributeParser(const std::string& attributeString);
 
   bool parseInteger(SVGIntegerType*);
   bool parseViewBox(SVGViewBoxType*);

--- a/src/svg/SVGNodeConstructor.cpp
+++ b/src/svg/SVGNodeConstructor.cpp
@@ -107,7 +107,7 @@ bool SVGNodeConstructor::SetLengthAttribute(SVGNode& node, SVGAttribute attr,
 bool SVGNodeConstructor::SetViewBoxAttribute(SVGNode& node, SVGAttribute attr,
                                              const std::string& stringValue) {
   SVGViewBoxType viewBox;
-  SVGAttributeParser parser(stringValue);
+  SVGAttributeParser parser(stringValue.c_str(), stringValue.length());
   if (!parser.parseViewBox(&viewBox)) {
     return false;
   }
@@ -130,7 +130,7 @@ bool SVGNodeConstructor::SetObjectBoundingBoxUnitsAttribute(SVGNode& node, SVGAt
 bool SVGNodeConstructor::SetPreserveAspectRatioAttribute(SVGNode& node, SVGAttribute attr,
                                                          const std::string& stringValue) {
   SVGPreserveAspectRatio par;
-  SVGAttributeParser parser(stringValue);
+  SVGAttributeParser parser(stringValue.c_str(), stringValue.length());
   if (!parser.parsePreserveAspectRatio(&par)) {
     return false;
   }


### PR DESCRIPTION
修复SVG文本解析器构造函数中，以临时字符串的初始化char指针成员变量（实际这个字符串对象立即会析构）。