### PR TITLE
Move the MakeFrom() method for wrapping existing pixel data from ImageBuffer to ImageCodec.

### DIFF
--- a/include/tgfx/core/Image.h
+++ b/include/tgfx/core/Image.h
@@ -78,12 +78,10 @@ class Image {
   static std::shared_ptr<Image> MakeFrom(std::shared_ptr<ImageGenerator> generator);
 
   /**
-   * Creates an Image from the ImageInfo and shares pixels from the immutable Data object. The
-   * returned Image takes a reference to the pixels. The caller must ensure the pixels are always
-   * the same for the lifetime of the returned Image. If the ImageInfo is unsuitable for direct
-   * texture uploading, the Image will internally create an ImageGenerator for pixel format
-   * conventing instead of an ImageBuffer. Returns nullptr if the ImageInfo is empty or the pixels
-   * are nullptr.
+   * Creates an Image using the provided ImageInfo and pixel data from an immutable Data object. The
+   * returned Image holds a reference to the pixel data. The caller must ensure the pixel data
+   * remains unchanged for the lifetime of the Image. Returns nullptr if the ImageInfo is empty or
+   * the pixel data is nullptr.
    */
   static std::shared_ptr<Image> MakeFrom(const ImageInfo& info, std::shared_ptr<Data> pixels);
 

--- a/include/tgfx/core/ImageBuffer.h
+++ b/include/tgfx/core/ImageBuffer.h
@@ -50,16 +50,6 @@ class ImageBuffer {
       HardwareBufferRef hardwareBuffer, YUVColorSpace colorSpace = YUVColorSpace::BT601_LIMITED);
 
   /**
-   * Creates an ImageBuffer from the ImageInfo and shares pixels from the immutable Data object. The
-   * caller must ensure the pixel data stay unchanged for the lifetime of the returned ImageBuffer.
-   * Returns nullptr if the pixels are nullptr or the ImageInfo is not suitable for direct texture
-   * uploading. ImageInfo parameters suitable for direct texture uploading include:
-   * The alpha type is either AlphaType::Premultiplied or AlphaType::Opaque;
-   * The color type is one of ColorType::ALPHA_8, ColorType::RGBA_8888, and ColorType::BGRA_8888.
-   */
-  static std::shared_ptr<ImageBuffer> MakeFrom(const ImageInfo& info, std::shared_ptr<Data> pixels);
-
-  /**
    * Creates an ImageBuffer in the I420 format with the specified YUVData and YUVColorSpace. The
    * caller must ensure the yuvData stays unchanged for the lifetime of the returned ImageBuffer.
    * Returns nullptr if the yuvData is invalid.
@@ -102,6 +92,13 @@ class ImageBuffer {
 
  protected:
   ImageBuffer() = default;
+
+  /**
+   * Returns true if the ImageBuffer is backed by a PixelBuffer, allowing pixel locking.
+   */
+  virtual bool isPixelBuffer() const {
+    return false;
+  }
 
   /**
    * Creates a new Texture capturing the pixels of the ImageBuffer. The mipmapped parameter

--- a/include/tgfx/core/ImageCodec.h
+++ b/include/tgfx/core/ImageCodec.h
@@ -31,7 +31,7 @@ namespace tgfx {
 class ImageBuffer;
 
 /**
- * Abstraction layer directly on top of an image codec.
+ * ImageCodec is an abstract class that defines the interface for decoding and encoding images.
  */
 class ImageCodec : public ImageGenerator {
  public:
@@ -70,6 +70,10 @@ class ImageCodec : public ImageGenerator {
 
   bool isAlphaOnly() const override {
     return false;
+  }
+
+  bool isImageCodec() const final {
+    return true;
   }
 
   /**

--- a/include/tgfx/core/ImageCodec.h
+++ b/include/tgfx/core/ImageCodec.h
@@ -31,7 +31,7 @@ namespace tgfx {
 class ImageBuffer;
 
 /**
- * ImageCodec is an abstract class that defines the interface for decoding and encoding images.
+ * ImageCodec is an abstract class that defines the interface for decoding images.
  */
 class ImageCodec : public ImageGenerator {
  public:

--- a/include/tgfx/core/ImageCodec.h
+++ b/include/tgfx/core/ImageCodec.h
@@ -48,6 +48,14 @@ class ImageCodec : public ImageGenerator {
   static std::shared_ptr<ImageCodec> MakeFrom(std::shared_ptr<Data> imageBytes);
 
   /**
+   * Creates a new ImageCodec using the provided ImageInfo and pixel data from an immutable Data
+   * object. The returned ImageCodec holds a reference to the pixel data, so the caller must ensure
+   * the pixels remain unchanged for the lifetime of the ImageCodec. Returns nullptr if ImageInfo is
+   * empty or pixels is nullptr.
+   */
+  static std::shared_ptr<ImageCodec> MakeFrom(const ImageInfo& info, std::shared_ptr<Data> pixels);
+
+  /**
    * Creates a new ImageCodec object from a platform-specific NativeImage. For example, the
    * NativeImage could be a jobject that represents a java Bitmap on the android platform or a
    * CGImageRef on the apple platform. The returned ImageCodec object takes a reference to the
@@ -85,7 +93,7 @@ class ImageCodec : public ImageGenerator {
   virtual bool readPixels(const ImageInfo& dstInfo, void* dstPixels) const = 0;
 
  protected:
-  ImageCodec(int width, int height, Orientation orientation)
+  ImageCodec(int width, int height, Orientation orientation = Orientation::TopLeft)
       : ImageGenerator(width, height), _orientation(orientation) {
   }
 

--- a/include/tgfx/core/ImageGenerator.h
+++ b/include/tgfx/core/ImageGenerator.h
@@ -59,6 +59,15 @@ class ImageGenerator {
   }
 
   /**
+   * Returns true if this ImageGenerator is an ImageCodec, meaning it can read pixels directly from
+   * the decoded image buffer. If false, the ImageGenerator is a custom generator and cannot read
+   * pixels directly.
+   */
+  virtual bool isImageCodec() const {
+    return false;
+  }
+
+  /**
    * Crates a new image buffer capturing the pixels decoded from this image generator.
    * ImageGenerator does not cache the returned image buffer, each call to this method allocates
    * additional storage. Returns an ImageBuffer backed by hardware if tryHardware is true and

--- a/src/core/GlyphRasterizer.cpp
+++ b/src/core/GlyphRasterizer.cpp
@@ -22,8 +22,8 @@ namespace tgfx {
 GlyphRasterizer::GlyphRasterizer(int width, int height,
                                  std::shared_ptr<ScalerContext> scalerContext, GlyphID glyphID,
                                  bool fauxBold, const Stroke* stroke)
-    : ImageCodec(width, height, Orientation::LeftTop), scalerContext(std::move(scalerContext)),
-      glyphID(glyphID), fauxBold(fauxBold), stroke(stroke ? new Stroke(*stroke) : nullptr) {
+    : ImageCodec(width, height), scalerContext(std::move(scalerContext)), glyphID(glyphID),
+      fauxBold(fauxBold), stroke(stroke ? new Stroke(*stroke) : nullptr) {
 }
 
 GlyphRasterizer::~GlyphRasterizer() {

--- a/src/core/ImageBuffer.cpp
+++ b/src/core/ImageBuffer.cpp
@@ -22,49 +22,6 @@
 
 namespace tgfx {
 /**
- * PixelData represents a pixel array described in a single plane.
- */
-class PixelData : public ImageBuffer {
- public:
-  PixelData(const ImageInfo& info, std::shared_ptr<Data> pixels)
-      : info(info), pixels(std::move(pixels)) {
-  }
-
-  int width() const override {
-    return info.width();
-  }
-
-  int height() const override {
-    return info.height();
-  }
-
-  bool isAlphaOnly() const override {
-    return info.isAlphaOnly();
-  }
-
- protected:
-  std::shared_ptr<Texture> onMakeTexture(Context* context, bool mipmapped) const override {
-    switch (info.colorType()) {
-      case ColorType::ALPHA_8:
-        return Texture::MakeAlpha(context, info.width(), info.height(), pixels->data(),
-                                  info.rowBytes(), mipmapped);
-      case ColorType::BGRA_8888:
-        return Texture::MakeFormat(context, info.width(), info.height(), pixels->data(),
-                                   info.rowBytes(), PixelFormat::BGRA_8888, mipmapped);
-      case ColorType::RGBA_8888:
-        return Texture::MakeRGBA(context, info.width(), info.height(), pixels->data(),
-                                 info.rowBytes(), mipmapped);
-      default:
-        return nullptr;
-    }
-  }
-
- private:
-  ImageInfo info = {};
-  std::shared_ptr<Data> pixels = nullptr;
-};
-
-/**
  * YUVBuffer represents a pixel array described in the YUV format with multiple planes.
  */
 class YUVBuffer : public ImageBuffer {
@@ -98,22 +55,6 @@ class YUVBuffer : public ImageBuffer {
   YUVColorSpace colorSpace = YUVColorSpace::BT601_LIMITED;
   YUVFormat format = YUVFormat::Unknown;
 };
-
-std::shared_ptr<ImageBuffer> ImageBuffer::MakeFrom(const ImageInfo& info,
-                                                   std::shared_ptr<Data> pixels) {
-  if (info.isEmpty() || pixels == nullptr || info.byteSize() > pixels->size() ||
-      info.alphaType() == AlphaType::Unpremultiplied) {
-    return nullptr;
-  }
-  switch (info.colorType()) {
-    case ColorType::ALPHA_8:
-    case ColorType::RGBA_8888:
-    case ColorType::BGRA_8888:
-      return std::make_shared<PixelData>(info, std::move(pixels));
-    default:
-      return nullptr;
-  }
-}
 
 std::shared_ptr<ImageBuffer> ImageBuffer::MakeI420(std::shared_ptr<YUVData> yuvData,
                                                    YUVColorSpace colorSpace) {

--- a/src/core/PathRasterizer.cpp
+++ b/src/core/PathRasterizer.cpp
@@ -35,8 +35,8 @@ std::shared_ptr<PathRasterizer> PathRasterizer::MakeFrom(int width, int height, 
 
 PathRasterizer::PathRasterizer(int width, int height, std::shared_ptr<Shape> shape, bool antiAlias,
                                bool needsGammaCorrection)
-    : ImageCodec(width, height, Orientation::LeftTop), shape(std::move(shape)),
-      antiAlias(antiAlias), needsGammaCorrection(needsGammaCorrection) {
+    : ImageCodec(width, height), shape(std::move(shape)), antiAlias(antiAlias),
+      needsGammaCorrection(needsGammaCorrection) {
 }
 
 bool PathRasterizer::asyncSupport() const {

--- a/src/core/PixelBuffer.h
+++ b/src/core/PixelBuffer.h
@@ -90,6 +90,10 @@ class PixelBuffer : public ImageBuffer {
  protected:
   explicit PixelBuffer(const ImageInfo& info);
 
+  bool isPixelBuffer() const final {
+    return true;
+  }
+
   std::shared_ptr<Texture> onMakeTexture(Context* context, bool mipmapped) const override;
 
   virtual void* onLockPixels() const = 0;

--- a/src/core/RawPixelCodec.cpp
+++ b/src/core/RawPixelCodec.cpp
@@ -1,0 +1,85 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "RawPixelCodec.h"
+#include "gpu/Texture.h"
+
+namespace tgfx {
+std::shared_ptr<ImageCodec> ImageCodec::MakeFrom(const ImageInfo& info,
+                                                 std::shared_ptr<Data> pixels) {
+  if (info.isEmpty() || pixels == nullptr || info.byteSize() > pixels->size()) {
+    return nullptr;
+  }
+  return std::make_shared<RawPixelCodec>(info, std::move(pixels));
+}
+
+class RawPixelData : public ImageBuffer {
+ public:
+  RawPixelData(const ImageInfo& info, std::shared_ptr<Data> pixels)
+      : info(info), pixels(std::move(pixels)) {
+  }
+
+  int width() const override {
+    return info.width();
+  }
+
+  int height() const override {
+    return info.height();
+  }
+
+  bool isAlphaOnly() const override {
+    return info.isAlphaOnly();
+  }
+
+ protected:
+  std::shared_ptr<Texture> onMakeTexture(Context* context, bool mipmapped) const override {
+    switch (info.colorType()) {
+      case ColorType::ALPHA_8:
+        return Texture::MakeAlpha(context, info.width(), info.height(), pixels->data(),
+                                  info.rowBytes(), mipmapped);
+      case ColorType::BGRA_8888:
+        return Texture::MakeFormat(context, info.width(), info.height(), pixels->data(),
+                                   info.rowBytes(), PixelFormat::BGRA_8888, mipmapped);
+      case ColorType::RGBA_8888:
+        return Texture::MakeRGBA(context, info.width(), info.height(), pixels->data(),
+                                 info.rowBytes(), mipmapped);
+      default:
+        return nullptr;
+    }
+  }
+
+ private:
+  ImageInfo info = {};
+  std::shared_ptr<Data> pixels = nullptr;
+};
+
+std::shared_ptr<ImageBuffer> RawPixelCodec::onMakeBuffer(bool tryHardware) const {
+  if (info.alphaType() != AlphaType::Unpremultiplied) {
+    switch (info.colorType()) {
+      case ColorType::ALPHA_8:
+      case ColorType::RGBA_8888:
+      case ColorType::BGRA_8888:
+        return std::make_shared<RawPixelData>(info, pixels);
+      default:
+        return nullptr;
+    }
+  }
+  return ImageCodec::onMakeBuffer(tryHardware);
+}
+
+}  // namespace tgfx

--- a/src/core/RawPixelCodec.h
+++ b/src/core/RawPixelCodec.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making tgfx available.
 //
-//  Copyright (C) 2024 Tencent. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at
@@ -16,16 +16,30 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "CodecImage.h"
-#include <memory>
+#pragma once
+
+#include "tgfx/core/ImageCodec.h"
 
 namespace tgfx {
-CodecImage::CodecImage(UniqueKey uniqueKey, std::shared_ptr<ImageCodec> codec)
-    : GeneratorImage(std::move(uniqueKey), std::move(codec)) {
-}
+class RawPixelCodec : public ImageCodec {
+ public:
+  RawPixelCodec(const ImageInfo& info, std::shared_ptr<Data> pixels)
+      : ImageCodec(info.width(), info.height()), info(info), pixels(std::move(pixels)) {
+  }
 
-std::shared_ptr<ImageCodec> CodecImage::getCodec() const {
-  return std::static_pointer_cast<ImageCodec>(generator);
-}
+  bool isAlphaOnly() const override {
+    return info.isAlphaOnly();
+  }
 
+  bool readPixels(const ImageInfo& dstInfo, void* dstPixels) const override {
+    return Pixmap(info, pixels->data()).readPixels(dstInfo, dstPixels);
+  }
+
+ protected:
+  std::shared_ptr<ImageBuffer> onMakeBuffer(bool tryHardware) const override;
+
+ private:
+  ImageInfo info = {};
+  std::shared_ptr<Data> pixels = nullptr;
+};
 }  // namespace tgfx

--- a/src/core/images/CodecImage.cpp
+++ b/src/core/images/CodecImage.cpp
@@ -20,20 +20,11 @@
 #include <memory>
 
 namespace tgfx {
-std::shared_ptr<Image> CodecImage::MakeFrom(const std::shared_ptr<ImageCodec>& codec) {
-  if (!codec) {
-    return nullptr;
-  }
-  auto image = std::shared_ptr<CodecImage>(new CodecImage(codec));
-  image->weakThis = image;
-  return image;
+CodecImage::CodecImage(std::shared_ptr<ImageCodec> codec)
+    : GeneratorImage(UniqueKey::Make(), std::move(codec)) {
 }
 
-CodecImage::CodecImage(const std::shared_ptr<ImageCodec>& codec)
-    : GeneratorImage(UniqueKey::Make(), codec) {
-}
-
-std::shared_ptr<ImageCodec> CodecImage::codec() const {
+std::shared_ptr<ImageCodec> CodecImage::getCodec() const {
   return std::static_pointer_cast<ImageCodec>(generator);
 }
 

--- a/src/core/images/CodecImage.h
+++ b/src/core/images/CodecImage.h
@@ -27,19 +27,14 @@ namespace tgfx {
 
 class CodecImage : public GeneratorImage {
  public:
-  static std::shared_ptr<Image> MakeFrom(const std::shared_ptr<ImageCodec>& codec);
+  explicit CodecImage(std::shared_ptr<ImageCodec> codec);
 
-  ~CodecImage() override = default;
-
-  std::shared_ptr<ImageCodec> codec() const;
+  std::shared_ptr<ImageCodec> getCodec() const;
 
  protected:
   Type type() const override {
     return Type::Codec;
   }
-
- private:
-  explicit CodecImage(const std::shared_ptr<ImageCodec>& codec);
 };
 
 }  // namespace tgfx

--- a/src/core/images/CodecImage.h
+++ b/src/core/images/CodecImage.h
@@ -27,7 +27,7 @@ namespace tgfx {
 
 class CodecImage : public GeneratorImage {
  public:
-  explicit CodecImage(std::shared_ptr<ImageCodec> codec);
+  CodecImage(UniqueKey uniqueKey, std::shared_ptr<ImageCodec> codec);
 
   std::shared_ptr<ImageCodec> getCodec() const;
 

--- a/src/core/images/GeneratorImage.cpp
+++ b/src/core/images/GeneratorImage.cpp
@@ -21,15 +21,6 @@
 #include "gpu/ProxyProvider.h"
 
 namespace tgfx {
-std::shared_ptr<Image> Image::MakeFrom(std::shared_ptr<ImageGenerator> generator) {
-  if (generator == nullptr) {
-    return nullptr;
-  }
-  auto image = std::make_shared<GeneratorImage>(UniqueKey::Make(), std::move(generator));
-  image->weakThis = image;
-  return image;
-}
-
 GeneratorImage::GeneratorImage(UniqueKey uniqueKey, std::shared_ptr<ImageGenerator> generator)
     : ResourceImage(std::move(uniqueKey)), generator(std::move(generator)) {
 }

--- a/src/core/images/Image.cpp
+++ b/src/core/images/Image.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<Image> Image::MakeFromFile(const std::string& filePath) {
     return cached;
   }
   auto codec = ImageCodec::MakeFrom(filePath);
-  auto image = CodecImage::MakeFrom(codec);
+  auto image = MakeFrom(codec);
   if (image == nullptr) {
     return nullptr;
   }
@@ -83,7 +83,7 @@ std::shared_ptr<Image> Image::MakeFromFile(const std::string& filePath) {
 
 std::shared_ptr<Image> Image::MakeFromEncoded(std::shared_ptr<Data> encodedData) {
   auto codec = ImageCodec::MakeFrom(std::move(encodedData));
-  auto image = CodecImage::MakeFrom(codec);
+  auto image = MakeFrom(codec);
   if (image == nullptr) {
     return nullptr;
   }
@@ -92,11 +92,27 @@ std::shared_ptr<Image> Image::MakeFromEncoded(std::shared_ptr<Data> encodedData)
 
 std::shared_ptr<Image> Image::MakeFrom(NativeImageRef nativeImage) {
   auto codec = ImageCodec::MakeFrom(nativeImage);
-  auto image = CodecImage::MakeFrom(codec);
+  auto image = MakeFrom(codec);
   if (image == nullptr) {
     return nullptr;
   }
   return image->makeOriented(codec->orientation());
+}
+
+std::shared_ptr<Image> Image::MakeFrom(std::shared_ptr<ImageGenerator> generator) {
+  if (generator == nullptr) {
+    return nullptr;
+  }
+  std::shared_ptr<Image> image = nullptr;
+  if (generator->isImageCodec()) {
+    auto codec = std::static_pointer_cast<ImageCodec>(generator);
+    image = std::make_shared<CodecImage>(std::move(codec));
+
+  } else {
+    image = std::make_shared<GeneratorImage>(UniqueKey::Make(), std::move(generator));
+  }
+  image->weakThis = image;
+  return image;
 }
 
 std::shared_ptr<Image> Image::MakeFrom(const ImageInfo& info, std::shared_ptr<Data> pixels) {

--- a/src/core/images/Image.cpp
+++ b/src/core/images/Image.cpp
@@ -33,34 +33,6 @@
 #include "tgfx/core/Pixmap.h"
 
 namespace tgfx {
-class PixelDataConverter : public ImageGenerator {
- public:
-  PixelDataConverter(const ImageInfo& info, std::shared_ptr<Data> pixels)
-      : ImageGenerator(info.width(), info.height()), info(info), pixels(std::move(pixels)) {
-  }
-
-  bool isAlphaOnly() const override {
-    return info.isAlphaOnly();
-  }
-
- protected:
-  std::shared_ptr<ImageBuffer> onMakeBuffer(bool tryHardware) const override {
-    Bitmap bitmap(width(), height(), isAlphaOnly(), tryHardware);
-    if (bitmap.isEmpty()) {
-      return nullptr;
-    }
-    auto success = bitmap.writePixels(info, pixels->data());
-    if (!success) {
-      return nullptr;
-    }
-    return bitmap.makeBuffer();
-  }
-
- private:
-  ImageInfo info = {};
-  std::shared_ptr<Data> pixels = nullptr;
-};
-
 std::shared_ptr<Image> Image::MakeFromFile(const std::string& filePath) {
   static WeakMap<std::string, Image> imageMap = {};
   if (filePath.empty()) {
@@ -71,32 +43,20 @@ std::shared_ptr<Image> Image::MakeFromFile(const std::string& filePath) {
   }
   auto codec = ImageCodec::MakeFrom(filePath);
   auto image = MakeFrom(codec);
-  if (image == nullptr) {
-    return nullptr;
+  if (image != nullptr) {
+    imageMap.insert(filePath, image);
   }
-  auto orientedImage = image->makeOriented(codec->orientation());
-  if (orientedImage) {
-    imageMap.insert(filePath, orientedImage);
-  }
-  return orientedImage;
+  return image;
 }
 
 std::shared_ptr<Image> Image::MakeFromEncoded(std::shared_ptr<Data> encodedData) {
   auto codec = ImageCodec::MakeFrom(std::move(encodedData));
-  auto image = MakeFrom(codec);
-  if (image == nullptr) {
-    return nullptr;
-  }
-  return image->makeOriented(codec->orientation());
+  return MakeFrom(std::move(codec));
 }
 
 std::shared_ptr<Image> Image::MakeFrom(NativeImageRef nativeImage) {
   auto codec = ImageCodec::MakeFrom(nativeImage);
-  auto image = MakeFrom(codec);
-  if (image == nullptr) {
-    return nullptr;
-  }
-  return image->makeOriented(codec->orientation());
+  return MakeFrom(std::move(codec));
 }
 
 std::shared_ptr<Image> Image::MakeFrom(std::shared_ptr<ImageGenerator> generator) {
@@ -106,25 +66,20 @@ std::shared_ptr<Image> Image::MakeFrom(std::shared_ptr<ImageGenerator> generator
   std::shared_ptr<Image> image = nullptr;
   if (generator->isImageCodec()) {
     auto codec = std::static_pointer_cast<ImageCodec>(generator);
-    image = std::make_shared<CodecImage>(std::move(codec));
-
+    auto orientation = codec->orientation();
+    image = std::make_shared<CodecImage>(UniqueKey::Make(), std::move(codec));
+    image->weakThis = image;
+    image = image->makeOriented(orientation);
   } else {
     image = std::make_shared<GeneratorImage>(UniqueKey::Make(), std::move(generator));
+    image->weakThis = image;
   }
-  image->weakThis = image;
   return image;
 }
 
 std::shared_ptr<Image> Image::MakeFrom(const ImageInfo& info, std::shared_ptr<Data> pixels) {
-  if (info.isEmpty() || pixels == nullptr || info.byteSize() > pixels->size()) {
-    return nullptr;
-  }
-  auto imageBuffer = ImageBuffer::MakeFrom(info, pixels);
-  if (imageBuffer != nullptr) {
-    return MakeFrom(std::move(imageBuffer));
-  }
-  auto converter = std::make_shared<PixelDataConverter>(info, std::move(pixels));
-  return MakeFrom(std::move(converter));
+  auto codec = ImageCodec::MakeFrom(info, std::move(pixels));
+  return MakeFrom(std::move(codec));
 }
 
 std::shared_ptr<Image> Image::MakeFrom(const Bitmap& bitmap) {

--- a/src/gpu/ops/AtlasTextOp.h
+++ b/src/gpu/ops/AtlasTextOp.h
@@ -31,7 +31,9 @@ class AtlasTextOp final : public DrawOp {
                                         PlacementPtr<RectsVertexProvider> provider,
                                         uint32_t renderFlags,
                                         std::shared_ptr<TextureProxy> textureProxy);
+
   void execute(RenderPass* renderPass) override;
+
   bool hasCoverage() const override;
 
  private:

--- a/src/platform/web/NativeCodec.cpp
+++ b/src/platform/web/NativeCodec.cpp
@@ -91,11 +91,11 @@ std::shared_ptr<ImageCodec> ImageCodec::MakeFrom(NativeImageRef nativeImage) {
 }
 
 NativeCodec::NativeCodec(int width, int height, std::shared_ptr<Data> imageBytes)
-    : ImageCodec(width, height, Orientation::TopLeft), imageBytes(std::move(imageBytes)) {
+    : ImageCodec(width, height), imageBytes(std::move(imageBytes)) {
 }
 
 NativeCodec::NativeCodec(int width, int height, emscripten::val nativeImage)
-    : ImageCodec(width, height, Orientation::TopLeft), nativeImage(std::move(nativeImage)) {
+    : ImageCodec(width, height), nativeImage(std::move(nativeImage)) {
 }
 
 bool NativeCodec::asyncSupport() const {

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -407,7 +407,7 @@ std::shared_ptr<Data> SVGExportContext::ImageToEncodedData(const std::shared_ptr
   Types::ImageType type = Types::Get(image.get());
   if (type != Types::ImageType::Codec) return nullptr;
   auto codecImage = static_cast<const CodecImage*>(image.get());
-  auto imageCodec = codecImage->codec();
+  auto imageCodec = codecImage->getCodec();
   return imageCodec->getEncodedData();
 }
 


### PR DESCRIPTION
1. 取消从外部像素数据创建 ImageBuffer 的 MakeFrom 方法，移动到 ImageCodec 上。
2. 给 ImageGenerator 添加 isImageCodec 的标志。
3. 给 ImageBuffer 添加 isPixelBuffer 的标志。