### PR TITLE
Add OpenHarmony build steps and update compatible SDK version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,22 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Platform to build (optional, leave empty to build all)'
+        required: false
+        type: choice
+        options:
+          - all
+          - ios
+          - android
+          - web
+          - win
+          - linux
+          - qt
+          - openharmony
+        default: 'all'
 
 jobs:
   ios:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,3 +340,94 @@ jobs:
         with:
           name: qt_build
           path: out
+
+
+  openharmony:
+    runs-on: macos-latest
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Get CLI Tools Cache
+        id: cli-tools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /opt/ohos-cmd-tools
+          key: ohos-cli-5.0.9.310-mac-arm64
+          restore-keys: ohos-cli-
+
+      - name: Install CLI Tools
+        if: steps.cli-tools-cache.outputs.cache-hit != 'true'
+        run: |
+          TOOLS_URL="https://pag.io/file/sdk/commandline-tools-mac-arm64-5.0.9.310.zip"
+          curl -L -o /tmp/cmdtools.zip "$TOOLS_URL"
+          unzip -q /tmp/cmdtools.zip -d /tmp
+          sudo mv /tmp/command-line-tools /opt/ohos-cmd-tools
+
+      - name: Save CLI Tools Cache
+        if: ${{ (github.event_name == 'push') && (steps.cli-tools-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: /opt/ohos-cmd-tools
+          key: ohos-cli-5.0.9.310-mac-arm64
+
+      - name: Configure Environment
+        run: |
+          CLI_DIR=/opt/ohos-cmd-tools
+          echo "$CLI_DIR/sdk/default/openharmony/toolchains" >> $GITHUB_PATH
+          echo "$CLI_DIR/ohpm/bin"                       >> $GITHUB_PATH
+          echo "$CLI_DIR/hvigor/bin"                     >> $GITHUB_PATH
+          echo "DEVECO_SDK_HOME=$CLI_DIR/sdk"            >> $GITHUB_ENV
+          echo "JAVA_HOME=$JAVA_HOME"                    >> $GITHUB_ENV
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup pnpm
+        run: |
+          npm install -g pnpm@8.13.1
+          echo "$(npm prefix -g)/bin" >> $GITHUB_PATH
+
+      - name: Get Third-Party Cache
+        id: third-party-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: third_party
+          key: third-party-openharmony-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}
+          restore-keys: third-party-openharmony-
+
+      - name: Run depsync
+        run: |
+          npm install depsync -g
+          depsync
+
+      - name: Install ohpm dependencies
+        run: |
+          cd ohos
+          ohpm config set registry https://ohpm.openharmony.cn/ohpm/
+          ohpm install --all
+
+      - name: Build Harmony
+        run: |
+          cd ohos
+          hvigorw clean --no-daemon -Dohos.sdk.root=$DEVECO_SDK_HOME
+          hvigorw assembleHap -Dohos.sdk.root=$DEVECO_SDK_HOME -p buildMode=release --no-daemon
+
+      - name: Save Third-Party Cache
+        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: third_party
+          key: third-party-openharmony-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}
+
+      - name: Job Failed
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: openharmony_build
+          path: ohos/out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,22 +5,6 @@ on:
     branches: [ main ]
   push:
     branches: [ main ]
-  workflow_dispatch:
-    inputs:
-      platform:
-        description: 'Platform to build (optional, leave empty to build all)'
-        required: false
-        type: choice
-        options:
-          - all
-          - ios
-          - android
-          - web
-          - win
-          - linux
-          - qt
-          - openharmony
-        default: 'all'
 
 jobs:
   ios:

--- a/ohos/build-profile.json5
+++ b/ohos/build-profile.json5
@@ -5,7 +5,7 @@
       {
         "name": "default",
         "signingConfig": "default",
-        "compatibleSdkVersion": "5.0.0(12)",
+        "compatibleSdkVersion": "5.0.3(15)",
         "runtimeOS": "HarmonyOS",
       }
     ],


### PR DESCRIPTION
**OpenHarmony CI integration:**

* Added a new `openharmony` job to `.github/workflows/build.yml` that automates environment setup, dependency installation, and build steps for OpenHarmony on macOS, including caching for CLI tools and third-party dependencies.

**SDK version update:**

* Updated `compatibleSdkVersion` from `5.0.0(12)` to `5.0.3(15)` in `ohos/build-profile.json5` to ensure compatibility with the latest HarmonyOS SDK.