### PR TITLE
Remove the useOwnUniqueKey parameter from StrokeShape to maximize cache reuse.

### DIFF
--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -383,7 +383,7 @@ void Canvas::drawPath(const Path& path, const MCState& state, const Fill& fill,
     if (shape == nullptr) {
       return;
     }
-    shape = StrokeShape::Apply(std::move(shape), stroke, false);
+    shape = Shape::ApplyStroke(std::move(shape), stroke);
     if (shape == nullptr) {
       return;
     }
@@ -417,7 +417,7 @@ void Canvas::drawShape(std::shared_ptr<Shape> shape, const Paint& paint) {
     drawPath(*path, state, fill, stroke);
     return;
   }
-  shape = StrokeShape::Apply(std::move(shape), stroke, false);
+  shape = Shape::ApplyStroke(std::move(shape), stroke);
   if (shape != nullptr) {
     drawContext->drawShape(std::move(shape), state, fill);
   }

--- a/src/core/shapes/InverseShape.cpp
+++ b/src/core/shapes/InverseShape.cpp
@@ -43,8 +43,7 @@ std::shared_ptr<Shape> Shape::ApplyInverse(std::shared_ptr<Shape> shape) {
     case Type::Stroke: {
       auto strokeShape = std::static_pointer_cast<StrokeShape>(shape);
       auto invertShape = Shape::ApplyInverse(strokeShape->shape);
-      return std::shared_ptr<StrokeShape>(new StrokeShape(
-          std::move(invertShape), strokeShape->stroke, strokeShape->useOwnUniqueKey));
+      return std::make_shared<StrokeShape>(std::move(invertShape), strokeShape->stroke);
     }
     default:
       break;

--- a/src/core/shapes/StrokeShape.cpp
+++ b/src/core/shapes/StrokeShape.cpp
@@ -25,11 +25,6 @@
 namespace tgfx {
 
 std::shared_ptr<Shape> Shape::ApplyStroke(std::shared_ptr<Shape> shape, const Stroke* stroke) {
-  return StrokeShape::Apply(std::move(shape), stroke, true);
-}
-
-std::shared_ptr<Shape> StrokeShape::Apply(std::shared_ptr<Shape> shape, const Stroke* stroke,
-                                          bool useOwnUniqueKey) {
   if (shape == nullptr) {
     return nullptr;
   }
@@ -40,22 +35,19 @@ std::shared_ptr<Shape> StrokeShape::Apply(std::shared_ptr<Shape> shape, const St
     return nullptr;
   }
   if (shape->type() != Type::Matrix) {
-    return std::shared_ptr<StrokeShape>(
-        new StrokeShape(std::move(shape), *stroke, useOwnUniqueKey));
+    return std::make_shared<StrokeShape>(std::move(shape), *stroke);
   }
   // Always apply stroke to the shape before the matrix, so that the outer matrix can be used to
   // do some optimization.
   auto matrixShape = std::static_pointer_cast<MatrixShape>(shape);
   auto scales = matrixShape->matrix.getAxisScales();
   if (scales.x != scales.y) {
-    return std::shared_ptr<StrokeShape>(
-        new StrokeShape(std::move(shape), *stroke, useOwnUniqueKey));
+    return std::make_shared<StrokeShape>(std::move(shape), *stroke);
   }
   auto scaleStroke = *stroke;
   DEBUG_ASSERT(scales.x != 0);
   scaleStroke.width /= scales.x;
-  shape = std::shared_ptr<StrokeShape>(
-      new StrokeShape(matrixShape->shape, scaleStroke, useOwnUniqueKey));
+  shape = std::make_shared<StrokeShape>(matrixShape->shape, scaleStroke);
   return std::make_shared<MatrixShape>(std::move(shape), matrixShape->matrix);
 }
 
@@ -72,9 +64,6 @@ Path StrokeShape::getPath() const {
 }
 
 UniqueKey StrokeShape::getUniqueKey() const {
-  if (useOwnUniqueKey) {
-    return uniqueKey.get();
-  }
   static const auto WidthStrokeShapeType = UniqueID::Next();
   static const auto CapJoinStrokeShapeType = UniqueID::Next();
   static const auto FullStrokeShapeType = UniqueID::Next();

--- a/src/core/shapes/StrokeShape.h
+++ b/src/core/shapes/StrokeShape.h
@@ -28,8 +28,9 @@ namespace tgfx {
  */
 class StrokeShape : public Shape {
  public:
-  static std::shared_ptr<Shape> Apply(std::shared_ptr<Shape> shape, const Stroke* stroke,
-                                      bool useOwnUniqueKey);
+  StrokeShape(std::shared_ptr<Shape> shape, const Stroke& stroke)
+      : shape(std::move(shape)), stroke(stroke) {
+  }
 
   bool isInverseFillType() const override {
     return shape->isInverseFillType();
@@ -39,22 +40,15 @@ class StrokeShape : public Shape {
 
   Path getPath() const override;
 
+  std::shared_ptr<Shape> shape = nullptr;
+  Stroke stroke = {};
+
  protected:
   Type type() const override {
     return Type::Stroke;
   }
 
   UniqueKey getUniqueKey() const override;
-
- private:
-  LazyUniqueKey uniqueKey = {};
-  std::shared_ptr<Shape> shape = nullptr;
-  Stroke stroke = {};
-  bool useOwnUniqueKey = true;
-
-  StrokeShape(std::shared_ptr<Shape> shape, const Stroke& stroke, bool useOwnUniqueKey)
-      : shape(std::move(shape)), stroke(stroke), useOwnUniqueKey(useOwnUniqueKey) {
-  }
 
   friend class Shape;
 };


### PR DESCRIPTION
取消StrokeShape的useOwnUniqueKey属性，让外部创建的多个描边Shape也可以根据相同源Shape命中相同缓存。