### PR TITLE
Remove the applyToBound() method of Stroke from the public APIs.

### DIFF
--- a/include/tgfx/core/Stroke.h
+++ b/include/tgfx/core/Stroke.h
@@ -87,11 +87,6 @@ class Stroke {
   bool applyToPath(Path* path, float resolutionScale = 1.0f) const;
 
   /**
-   * Applies the stroke options to the given bounds.
-   */
-  void applyToBounds(Rect* bounds) const;
-
-  /**
    * The thickness of the pen used to outline the paths or glyphs.
    */
   float width = 1.0f;

--- a/src/core/Font.cpp
+++ b/src/core/Font.cpp
@@ -116,15 +116,7 @@ std::shared_ptr<ImageCodec> Font::getImage(GlyphID glyphID, const Stroke* stroke
     return nullptr;
   }
 
-  std::unique_ptr<Stroke> adjustMitterStroke = nullptr;
-  if (stroke != nullptr) {
-    adjustMitterStroke = std::make_unique<Stroke>(*stroke);
-    // Glyph stroke rarely creates sharp angles, so setting miterLimit = 1.0f
-    // helps produce tighter bounding box.
-    adjustMitterStroke->miterLimit = 1.0f;
-  }
-  auto bounds =
-      scalerContext->getImageTransform(glyphID, fauxBold, adjustMitterStroke.get(), matrix);
+  auto bounds = scalerContext->getImageTransform(glyphID, fauxBold, stroke, matrix);
   if (bounds.isEmpty()) {
     return nullptr;
   }
@@ -133,8 +125,7 @@ std::shared_ptr<ImageCodec> Font::getImage(GlyphID glyphID, const Stroke* stroke
   }
   auto width = static_cast<int>(ceilf(bounds.width()));
   auto height = static_cast<int>(ceilf(bounds.height()));
-  return std::make_shared<GlyphRasterizer>(width, height, scalerContext, glyphID, fauxBold,
-                                           std::move(adjustMitterStroke));
+  return std::make_shared<GlyphRasterizer>(width, height, scalerContext, glyphID, fauxBold, stroke);
 }
 
 bool Font::operator==(const Font& font) const {

--- a/src/core/GlyphRasterizer.h
+++ b/src/core/GlyphRasterizer.h
@@ -28,7 +28,9 @@ namespace tgfx {
 class GlyphRasterizer : public ImageCodec {
  public:
   GlyphRasterizer(int width, int height, std::shared_ptr<ScalerContext> scalerContext,
-                  GlyphID glyphID, bool fauxBold, std::unique_ptr<Stroke> stroke);
+                  GlyphID glyphID, bool fauxBold, const Stroke* stroke);
+
+  ~GlyphRasterizer() override;
 
   bool isAlphaOnly() const override {
     return !scalerContext->hasColor();
@@ -40,6 +42,6 @@ class GlyphRasterizer : public ImageCodec {
   std::shared_ptr<ScalerContext> scalerContext = nullptr;
   GlyphID glyphID = 0;
   bool fauxBold = false;
-  std::unique_ptr<Stroke> stroke = nullptr;
+  Stroke* stroke = nullptr;
 };
 }  // namespace tgfx

--- a/src/core/MeasureContext.cpp
+++ b/src/core/MeasureContext.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "MeasureContext.h"
+#include "core/utils/ApplyStrokeToBound.h"
 #include "core/utils/Log.h"
 
 namespace tgfx {
@@ -31,7 +32,7 @@ void MeasureContext::drawRRect(const RRect& rRect, const MCState& state, const F
                                const Stroke* stroke) {
   auto rect = rRect.rect;
   if (stroke) {
-    stroke->applyToBounds(&rect);
+    ApplyStrokeToBounds(*stroke, &rect);
   }
   addLocalBounds(state, fill, rect, false);
 }
@@ -64,7 +65,7 @@ void MeasureContext::drawGlyphRunList(std::shared_ptr<GlyphRunList> glyphRunList
                                       const Stroke* stroke) {
   auto localBounds = glyphRunList->getBounds();
   if (stroke) {
-    stroke->applyToBounds(&localBounds);
+    ApplyStrokeToBounds(*stroke, &localBounds);
   }
   addLocalBounds(state, fill, localBounds);
 }

--- a/src/core/Stroke.cpp
+++ b/src/core/Stroke.cpp
@@ -62,16 +62,4 @@ bool Stroke::applyToPath(Path* path, float resolutionScale) const {
   return paint.getFillPath(skPath, &skPath, nullptr, resolutionScale);
 }
 
-void Stroke::applyToBounds(Rect* bounds) const {
-  if (bounds == nullptr) {
-    return;
-  }
-  auto expand = width * 0.5f;
-  if (join == LineJoin::Miter) {
-    expand *= miterLimit;
-  }
-  expand = ceilf(expand);
-  bounds->outset(expand, expand);
-}
-
 }  // namespace tgfx

--- a/src/core/shapes/StrokeShape.cpp
+++ b/src/core/shapes/StrokeShape.cpp
@@ -18,6 +18,7 @@
 
 #include "StrokeShape.h"
 #include "core/shapes/MatrixShape.h"
+#include "core/utils/ApplyStrokeToBound.h"
 #include "core/utils/Log.h"
 #include "core/utils/UniqueID.h"
 
@@ -52,7 +53,7 @@ std::shared_ptr<Shape> Shape::ApplyStroke(std::shared_ptr<Shape> shape, const St
 
 Rect StrokeShape::getBounds() const {
   auto bounds = shape->getBounds();
-  stroke.applyToBounds(&bounds);
+  ApplyStrokeToBounds(stroke, &bounds, true);
   return bounds;
 }
 

--- a/src/core/utils/ApplyStrokeToBound.h
+++ b/src/core/utils/ApplyStrokeToBound.h
@@ -16,23 +16,14 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "GlyphRasterizer.h"
+#pragma once
+
+#include "tgfx/core/Rect.h"
+#include "tgfx/core/Stroke.h"
 
 namespace tgfx {
-GlyphRasterizer::GlyphRasterizer(int width, int height,
-                                 std::shared_ptr<ScalerContext> scalerContext, GlyphID glyphID,
-                                 bool fauxBold, const Stroke* stroke)
-    : ImageCodec(width, height, Orientation::LeftTop), scalerContext(std::move(scalerContext)),
-      glyphID(glyphID), fauxBold(fauxBold), stroke(stroke ? new Stroke(*stroke) : nullptr) {
-}
-
-GlyphRasterizer::~GlyphRasterizer() {
-  if (stroke) {
-    delete stroke;
-  }
-}
-
-bool GlyphRasterizer::readPixels(const ImageInfo& dstInfo, void* dstPixels) const {
-  return scalerContext->readPixels(glyphID, fauxBold, stroke, dstInfo, dstPixels);
-}
+/**
+ * Applies the stroke options to the given bounds.
+ */
+void ApplyStrokeToBounds(const Stroke& stroke, Rect* bounds, bool applyMiterLimit = false);
 }  // namespace tgfx

--- a/src/core/utils/StrokeUtils.cpp
+++ b/src/core/utils/StrokeUtils.cpp
@@ -1,0 +1,18 @@
+#include <cmath>
+#include "ApplyStrokeToBound.h"
+
+namespace tgfx {
+
+void ApplyStrokeToBounds(const Stroke& stroke, Rect* bounds, bool applyMiterLimit) {
+  if (bounds == nullptr) {
+    return;
+  }
+  auto expand = stroke.width * 0.5f;
+  if (applyMiterLimit && stroke.join == LineJoin::Miter) {
+    expand *= stroke.miterLimit;
+  }
+  expand = ceilf(expand);
+  bounds->outset(expand, expand);
+}
+
+}  // namespace tgfx

--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -22,6 +22,7 @@
 #include "core/PathTriangulator.h"
 #include "core/Rasterizer.h"
 #include "core/images/SubsetImage.h"
+#include "core/utils/ApplyStrokeToBound.h"
 #include "core/utils/MathExtra.h"
 #include "core/utils/Types.h"
 #include "gpu/DrawingManager.h"
@@ -142,7 +143,7 @@ void RenderContext::drawGlyphRunList(std::shared_ptr<GlyphRunList> glyphRunList,
   }
   auto bounds = glyphRunList->getBounds(maxScale);
   if (stroke) {
-    stroke->applyToBounds(&bounds);
+    ApplyStrokeToBounds(*stroke, &bounds);
   }
   state.matrix.mapRect(&bounds);  // To device space
   auto clipBounds = getClipBounds(state.clip);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -24,7 +24,7 @@
         "Path_addArc_reversed7": "4802e56",
         "Path_addArc_reversed8": "4802e56",
         "Path_complex": "e031f25",
-        "Picture": "99c36f0c",
+        "Picture": "ced3b513",
         "PictureImage": "c475bfb",
         "PictureImage_Path": "1ae5042",
         "PictureImage_Text": "1ae5042",
@@ -71,7 +71,7 @@
         "ImageWithMipmap": "da590da",
         "ImageWithShadow": "50136952",
         "SimpleLayerTreeDrawer": "0224fbeb",
-        "SimpleText": "15e0e39"
+        "SimpleText": "ced3b513"
     },
     "DstTextureTest": {
         "EmptyLocalBounds": "be94e666",


### PR DESCRIPTION
1、将stroke的applyToBound函数从公开目录移动到私有目录