### PR TITLE
Improve the method for determining the size of the rendered SVG.

### DIFF
--- a/include/tgfx/svg/SVGDOM.h
+++ b/include/tgfx/svg/SVGDOM.h
@@ -77,7 +77,7 @@ class SVGDOM {
   void setContainerSize(const Size& size);
 
   /**
-   * Sets the size of the container that the SVG will be rendered into. If not set, the size of the
+   * Gets the size of the container that the SVG will be rendered into. If not set, the size of the
    * root node will be used by default.
    */
   Size getContainerSize() const;

--- a/include/tgfx/svg/SVGDOM.h
+++ b/include/tgfx/svg/SVGDOM.h
@@ -20,7 +20,6 @@
 
 #include <memory>
 #include "tgfx/core/Canvas.h"
-#include "tgfx/core/Data.h"
 #include "tgfx/core/Picture.h"
 #include "tgfx/core/Size.h"
 #include "tgfx/core/Stream.h"
@@ -73,14 +72,15 @@ class SVGDOM {
   void render(Canvas* canvas);
 
   /**
-   * Sets the size of the container that the SVG will be rendered into.
+   * Sets the size of the container where the SVG will be rendered.
    */
   void setContainerSize(const Size& size);
 
   /**
-   * Returns the size of the container that the SVG will be rendered into.
+   * Gets the size of the container where the SVG will be rendered. If not explicitly set, it 
+   * defaults to the size of the root node. 
    */
-  const Size& getContainerSize() const;
+  Size getContainerSize() const;
 
   /**
    * Returns the ID mapper for the SVG nodes.

--- a/include/tgfx/svg/SVGDOM.h
+++ b/include/tgfx/svg/SVGDOM.h
@@ -72,13 +72,13 @@ class SVGDOM {
   void render(Canvas* canvas);
 
   /**
-   * Sets the size of the container where the SVG will be rendered.
+   * Sets the size of the container that the SVG will be rendered into.
    */
   void setContainerSize(const Size& size);
 
   /**
-   * Gets the size of the container where the SVG will be rendered. If not explicitly set, it 
-   * defaults to the size of the root node. 
+   * Sets the size of the container that the SVG will be rendered into. If not set, the size of the
+   * root node will be used by default.
    */
   Size getContainerSize() const;
 

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -221,7 +221,7 @@
         "path": "50136952",
         "png_image": "b1db872",
         "radialGradient": "b1db872",
-        "referenceStyle": "491f371",
+        "referenceStyle": "8769f398",
         "text": "50136952",
         "textEmoji": "50136952",
         "textFont": "50136952"

--- a/test/src/SVGRenderTest.cpp
+++ b/test/src/SVGRenderTest.cpp
@@ -97,8 +97,9 @@ TGFX_TEST(SVGRenderTest, PathSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -115,8 +116,9 @@ TGFX_TEST(SVGRenderTest, PNGImageSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -133,8 +135,9 @@ TGFX_TEST(SVGRenderTest, JPGImageSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -151,8 +154,9 @@ TGFX_TEST(SVGRenderTest, MaskSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -170,8 +174,9 @@ TGFX_TEST(SVGRenderTest, GradientSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -188,8 +193,9 @@ TGFX_TEST(SVGRenderTest, BlurSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -211,8 +217,9 @@ TGFX_TEST(SVGRenderTest, TextSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -234,8 +241,9 @@ TGFX_TEST(SVGRenderTest, TextFontSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -259,8 +267,9 @@ TGFX_TEST(SVGRenderTest, TextEmojiSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);
@@ -395,8 +404,9 @@ TGFX_TEST(SVGRenderTest, ReferenceStyleSVG) {
   ContextScope scope;
   auto* context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto surface = Surface::Make(context, static_cast<int>(rootNode->getWidth().value()),
-                               static_cast<int>(rootNode->getHeight().value()));
+  auto size = SVGDom->getContainerSize();
+  auto surface =
+      Surface::Make(context, static_cast<int>(size.width), static_cast<int>(size.height));
   auto* canvas = surface->getCanvas();
 
   SVGDom->render(canvas);


### PR DESCRIPTION
改进获取SVG渲染区域大小的方法，如果没有设置就返回根节点的大小。
以提供给用户来获取合适的渲染区域大小。