### PR TITLE
Add a PathRasterizer::Make API with customizable width and height to  to support path render clipping.

### DIFF
--- a/src/core/PathRasterizer.h
+++ b/src/core/PathRasterizer.h
@@ -29,16 +29,9 @@ namespace tgfx {
 class PathRasterizer : public ImageCodec {
  public:
   /**
-   * Creates a new PathRasterizer instance with the specified shape,anti-aliasing setting,
-   * and gamma correction flag. Anti-aliasing and gamma correction are recommended for glyph path rendering,
-   * while gamma correction is generally unnecessary for regular path rendering.
-   */
-  static std::shared_ptr<PathRasterizer> Make(std::shared_ptr<Shape> shape, bool antiAlias,
-                                              bool needsGammaCorrection = false);
-
-  /**
-   * Creates a new PathRasterizer instance with the specified width, height. Maybe only part of the
-   * shape can be displayed. The same considerations apply to the other parameters as mentioned above.
+   * Creates a new PathRasterizer instance with the specified width, height, shape, anti-aliasing
+   * setting, and gamma correction flag. Anti-aliasing and gamma correction are recommended for glyph
+   * path rendering, while gamma correction is generally unnecessary for regular path rendering.
    */
   static std::shared_ptr<PathRasterizer> Make(int width, int height, std::shared_ptr<Shape> shape,
                                               bool antiAlias, bool needsGammaCorrection = false);

--- a/src/core/PathRasterizer.h
+++ b/src/core/PathRasterizer.h
@@ -36,6 +36,13 @@ class PathRasterizer : public ImageCodec {
   static std::shared_ptr<PathRasterizer> Make(std::shared_ptr<Shape> shape, bool antiAlias,
                                               bool needsGammaCorrection = false);
 
+  /**
+   * Creates a new PathRasterizer instance with the specified width, height. Maybe only part of the
+   * shape can be displayed. The same considerations apply to the other parameters as mentioned above.
+   */
+  static std::shared_ptr<PathRasterizer> Make(int width, int height, std::shared_ptr<Shape> shape,
+                                              bool antiAlias, bool needsGammaCorrection = false);
+
   bool isAlphaOnly() const override {
     return true;
   }

--- a/src/core/vectors/coregraphics/CGPathRasterizer.cpp
+++ b/src/core/vectors/coregraphics/CGPathRasterizer.cpp
@@ -108,9 +108,6 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
   if (shape == nullptr || width <= 0 || height <= 0) {
     return nullptr;
   }
-  if (shape->getBounds().isEmpty()) {
-    return nullptr;
-  }
   return std::make_shared<CGPathRasterizer>(width, height, std::move(shape), antiAlias,
                                             needsGammaCorrection);
 }

--- a/src/core/vectors/coregraphics/CGPathRasterizer.cpp
+++ b/src/core/vectors/coregraphics/CGPathRasterizer.cpp
@@ -117,6 +117,19 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(std::shared_ptr<Shape> shap
                                             needsGammaCorrection);
 }
 
+std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
+                                                     std::shared_ptr<Shape> shape, bool antiAlias,
+                                                     bool needsGammaCorrection) {
+  if (shape == nullptr || width <= 0 || height <= 0) {
+    return nullptr;
+  }
+  if (shape->getBounds().isEmpty()) {
+    return nullptr;
+  }
+  return std::make_shared<CGPathRasterizer>(width, height, std::move(shape), antiAlias,
+                                            needsGammaCorrection);
+}
+
 bool CGPathRasterizer::readPixels(const ImageInfo& dstInfo, void* dstPixels) const {
   if (dstPixels == nullptr || dstInfo.isEmpty()) {
     return false;

--- a/src/core/vectors/coregraphics/CGPathRasterizer.cpp
+++ b/src/core/vectors/coregraphics/CGPathRasterizer.cpp
@@ -102,21 +102,6 @@ static CGImageRef CreateCGImage(const Path& path, void* pixels, const ImageInfo&
   return image;
 }
 
-std::shared_ptr<PathRasterizer> PathRasterizer::Make(std::shared_ptr<Shape> shape, bool antiAlias,
-                                                     bool needsGammaCorrection) {
-  if (shape == nullptr) {
-    return nullptr;
-  }
-  auto bounds = shape->getBounds();
-  if (bounds.isEmpty()) {
-    return nullptr;
-  }
-  auto width = static_cast<int>(ceilf(bounds.width()));
-  auto height = static_cast<int>(ceilf(bounds.height()));
-  return std::make_shared<CGPathRasterizer>(width, height, std::move(shape), antiAlias,
-                                            needsGammaCorrection);
-}
-
 std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
                                                      std::shared_ptr<Shape> shape, bool antiAlias,
                                                      bool needsGammaCorrection) {

--- a/src/core/vectors/freetype/FTPathRasterizer.cpp
+++ b/src/core/vectors/freetype/FTPathRasterizer.cpp
@@ -50,9 +50,6 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
   if (shape == nullptr || width <= 0 || height <= 0) {
     return nullptr;
   }
-  if (shape->getBounds().isEmpty()) {
-    return nullptr;
-  }
   return std::make_shared<FTPathRasterizer>(width, height, std::move(shape), antiAlias,
                                             needsGammaCorrection);
 }

--- a/src/core/vectors/freetype/FTPathRasterizer.cpp
+++ b/src/core/vectors/freetype/FTPathRasterizer.cpp
@@ -44,21 +44,6 @@ static void Iterator(PathVerb verb, const Point points[4], void* info) {
   }
 }
 
