### PR TITLE
If the _rasterizationScale equals zero, the layer will automatically apply adaptive scaling using the Canvas scale value.

### DIFF
--- a/include/tgfx/core/Matrix.h
+++ b/include/tgfx/core/Matrix.h
@@ -698,14 +698,14 @@ class Matrix {
 
   /**
    * Returns the minimum scale factor of the Matrix by decomposing the scaling and skewing elements.
-   * The scale factor is an absolute value and may not align with the x/y axes. Returns -1 if the
+   * The scale factor is an absolute value and may not align with the x/y axes. Returns 0.0f if the
    * scale factor overflows.
    */
   float getMinScale() const;
 
   /**
    * Returns the maximum scale factor of the Matrix by decomposing the scaling and skewing elements.
-   * The scale factor is an absolute value and may not align with the x/y axes. Returns -1 if the
+   * The scale factor is an absolute value and may not align with the x/y axes. Returns 0.0f if the
    * scale factor overflows.
    */
   float getMaxScale() const;

--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -565,7 +565,7 @@ class Layer {
 
   std::shared_ptr<ImageFilter> getImageFilter(float contentScale);
 
-  LayerContent* getRasterizedCache(const DrawArgs& args);
+  LayerContent* getRasterizedCache(const DrawArgs& args, float contentScale);
 
   std::shared_ptr<Image> getRasterizedImage(const DrawArgs& args, float contentScale,
                                             Matrix* drawingMatrix);
@@ -614,7 +614,7 @@ class Layer {
   std::string _name;
   float _alpha = 1.0f;
   Matrix _matrix = {};
-  float _rasterizationScale = 1.0f;
+  float _rasterizationScale = 0.0f;
   std::vector<std::shared_ptr<LayerFilter>> _filters = {};
   std::shared_ptr<Layer> _mask = nullptr;
   Layer* maskOwner = nullptr;

--- a/src/core/GlyphRunList.cpp
+++ b/src/core/GlyphRunList.cpp
@@ -48,7 +48,7 @@ GlyphRunList::GlyphRunList(std::vector<GlyphRun> glyphRuns) : _glyphRuns(std::mo
 }
 
 Rect GlyphRunList::getBounds(float resolutionScale) const {
-  if (resolutionScale <= 0.0f) {
+  if (FloatNearlyZero(resolutionScale)) {
     return {};
   }
   auto hasScale = !FloatNearlyEqual(resolutionScale, 1.0f);
@@ -77,7 +77,7 @@ Rect GlyphRunList::getBounds(float resolutionScale) const {
 }
 
 bool GlyphRunList::getPath(Path* path, float resolutionScale) const {
-  if (resolutionScale <= 0.0f || !hasOutlines()) {
+  if (FloatNearlyZero(resolutionScale) || !hasOutlines()) {
     return false;
   }
   auto hasScale = !FloatNearlyEqual(resolutionScale, 1.0f);

--- a/src/core/Matrix.cpp
+++ b/src/core/Matrix.cpp
@@ -349,7 +349,7 @@ float Matrix::getMinScale() const {
   if (getMinMaxScaleFactors(results)) {
     return results[0];
   }
-  return -1.0f;
+  return 0.0f;
 }
 
 float Matrix::getMaxScale() const {
@@ -357,7 +357,7 @@ float Matrix::getMaxScale() const {
   if (getMinMaxScaleFactors(results)) {
     return results[1];
   }
-  return -1.0f;
+  return 0.0f;
 }
 
 Point Matrix::getAxisScales() const {

--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -22,6 +22,7 @@
 #include "core/PathTriangulator.h"
 #include "core/Rasterizer.h"
 #include "core/images/SubsetImage.h"
+#include "core/utils/MathExtra.h"
 #include "core/utils/Types.h"
 #include "gpu/DrawingManager.h"
 #include "gpu/ProxyProvider.h"
@@ -136,7 +137,7 @@ void RenderContext::drawGlyphRunList(std::shared_ptr<GlyphRunList> glyphRunList,
     return;
   }
   auto maxScale = state.matrix.getMaxScale();
-  if (maxScale <= 0.0f) {
+  if (FloatNearlyZero(maxScale)) {
     return;
   }
   auto bounds = glyphRunList->getBounds(maxScale);
@@ -223,7 +224,7 @@ void RenderContext::drawColorGlyphs(std::shared_ptr<GlyphRunList> glyphRunList,
                                     const MCState& state, const Fill& fill) {
   auto viewMatrix = state.matrix;
   auto scale = viewMatrix.getMaxScale();
-  if (scale <= 0) {
+  if (FloatNearlyZero(scale)) {
     return;
   }
   viewMatrix.preScale(1.0f / scale, 1.0f / scale);

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -261,7 +261,7 @@ void SVGExportContext::exportGlyphsAsImage(const std::shared_ptr<GlyphRunList>& 
                                            const MCState& state, const Fill& fill) {
   auto viewMatrix = state.matrix;
   auto scale = viewMatrix.getMaxScale();
-  if (scale <= 0) {
+  if (FloatNearlyZero(scale)) {
     return;
   }
   viewMatrix.preScale(1.0f / scale, 1.0f / scale);


### PR DESCRIPTION
1、修改layer代码，当_rasterizationScale为0时，采用canvas中的scale。
2、将matrix中getmaxscale和getminscale返回的无效值从-1改为0。