### PR TITLE
Support more emsdk versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,33 @@ npm run build:debug
 
 With these steps completed, you can debug C++ files directly in Chrome DevTools.
 
-The above commands build and run a multithreaded version. To build a single-threaded version,
-just add the suffix ":st" to each command. For example:
+The above commands build and run a multithreaded version. 
+
+>**⚠️** In the multithreaded version, if you modify the filename of the compiled output hello2d.js, you need to search for
+> the keyword "hello2d.js" within the hello2d.js file and replace all occurrences of "hello2d.js" with the new filename.
+> Failure to do this will result in the program failing to run. Here's an example of how to modify it:
+
+Before modification:
+
+```js
+    // filename: hello2d.js
+    var worker = new Worker(new URL("hello2d.js", import.meta.url), {
+     type: "module",
+     name: "em-pthread"
+    });
+```
+
+After modification:
+
+```js
+    // filename: hello2d-test.js
+    var worker = new Worker(new URL("hello2d-test.js", import.meta.url), {
+     type: "module",
+     name: "em-pthread"
+    });
+```
+
+To build a single-threaded version, just add the suffix ":st" to each command. For example:
 
 ```
 npm run build:st

--- a/web/demo/CMakeLists.txt
+++ b/web/demo/CMakeLists.txt
@@ -20,12 +20,13 @@ if (DEFINED EMSCRIPTEN)
     list(APPEND H2D_COMPILE_OPTIONS -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0)
     list(APPEND H2D_LINK_OPTIONS --no-entry -lembind -fno-rtti -DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0 -sEXPORT_NAME='Hello2D' -sWASM=1 -sASYNCIFY
             -sMAX_WEBGL_VERSION=2 -sEXPORTED_RUNTIME_METHODS=['GL','Asyncify','HEAPU8'] -sMODULARIZE=1
-            -sENVIRONMENT='web,worker' -sEXPORT_ES6=1 -sASYNCIFY_STACK_SIZE=16384)
-    if (${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.4")
-        list(APPEND H2D_LINK_OPTIONS -sUSE_ES6_IMPORT_META=0)
-    elseif (${EMSCRIPTEN_VERSION} VERSION_GREATER_EQUAL "4.0.4" AND ${EMSCRIPTEN_VERSION} VERSION_LESS "4.0.6")
-        message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported. Please upgrade to 4.0.6 or higher.")
-    endif ()
+            -sENVIRONMENT=web,worker -sEXPORT_ES6=1 -sASYNCIFY_STACK_SIZE=16384)
+    set(unsupported_emsdk_versions "4.0.11")
+    foreach (unsupported_version IN LISTS unsupported_emsdk_versions)
+        if (${EMSCRIPTEN_VERSION} VERSION_EQUAL ${unsupported_version})
+            message(FATAL_ERROR "Emscripten version ${EMSCRIPTEN_VERSION} is not supported.")
+        endif ()
+    endforeach ()
     if (EMSCRIPTEN_PTHREADS)
         list(APPEND H2D_LINK_OPTIONS -sUSE_PTHREADS=1 -sINITIAL_MEMORY=32MB -sALLOW_MEMORY_GROWTH=1
                 -sPTHREAD_POOL_SIZE=navigator.hardwareConcurrency -sPROXY_TO_PTHREAD=1

--- a/web/demo/index-st.html
+++ b/web/demo/index-st.html
@@ -13,6 +13,6 @@
 <div id="container" class="container">
     <canvas class="canvas" id="hello2d"></canvas>
 </div>
-<script type="module" src="./index-st.js"></script>
+<script type="module" src="./wasm/index-st.js"></script>
 </body>
 </html>

--- a/web/demo/index.html
+++ b/web/demo/index.html
@@ -13,6 +13,6 @@
 <div id="container" class="container">
     <canvas class="canvas" id="hello2d"></canvas>
 </div>
-<script type="module" src="./index.js"></script>
+<script type="module" src="./wasm-mt/index.js"></script>
 </body>
 </html>

--- a/web/script/rollup.demo.js
+++ b/web/script/rollup.demo.js
@@ -2,34 +2,31 @@ import esbuild from 'rollup-plugin-esbuild';
 import resolve from '@rollup/plugin-node-resolve';
 import commonJs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import path from "path";
+import {readFileSync} from "node:fs";
 
-const banner = `/////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//  Tencent is pleased to support the open source community by making tgfx available.
-//
-//  Copyright (C) 2023 Tencent. All rights reserved.
-//
-//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-//  in compliance with the License. You may obtain a copy of the License at
-//
-//      https://opensource.org/licenses/BSD-3-Clause
-//
-//  unless required by applicable law or agreed to in writing, software distributed under the
-//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
-//  either express or implied. see the license for the specific language governing permissions
-//  and limitations under the license.
-//
-/////////////////////////////////////////////////////////////////////////////////////////////////
-`;
+const fileHeaderPath = path.resolve(__dirname, '../../.idea/fileTemplates/includes/TGFX File Header.h');
+const banner = readFileSync(fileHeaderPath, 'utf-8');
 
 const arch = process.env.ARCH;
 var fileName = (arch === 'wasm-mt'? 'index': 'index-st');
+var filePath = (arch === 'wasm-mt'? 'wasm-mt': 'wasm');
 
 const plugins = [
     esbuild({tsconfig: "tsconfig.json", minify: false}),
     json(),
     resolve(),
     commonJs(),
+    {
+        name: 'preserve-import-meta-url',
+        resolveImportMeta(property, options) {
+            // Preserve the original behavior of `import.meta.url`.
+            if (property === 'url') {
+                return 'import.meta.url';
+            }
+            return null;
+        },
+    },
 ];
 
 export default [
@@ -37,7 +34,7 @@ export default [
         input: `demo/${fileName}.ts`,
         output: {
             banner,
-            file: `demo/${fileName}.js`,
+            file: `demo/${filePath}/${fileName}.js`,
             format: 'esm',
             sourcemap: true
         },

--- a/web/script/rollup.dev.js
+++ b/web/script/rollup.dev.js
@@ -2,25 +2,11 @@ import esbuild from 'rollup-plugin-esbuild';
 import resolve from '@rollup/plugin-node-resolve';
 import commonJs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
+import path from "path";
+import {readFileSync} from "node:fs";
 
-const banner = `/////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//  Tencent is pleased to support the open source community by making tgfx available.
-//
-//  Copyright (C) 2023 Tencent. All rights reserved.
-//
-//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-//  in compliance with the License. You may obtain a copy of the License at
-//
-//      https://opensource.org/licenses/BSD-3-Clause
-//
-//  unless required by applicable law or agreed to in writing, software distributed under the
-//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
-//  either express or implied. see the license for the specific language governing permissions
-//  and limitations under the license.
-//
-/////////////////////////////////////////////////////////////////////////////////////////////////
-`;
+const fileHeaderPath = path.resolve(__dirname, '../../.idea/fileTemplates/includes/TGFX File Header.h');
+const banner = readFileSync(fileHeaderPath, 'utf-8');
 
 const arch = process.env.ARCH;
 var fileName = (arch === 'wasm-mt'? 'index': 'index-st');
@@ -30,6 +16,16 @@ const plugins = [
     json(),
     resolve(),
     commonJs(),
+    {
+        name: 'preserve-import-meta-url',
+        resolveImportMeta(property, options) {
+            // Preserve the original behavior of `import.meta.url`.
+            if (property === 'url') {
+                return 'import.meta.url';
+            }
+            return null;
+        },
+    },
 ];
 
 export default [

--- a/web/script/rollup.tgfx.js
+++ b/web/script/rollup.tgfx.js
@@ -3,25 +3,31 @@ import commonJs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import {terser} from 'rollup-plugin-terser';
 import esbuild from 'rollup-plugin-esbuild';
+import path from "path";
+import {readFileSync} from "node:fs";
 
-const banner = `/////////////////////////////////////////////////////////////////////////////////////////////////
-//
-//  Tencent is pleased to support the open source community by making tgfx available.
-//
-//  Copyright (C) 2023 Tencent. All rights reserved.
-//
-//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
-//  in compliance with the License. You may obtain a copy of the License at
-//
-//      https://opensource.org/licenses/BSD-3-Clause
-//
-//  unless required by applicable law or agreed to in writing, software distributed under the
-//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
-//  either express or implied. see the license for the specific language governing permissions
-//  and limitations under the license.
-//
-/////////////////////////////////////////////////////////////////////////////////////////////////
-`;
+const fileHeaderPath = path.resolve(__dirname, '../../.idea/fileTemplates/includes/TGFX File Header.h');
+const banner = readFileSync(fileHeaderPath, 'utf-8');
+
+const plugins = [
+    esbuild({
+        tsconfig: 'tsconfig.json',
+        minify: false,
+    }),
+    json(),
+    resolve(),
+    commonJs(),
+    {
+        name: 'preserve-import-meta-url',
+        resolveImportMeta(property, options) {
+            // Preserve the original behavior of `import.meta.url`.
+            if (property === 'url') {
+                return 'import.meta.url';
+            }
+            return null;
+        },
+    },
+];
 
 const umdConfig = {
     input: 'src/binding.ts',
@@ -35,15 +41,7 @@ const umdConfig = {
             file: 'lib/tgfx.js',
         },
     ],
-    plugins: [
-        esbuild({
-            tsconfig: 'tsconfig.json',
-            minify: false,
-        }),
-        json(),
-        resolve(),
-        commonJs(),
-    ],
+    plugins: plugins,
 };
 
 const umdMinConfig = {
@@ -59,13 +57,7 @@ const umdMinConfig = {
         },
     ],
     plugins: [
-        esbuild({
-            tsconfig: 'tsconfig.json',
-            minify: false,
-        }),
-        json(),
-        resolve(),
-        commonJs(),
+        ...plugins,
         terser(),
     ],
 };
@@ -79,14 +71,6 @@ export default [
             {banner, file: 'lib/tgfx.esm.js', format: 'esm', sourcemap: true},
             {banner, file: 'lib/tgfx.cjs.js', format: 'cjs', exports: 'auto', sourcemap: true},
         ],
-        plugins: [
-            esbuild({
-                tsconfig: 'tsconfig.json',
-                minify: false
-            }),
-            json(),
-            resolve(),
-            commonJs()
-        ],
+        plugins: plugins,
     },
 ];


### PR DESCRIPTION
1、使用emsdk编译web时默认开启import.meta，并针对import.meta做兼容性适配
2、添加emsdk版本检查，遇到不支持的版本时结束构建
3、更新README.md，编译多线程web版本时添加用户说明