### PR TITLE
Enable compatibility with the latest version of Emscripten

### DIFF
--- a/web/demo/CMakeLists.txt
+++ b/web/demo/CMakeLists.txt
@@ -18,17 +18,14 @@ file(GLOB_RECURSE HELLO_2D_FILES src/*.cpp)
 if (DEFINED EMSCRIPTEN)
     add_executable(hello2d ${HELLO_2D_FILES})
     list(APPEND H2D_COMPILE_OPTIONS -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
-    if(NOT EMSCRIPTEN_VERSION)
-        message(FATAL_ERROR "Failed to get emsdk version. Please ensure emsdk is properly installed and configured.")
-    endif()
-    if (EMSCRIPTEN_VERSION AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.4")
-        list(APPEND H2D_LINK_OPTIONS -sUSE_ES6_IMPORT_META=0)
-    elseif (EMSCRIPTEN_VERSION AND ${EMSCRIPTEN_VERSION} VERSION_GREATER_EQUAL "4.0.4" AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.6")
-        message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported. Please upgrade to 4.0.6 or higher.")
-    endif ()
     list(APPEND H2D_LINK_OPTIONS --no-entry -lembind -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 -sEXPORT_NAME='Hello2D' -sWASM=1 -sASYNCIFY
             -sMAX_WEBGL_VERSION=2 -sEXPORTED_RUNTIME_METHODS=['GL','Asyncify'] -sMODULARIZE=1
             -sENVIRONMENT='web,worker' -sEXPORT_ES6=1 -sASYNCIFY_STACK_SIZE=16384)
+    if (${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.4")
+        list(APPEND H2D_LINK_OPTIONS -sUSE_ES6_IMPORT_META=0)
+    elseif (${EMSCRIPTEN_VERSION} VERSION_GREATER_EQUAL "4.0.4" AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.6")
+        message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported. Please upgrade to 4.0.6 or higher.")
+    endif ()
     if (EMSCRIPTEN_PTHREADS)
         list(APPEND H2D_LINK_OPTIONS -sUSE_PTHREADS=1 -sINITIAL_MEMORY=32MB -sALLOW_MEMORY_GROWTH=1
                 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency -sPROXY_TO_PTHREAD=1

--- a/web/demo/CMakeLists.txt
+++ b/web/demo/CMakeLists.txt
@@ -18,9 +18,17 @@ file(GLOB_RECURSE HELLO_2D_FILES src/*.cpp)
 if (DEFINED EMSCRIPTEN)
     add_executable(hello2d ${HELLO_2D_FILES})
     list(APPEND H2D_COMPILE_OPTIONS -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
+    if(NOT EMSCRIPTEN_VERSION)
+        message(FATAL_ERROR "Failed to get emsdk version. Please ensure emsdk is properly installed and configured.")
+    endif()
+    if (EMSCRIPTEN_VERSION AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.4")
+        list(APPEND H2D_LINK_OPTIONS -sUSE_ES6_IMPORT_META=0)
+    elseif (EMSCRIPTEN_VERSION AND ${EMSCRIPTEN_VERSION} VERSION_GREATER_EQUAL "4.0.4" AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.6")
+        message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported. Please upgrade to 4.0.6 or higher.")
+    endif ()
     list(APPEND H2D_LINK_OPTIONS --no-entry -lembind -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 -sEXPORT_NAME='Hello2D' -sWASM=1 -sASYNCIFY
             -sMAX_WEBGL_VERSION=2 -sEXPORTED_RUNTIME_METHODS=['GL','Asyncify'] -sMODULARIZE=1
-            -sENVIRONMENT='web,worker' -sEXPORT_ES6=1 -sUSE_ES6_IMPORT_META=0 -sASYNCIFY_STACK_SIZE=16384)
+            -sENVIRONMENT='web,worker' -sEXPORT_ES6=1 -sASYNCIFY_STACK_SIZE=16384)
     if (EMSCRIPTEN_PTHREADS)
         list(APPEND H2D_LINK_OPTIONS -sUSE_PTHREADS=1 -sINITIAL_MEMORY=32MB -sALLOW_MEMORY_GROWTH=1
                 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency -sPROXY_TO_PTHREAD=1

--- a/web/demo/index-st.html
+++ b/web/demo/index-st.html
@@ -13,6 +13,6 @@
 <div id="container" class="container">
     <canvas class="canvas" id="hello2d"></canvas>
 </div>
-<script src="./index-st.js"></script>
+<script type="module" src="./index-st.js"></script>
 </body>
 </html>

--- a/web/demo/index-st.ts
+++ b/web/demo/index-st.ts
@@ -42,7 +42,7 @@ if (typeof window !== 'undefined') {
 
     window.onresize = () => {
         onresizeEvent(shareData);
-        window.setTimeout(updateSize(shareData), 300);
+        window.setTimeout(() => updateSize(shareData), 300);
     };
 
     window.onclick = () => {

--- a/web/demo/index.html
+++ b/web/demo/index.html
@@ -13,6 +13,6 @@
 <div id="container" class="container">
     <canvas class="canvas" id="hello2d"></canvas>
 </div>
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>
 </body>
 </html>

--- a/web/demo/index.ts
+++ b/web/demo/index.ts
@@ -26,7 +26,10 @@ let shareData: ShareData = new ShareData();
 if (typeof window !== 'undefined') {
     window.onload = async () => {
         try {
-            shareData.Hello2DModule = await Hello2D({ locateFile: (file: string) => './wasm-mt/' + file });
+            shareData.Hello2DModule = await Hello2D({
+                locateFile: (file: string) => './wasm-mt/' + file ,
+                mainScriptUrlOrBlob: './wasm-mt/hello2d.js'
+            });
             TGFXBind(shareData.Hello2DModule);
 
             let tgfxView = shareData.Hello2DModule.TGFXThreadsView.MakeFrom('#hello2d');
@@ -50,7 +53,7 @@ if (typeof window !== 'undefined') {
 
     window.onresize = () => {
         onresizeEvent(shareData);
-        window.setTimeout(updateSize(shareData), 300);
+        window.setTimeout(() => updateSize(shareData), 300);
     };
 
     window.onclick = () => {


### PR DESCRIPTION
1、emsdk version < 4.0.4，禁用import.meta
2、4.0.4 <= emsdk version < 4.0.6，cmake构建报错，提示用户升级至4.0.6及更高版本
3、emsdk sdk >= 4.0.6，默认启用import.meta，多线程加载.js时指定加载路径