### PR TITLE
Fix an issue where a second ResourceTask with the same UniqueKey is not started in DrawingManager::addResourceTask().

### DIFF
--- a/src/gpu/DrawingManager.cpp
+++ b/src/gpu/DrawingManager.cpp
@@ -114,10 +114,9 @@ void DrawingManager::addResourceTask(PlacementPtr<ResourceTask> resourceTask) {
   if (result != resourceTaskMap.end()) {
     // Remove the unique key from the old task, so it will be skipped when the task is executed.
     result->second->uniqueKey = {};
-  } else {
-    resourceTaskMap[resourceTask->uniqueKey] = resourceTask.get();
-    resourceTasks.emplace_back(std::move(resourceTask));
   }
+  resourceTaskMap[resourceTask->uniqueKey] = resourceTask.get();
+  resourceTasks.emplace_back(std::move(resourceTask));
 }
 
 bool DrawingManager::flush() {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -136,7 +136,7 @@
         "MaskAlpha": "3dbeed5",
         "ModeColorFilter": "c475bfb",
         "PassThoughAndNormal": "43cd416",
-        "RasterizedCache": "dc56ff16",
+        "RasterizedCache": "e48721fb",
         "ShapeStyleWithMatrix": "c475bfb",
         "StrokeOnTop_Off": "55c619d",
         "StrokeOnTop_On": "55c619d",

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -2359,18 +2359,19 @@ TGFX_TEST(LayerTest, RasterizedCache) {
   rectLayer->setFillStyle(SolidColor::Make(Color::Red()));
   rectLayer->setShouldRasterize(true);
   rectLayer->setLayerStyles({style});
-  rectLayer->setMatrix(Matrix::MakeTrans(100, 0));
+  rectLayer->setMatrix(Matrix::MakeTrans(150, 0));
   imageLayer->addChild(rectLayer);
 
   auto blurLayer = ShapeLayer::Make();
   Path childPath;
-  childPath.addRect(Rect::MakeWH(250, 100));
+  childPath.addRect(Rect::MakeWH(100, 100));
   blurLayer->setPath(childPath);
   auto fillStyle = SolidColor::Make(Color::FromRGBA(100, 0, 0, 128));
   blurLayer->setFillStyle(fillStyle);
   blurLayer->setShouldRasterize(true);
+  blurLayer->setMatrix(Matrix::MakeTrans(150, 0));
   blurLayer->setLayerStyles({BackgroundBlurStyle::Make(10, 10)});
-  rootLayer->addChild(blurLayer);
+  imageLayer->addChild(blurLayer);
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());


### PR DESCRIPTION
DrawingManager::addResourceTask存在已有的ResourceTask时，跳过之前的，创建新的ResourceTask。