### PR TITLE
Apply color filters early when drawing simple shapes.

### DIFF
--- a/include/tgfx/core/ColorFilter.h
+++ b/include/tgfx/core/ColorFilter.h
@@ -99,6 +99,12 @@ class ColorFilter {
     return false;
   }
 
+  /**
+   * Try apply the filter to the specified color and return the filtered color or nullopt when failed.
+   * All colors are in non-premultiplied alpha format.
+   */
+  [[nodiscard]] virtual std::optional<Color> tryFilterColor(const Color& input) const = 0;
+
  protected:
   enum class Type { Blend, Matrix, AlphaThreshold, Compose, Luma };
 

--- a/src/core/filters/AlphaThresholdColorFilter.cpp
+++ b/src/core/filters/AlphaThresholdColorFilter.cpp
@@ -27,6 +27,16 @@ std::shared_ptr<ColorFilter> ColorFilter::AlphaThreshold(float threshold) {
   return std::make_shared<AlphaThresholdColorFilter>(threshold);
 }
 
+std::optional<Color> AlphaThresholdColorFilter::tryFilterColor(const Color& input) const {
+  if (input.alpha >= threshold) {
+    return Color(input.red, input.green, input.blue, 1.0f);
+  } else {
+    // When the generated color’s alpha is 0, premultiplication can zero out all channels, causing
+    // data loss and computation errors.
+    return std::nullopt;
+  }
+}
+
 bool AlphaThresholdColorFilter::isEqual(const ColorFilter* colorFilter) const {
   auto type = Types::Get(colorFilter);
   if (type != Types::ColorFilterType::AlphaThreshold) {

--- a/src/core/filters/AlphaThresholdColorFilter.h
+++ b/src/core/filters/AlphaThresholdColorFilter.h
@@ -25,6 +25,8 @@ class AlphaThresholdColorFilter : public ColorFilter {
  public:
   explicit AlphaThresholdColorFilter(float threshold) : threshold(threshold){};
 
+  [[nodiscard]] std::optional<Color> tryFilterColor(const Color& input) const override;
+
   float threshold = 0.0f;
 
  protected:

--- a/src/core/filters/ComposeColorFilter.cpp
+++ b/src/core/filters/ComposeColorFilter.cpp
@@ -44,6 +44,14 @@ bool ComposeColorFilter::isAlphaUnchanged() const {
   return outer->isAlphaUnchanged() && inner->isAlphaUnchanged();
 }
 
+std::optional<Color> ComposeColorFilter::tryFilterColor(const Color& input) const {
+  std::optional<Color> innerResult = inner->tryFilterColor(input);
+  if (innerResult == std::nullopt) {
+    return std::nullopt;
+  }
+  return outer->tryFilterColor(*innerResult);
+}
+
 bool ComposeColorFilter::isEqual(const ColorFilter* colorFilter) const {
   auto type = Types::Get(colorFilter);
   if (type != Types::ColorFilterType::Compose) {

--- a/src/core/filters/ComposeColorFilter.h
+++ b/src/core/filters/ComposeColorFilter.h
@@ -28,6 +28,8 @@ class ComposeColorFilter : public ColorFilter {
 
   bool isAlphaUnchanged() const override;
 
+  [[nodiscard]] std::optional<Color> tryFilterColor(const Color& input) const override;
+
   std::shared_ptr<ColorFilter> inner = nullptr;
   std::shared_ptr<ColorFilter> outer = nullptr;
 

--- a/src/core/filters/LumaColorFilter.cpp
+++ b/src/core/filters/LumaColorFilter.cpp
@@ -29,4 +29,13 @@ PlacementPtr<FragmentProcessor> LumaColorFilter::asFragmentProcessor(Context* co
   return LumaFragmentProcessor::Make(context->drawingBuffer());
 }
 
+std::optional<Color> LumaColorFilter::tryFilterColor(const Color& input) const {
+  /** See ITU-R Recommendation BT.709 at http://www.itu.int/rec/R-REC-BT.709/ .*/
+  // Must use premultiplied color to compute luma. Othereise, use 'MatrixColorFilter' instead.
+  const Color pmColor = input.premultiply();
+  float luma = pmColor.red * 0.2126f + pmColor.green * 0.7152f + pmColor.blue * 0.0722f;
+  // Return non-premultiplied RGBA color.
+  return Color(1.0f, 1.0f, 1.0f, luma);
+}
+
 }  // namespace tgfx

--- a/src/core/filters/LumaColorFilter.h
+++ b/src/core/filters/LumaColorFilter.h
@@ -26,6 +26,9 @@ namespace tgfx {
  * while LumaFilter uses premultiplied RGBA.
  */
 class LumaColorFilter : public ColorFilter {
+ public:
+  [[nodiscard]] std::optional<Color> tryFilterColor(const Color& input) const override;
+
  protected:
   Type type() const override {
     return Type::Luma;

--- a/src/core/filters/MatrixColorFilter.cpp
+++ b/src/core/filters/MatrixColorFilter.cpp
@@ -37,6 +37,24 @@ MatrixColorFilter::MatrixColorFilter(const std::array<float, 20>& matrix)
     : matrix(matrix), alphaIsUnchanged(IsAlphaUnchanged(matrix.data())) {
 }
 
+std::optional<Color> MatrixColorFilter::tryFilterColor(const Color& input) const {
+  Color transformedColor;
+  transformedColor.red = matrix[0] * input.red + matrix[1] * input.green + matrix[2] * input.blue +
+                         matrix[3] * input.alpha + matrix[4];
+  transformedColor.green = matrix[5] * input.red + matrix[6] * input.green +
+                           matrix[7] * input.blue + matrix[8] * input.alpha + matrix[9];
+  transformedColor.blue = matrix[10] * input.red + matrix[11] * input.green +
+                          matrix[12] * input.blue + matrix[13] * input.alpha + matrix[14];
+  transformedColor.alpha = matrix[15] * input.red + matrix[16] * input.green +
+                           matrix[17] * input.blue + matrix[18] * input.alpha + matrix[19];
+
+  transformedColor.red = std::clamp(transformedColor.red, 0.0f, 1.0f);
+  transformedColor.green = std::clamp(transformedColor.green, 0.0f, 1.0f);
+  transformedColor.blue = std::clamp(transformedColor.blue, 0.0f, 1.0f);
+  transformedColor.alpha = std::clamp(transformedColor.alpha, 0.0f, 1.0f);
+  return std::optional<Color>(transformedColor);
+}
+
 bool MatrixColorFilter::isEqual(const ColorFilter* colorFilter) const {
   auto type = Types::Get(colorFilter);
   if (type != Types::ColorFilterType::Matrix) {

--- a/src/core/filters/MatrixColorFilter.h
+++ b/src/core/filters/MatrixColorFilter.h
@@ -29,6 +29,8 @@ class MatrixColorFilter : public ColorFilter {
     return alphaIsUnchanged;
   }
 
+  [[nodiscard]] std::optional<Color> tryFilterColor(const Color& input) const override;
+
   std::array<float, 20> matrix;
   bool alphaIsUnchanged;
 

--- a/src/core/filters/ModeColorFilter.cpp
+++ b/src/core/filters/ModeColorFilter.cpp
@@ -59,6 +59,12 @@ bool ModeColorFilter::asColorMode(Color* color, BlendMode* mode) const {
   return true;
 }
 
+std::optional<Color> ModeColorFilter::tryFilterColor(const Color& input) const {
+  (void)input;
+  // Blend logic do not support to be applied immediately.
+  return std::nullopt;
+}
+
 bool ModeColorFilter::isEqual(const ColorFilter* colorFilter) const {
   auto type = Types::Get(colorFilter);
   if (type != Types::ColorFilterType::Blend) {

--- a/src/core/filters/ModeColorFilter.h
+++ b/src/core/filters/ModeColorFilter.h
@@ -31,6 +31,8 @@ class ModeColorFilter : public ColorFilter {
 
   bool asColorMode(Color* color, BlendMode* mode) const override;
 
+  [[nodiscard]] std::optional<Color> tryFilterColor(const Color& input) const override;
+
   Color color;
   BlendMode mode;
 

--- a/src/gpu/opengl/GLBlend.cpp
+++ b/src/gpu/opengl/GLBlend.cpp
@@ -446,12 +446,12 @@ static void CoeffHandler_ONE_MINUS_SRC1_COLOR(FragmentShaderBuilder* fsBuilder, 
 
 static void CoeffHandler_SRC1_ALPHA(FragmentShaderBuilder* fsBuilder, const char*,
                                     const char* src1ColorName, const char*) {
-  fsBuilder->codeAppendf(" * (vec4(1.0) - %s);", src1ColorName);
+  fsBuilder->codeAppendf(" * %s.a;", src1ColorName);
 }
 
 static void CoeffHandler_ONE_MINUS_SRC1_ALPHA(FragmentShaderBuilder* fsBuilder, const char*,
                                               const char* src1ColorName, const char*) {
-  fsBuilder->codeAppendf(" * (vec4(1.0) - %s);", src1ColorName);
+  fsBuilder->codeAppendf(" * (1.0 - %s.a);", src1ColorName);
 }
 
 using CoeffHandler = void (*)(FragmentShaderBuilder* fsBuilder, const char* srcColorName,

--- a/src/gpu/opengl/processors/GLLumaFragmentProcessor.cpp
+++ b/src/gpu/opengl/processors/GLLumaFragmentProcessor.cpp
@@ -27,7 +27,7 @@ PlacementPtr<FragmentProcessor> LumaFragmentProcessor::Make(BlockBuffer* buffer)
 void GLLumaFragmentProcessor::emitCode(EmitArgs& args) const {
   /** See ITU-R Recommendation BT.709 at http://www.itu.int/rec/R-REC-BT.709/ .*/
   args.fragBuilder->codeAppendf("float luma = dot(%s.rgb, vec3(0.2126, 0.7152, 0.0722));\n",
-                                args.inputColor.c_str(), args.inputColor.c_str());
+                                args.inputColor.c_str());
   args.fragBuilder->codeAppendf("%s = vec4(luma);\n", args.outputColor.c_str());
 }
 

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -190,7 +190,7 @@
         "PartialBackgroundBlur": "ee2cc771",
         "PartialBackgroundBlur_move": "cebc420b",
         "PartialBackgroundBlur_partial": "cebc420b",
-        "PartialDrawLayer": "572ae96b",
+        "PartialDrawLayer": "e41ab83d",
         "PartialInnerShadow": "9a05dc38",
         "PassThoughAndNormal": "43cd416",
         "RasterizedCache": "cebc420b",


### PR DESCRIPTION
Apply color filters ahead of time for simple shapes (rectangle, rounded rectangle, vector graphics, text glyphs) to eliminate redundant fragment shader color operations and improve rendering performance.