-std::shared_ptr<PathRasterizer> PathRasterizer::Make(std::shared_ptr<Shape> shape, bool antiAlias,
-                                                     bool needsGammaCorrection) {
-  if (shape == nullptr) {
-    return nullptr;
-  }
-  auto bounds = shape->getBounds();
-  if (bounds.isEmpty()) {
-    return nullptr;
-  }
-  auto width = static_cast<int>(ceilf(bounds.width()));
-  auto height = static_cast<int>(ceilf(bounds.height()));
-  return std::make_shared<FTPathRasterizer>(width, height, std::move(shape), antiAlias,
-                                            needsGammaCorrection);
-}
-
 std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
                                                      std::shared_ptr<Shape> shape, bool antiAlias,
                                                      bool needsGammaCorrection) {

--- a/src/core/vectors/freetype/FTPathRasterizer.cpp
+++ b/src/core/vectors/freetype/FTPathRasterizer.cpp
@@ -59,6 +59,19 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(std::shared_ptr<Shape> shap
                                             needsGammaCorrection);
 }
 
+std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
+                                                     std::shared_ptr<Shape> shape, bool antiAlias,
+                                                     bool needsGammaCorrection) {
+  if (shape == nullptr || width <= 0 || height <= 0) {
+    return nullptr;
+  }
+  if (shape->getBounds().isEmpty()) {
+    return nullptr;
+  }
+  return std::make_shared<FTPathRasterizer>(width, height, std::move(shape), antiAlias,
+                                            needsGammaCorrection);
+}
+
 bool FTPathRasterizer::readPixels(const ImageInfo& dstInfo, void* dstPixels) const {
   if (dstPixels == nullptr || dstInfo.isEmpty()) {
     return false;

--- a/src/core/vectors/web/WebPathRasterizer.cpp
+++ b/src/core/vectors/web/WebPathRasterizer.cpp
@@ -30,9 +30,6 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
   if (shape == nullptr || width <= 0 || height <= 0) {
     return nullptr;
   }
-  if (shape->getBounds().isEmpty()) {
-    return nullptr;
-  }
   return std::make_shared<WebPathRasterizer>(width, height, std::move(shape), antiAlias,
                                              needsGammaCorrection);
 }

--- a/src/core/vectors/web/WebPathRasterizer.cpp
+++ b/src/core/vectors/web/WebPathRasterizer.cpp
@@ -38,6 +38,18 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(std::shared_ptr<Shape> shap
   return std::make_shared<WebPathRasterizer>(width, height, shape, antiAlias, needsGammaCorrection);
 }
 
+std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
+                                                     std::shared_ptr<Shape> shape, bool antiAlias,
+                                                     bool needsGammaCorrection) {
+  if (shape == nullptr || width <= 0 || height <= 0) {
+    return nullptr;
+  }
+  if (shape->getBounds().isEmpty()) {
+    return nullptr;
+  }
+  return std::make_shared<WebPathRasterizer>(width, height, shape, antiAlias, needsGammaCorrection);
+}
+
 static void Iterator(PathVerb verb, const Point points[4], void* info) {
   auto path2D = reinterpret_cast<val*>(info);
   switch (verb) {

--- a/src/core/vectors/web/WebPathRasterizer.cpp
+++ b/src/core/vectors/web/WebPathRasterizer.cpp
@@ -24,20 +24,6 @@
 using namespace emscripten;
 
 namespace tgfx {
-std::shared_ptr<PathRasterizer> PathRasterizer::Make(std::shared_ptr<Shape> shape, bool antiAlias,
-                                                     bool needsGammaCorrection) {
-  if (shape == nullptr) {
-    return nullptr;
-  }
-  auto bounds = shape->getBounds();
-  if (bounds.isEmpty()) {
-    return nullptr;
-  }
-  auto width = static_cast<int>(ceilf(bounds.width()));
-  auto height = static_cast<int>(ceilf(bounds.height()));
-  return std::make_shared<WebPathRasterizer>(width, height, shape, antiAlias, needsGammaCorrection);
-}
-
 std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
                                                      std::shared_ptr<Shape> shape, bool antiAlias,
                                                      bool needsGammaCorrection) {
@@ -47,7 +33,8 @@ std::shared_ptr<PathRasterizer> PathRasterizer::Make(int width, int height,
   if (shape->getBounds().isEmpty()) {
     return nullptr;
   }
-  return std::make_shared<WebPathRasterizer>(width, height, shape, antiAlias, needsGammaCorrection);
+  return std::make_shared<WebPathRasterizer>(width, height, std::move(shape), antiAlias,
+                                             needsGammaCorrection);
 }
 
 static void Iterator(PathVerb verb, const Point points[4], void* info) {


### PR DESCRIPTION
增加可以自定义宽高的PathRasterizer::Make API , 因此path再绘制可以实现裁剪功能