### PR TITLE
Fix the issue of exporting FilterImage and PictureImage as bitmaps in SVGs instead of as SVG elements.

### DIFF
--- a/src/core/images/FilterImage.h
+++ b/src/core/images/FilterImage.h
@@ -43,6 +43,8 @@ class FilterImage : public SubsetImage {
     return static_cast<int>(bounds.height());
   }
 
+  std::shared_ptr<ImageFilter> filter = nullptr;
+
  protected:
   Type type() const override {
     return Type::Filter;
@@ -68,8 +70,6 @@ class FilterImage : public SubsetImage {
                                                       const Matrix* uvMatrix) const override;
 
  private:
-  std::shared_ptr<ImageFilter> filter = nullptr;
-
   static std::shared_ptr<Image> Wrap(std::shared_ptr<Image> source, const Rect& bounds,
                                      std::shared_ptr<ImageFilter> filter);
 };

--- a/src/svg/ElementWriter.cpp
+++ b/src/svg/ElementWriter.cpp
@@ -17,14 +17,8 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "ElementWriter.h"
-#include <iostream>
-#include <memory>
-#include <string>
-#include <tuple>
-#include <unordered_set>
 #include "SVGExportContext.h"
 #include "SVGUtils.h"
-#include "core/CanvasState.h"
 #include "core/codecs/jpeg/JpegCodec.h"
 #include "core/codecs/png/PngCodec.h"
 #include "core/filters/ComposeImageFilter.h"
@@ -40,7 +34,6 @@
 #include "tgfx/core/Pixmap.h"
 #include "tgfx/core/Rect.h"
 #include "tgfx/core/Shader.h"
-#include "tgfx/core/Size.h"
 #include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Context.h"
 #include "tgfx/svg/SVGPathParser.h"

--- a/src/svg/ElementWriter.cpp
+++ b/src/svg/ElementWriter.cpp
@@ -276,13 +276,14 @@ std::string ElementWriter::addImageFilter(const std::shared_ptr<ImageFilter>& im
     }
     case Types::ImageFilterType::Compose: {
       const auto* composeFilter = static_cast<const ComposeImageFilter*>(imageFilter.get());
+      std::string filterID;
       for (const auto& filterItem : composeFilter->filters) {
         auto id = addImageFilter(filterItem, bound);
         if (!id.empty()) {
-          return id;
+          filterID = id;
         }
       }
-      return "";
+      return filterID;
     }
     default:
       reportUnsupportedElement("Unsupported image filter");

--- a/src/svg/ElementWriter.cpp
+++ b/src/svg/ElementWriter.cpp
@@ -17,14 +17,17 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "ElementWriter.h"
+#include <iostream>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include "SVGExportContext.h"
 #include "SVGUtils.h"
 #include "core/CanvasState.h"
 #include "core/codecs/jpeg/JpegCodec.h"
 #include "core/codecs/png/PngCodec.h"
+#include "core/filters/ComposeImageFilter.h"
 #include "core/filters/GaussianBlurImageFilter.h"
 #include "core/filters/ShaderMaskFilter.h"
 #include "core/shaders/MatrixShader.h"
@@ -226,54 +229,72 @@ void ElementWriter::addPathAttributes(const Path& path, SVGPathParser::PathEncod
 
 Resources ElementWriter::addImageFilterResource(const std::shared_ptr<ImageFilter>& imageFilter,
                                                 Rect bound) {
-  std::string filterID = resourceStore->addFilter();
-  {
-    ElementWriter filterElement("filter", writer);
-    filterElement.addAttribute("id", filterID);
-    auto type = Types::Get(imageFilter.get());
-    switch (type) {
-      case Types::ImageFilterType::Blur: {
-        auto blurFilter = static_cast<const GaussianBlurImageFilter*>(imageFilter.get());
-        bound = blurFilter->filterBounds(bound);
-        filterElement.addAttribute("x", bound.x());
-        filterElement.addAttribute("y", bound.y());
-        filterElement.addAttribute("width", bound.width());
-        filterElement.addAttribute("height", bound.height());
-        filterElement.addAttribute("filterUnits", "userSpaceOnUse");
-        addBlurImageFilter(blurFilter);
-        break;
-      }
-      case Types::ImageFilterType::DropShadow: {
-        auto dropShadowFilter = static_cast<const DropShadowImageFilter*>(imageFilter.get());
-        bound = dropShadowFilter->filterBounds(bound);
-        filterElement.addAttribute("x", bound.x());
-        filterElement.addAttribute("y", bound.y());
-        filterElement.addAttribute("width", bound.width());
-        filterElement.addAttribute("height", bound.height());
-        filterElement.addAttribute("filterUnits", "userSpaceOnUse");
-        addDropShadowImageFilter(dropShadowFilter);
-        break;
-      }
-      case Types::ImageFilterType::InnerShadow: {
-        auto innerShadowFilter = static_cast<const InnerShadowImageFilter*>(imageFilter.get());
-        bound = innerShadowFilter->filterBounds(bound);
-        filterElement.addAttribute("x", bound.x());
-        filterElement.addAttribute("y", bound.y());
-        filterElement.addAttribute("width", bound.width() + innerShadowFilter->dx);
-        filterElement.addAttribute("height", bound.height() + innerShadowFilter->dy);
-        filterElement.addAttribute("filterUnits", "userSpaceOnUse");
-        addInnerShadowImageFilter(innerShadowFilter);
-        break;
-      }
-      default:
-        // TODO (YGaurora): The compose filter can be expanded into multiple filters for export. This
-        // can be implemented.
-        reportUnsupportedElement("Unsupported image filter");
-    }
-  }
+  auto filterID = addImageFilter(imageFilter, bound);
   Resources resources;
   resources.filter = "url(#" + filterID + ")";
   return resources;
+}
+
+std::string ElementWriter::addImageFilter(const std::shared_ptr<ImageFilter>& imageFilter,
+                                          Rect bound) {
+  auto type = Types::Get(imageFilter.get());
+  switch (type) {
+    case Types::ImageFilterType::Blur: {
+      const auto* blurFilter = static_cast<const GaussianBlurImageFilter*>(imageFilter.get());
+      bound = blurFilter->filterBounds(bound);
+      std::string filterID = resourceStore->addFilter();
+      ElementWriter filterElement("filter", writer);
+      filterElement.addAttribute("id", filterID);
+      filterElement.addAttribute("x", bound.x());
+      filterElement.addAttribute("y", bound.y());
+      filterElement.addAttribute("width", bound.width());
+      filterElement.addAttribute("height", bound.height());
+      filterElement.addAttribute("filterUnits", "userSpaceOnUse");
+      addBlurImageFilter(blurFilter);
+      return filterID;
+    }
+    case Types::ImageFilterType::DropShadow: {
+      const auto* dropShadowFilter = static_cast<const DropShadowImageFilter*>(imageFilter.get());
+      bound = dropShadowFilter->filterBounds(bound);
+      std::string filterID = resourceStore->addFilter();
+      ElementWriter filterElement("filter", writer);
+      filterElement.addAttribute("id", filterID);
+      filterElement.addAttribute("x", bound.x());
+      filterElement.addAttribute("y", bound.y());
+      filterElement.addAttribute("width", bound.width());
+      filterElement.addAttribute("height", bound.height());
+      filterElement.addAttribute("filterUnits", "userSpaceOnUse");
+      addDropShadowImageFilter(dropShadowFilter);
+      return filterID;
+    }
+    case Types::ImageFilterType::InnerShadow: {
+      const auto* innerShadowFilter = static_cast<const InnerShadowImageFilter*>(imageFilter.get());
+      bound = innerShadowFilter->filterBounds(bound);
+      std::string filterID = resourceStore->addFilter();
+      ElementWriter filterElement("filter", writer);
+      filterElement.addAttribute("id", filterID);
+      filterElement.addAttribute("x", bound.x());
+      filterElement.addAttribute("y", bound.y());
+      filterElement.addAttribute("width", bound.width() + innerShadowFilter->dx);
+      filterElement.addAttribute("height", bound.height() + innerShadowFilter->dy);
+      filterElement.addAttribute("filterUnits", "userSpaceOnUse");
+      addInnerShadowImageFilter(innerShadowFilter);
+      return filterID;
+    }
+    case Types::ImageFilterType::Compose: {
+      const auto* composeFilter = static_cast<const ComposeImageFilter*>(imageFilter.get());
+      for (const auto& filterItem : composeFilter->filters) {
+        auto id = addImageFilter(filterItem, bound);
+        if (!id.empty()) {
+          return id;
+        }
+      }
+      return "";
+    }
+    default:
+      reportUnsupportedElement("Unsupported image filter");
+      return "";
+  }
 }
 
 void ElementWriter::addBlurImageFilter(const GaussianBlurImageFilter* filter) {
@@ -284,9 +305,6 @@ void ElementWriter::addBlurImageFilter(const GaussianBlurImageFilter* filter) {
 }
 
 void ElementWriter::addDropShadowImageFilter(const DropShadowImageFilter* filter) {
-  if (!filter->blurFilter) {
-    return;
-  }
   {
     ElementWriter offsetElement("feOffset", writer);
     offsetElement.addAttribute("dx", filter->dx);
@@ -294,12 +312,16 @@ void ElementWriter::addDropShadowImageFilter(const DropShadowImageFilter* filter
   }
   {
     ElementWriter blurElement("feGaussianBlur", writer);
-    if (Types::Get(filter->blurFilter.get()) == Types::ImageFilterType::Blur) {
-      auto blurFilter = static_cast<const GaussianBlurImageFilter*>(filter->blurFilter.get());
-      blurElement.addAttribute("stdDeviation",
-                               std::max(blurFilter->blurrinessX, blurFilter->blurrinessY) / 2.f);
-      blurElement.addAttribute("result", "blur");
+    float blurriness = 0.f;
+    if (filter->blurFilter) {
+      if (Types::Get(filter->blurFilter.get()) == Types::ImageFilterType::Blur) {
+        const auto* blurFilter =
+            static_cast<const GaussianBlurImageFilter*>(filter->blurFilter.get());
+        blurriness = std::max(blurFilter->blurrinessX, blurFilter->blurrinessY) / 2.f;
+      }
     }
+    blurElement.addAttribute("stdDeviation", blurriness);
+    blurElement.addAttribute("result", "blur");
   }
   {
     ElementWriter colorMatrixElement("feColorMatrix", writer);

--- a/src/svg/ElementWriter.h
+++ b/src/svg/ElementWriter.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include "ResourceStore.h"
 #include "SVGUtils.h"
 #include "core/filters/DropShadowImageFilter.h"
@@ -105,6 +106,7 @@ class ElementWriter {
   std::string addRadialGradientDef(const GradientInfo& info, const Matrix& matrix);
   std::string addUnsupportedGradientDef(const GradientInfo& info, const Matrix& matrix);
 
+  std::string addImageFilter(const std::shared_ptr<ImageFilter>& imageFilter, Rect bound);
   void addBlurImageFilter(const GaussianBlurImageFilter* filter);
   void addDropShadowImageFilter(const DropShadowImageFilter* filter);
   void addInnerShadowImageFilter(const InnerShadowImageFilter* filter);

--- a/src/svg/ElementWriter.h
+++ b/src/svg/ElementWriter.h
@@ -18,11 +18,7 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <tuple>
 #include "ResourceStore.h"
-#include "SVGUtils.h"
 #include "core/filters/DropShadowImageFilter.h"
 #include "core/filters/GaussianBlurImageFilter.h"
 #include "core/filters/InnerShadowImageFilter.h"

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -17,12 +17,8 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "SVGExportContext.h"
-#include <cstdlib>
-#include <memory>
-#include <string>
 #include "ElementWriter.h"
 #include "SVGUtils.h"
-#include "core/CanvasState.h"
 #include "core/images/CodecImage.h"
 #include "core/images/FilterImage.h"
 #include "core/images/PictureImage.h"
@@ -43,7 +39,6 @@
 #include "tgfx/core/Point.h"
 #include "tgfx/core/RRect.h"
 #include "tgfx/core/Rect.h"
-#include "tgfx/core/Size.h"
 #include "tgfx/core/Stroke.h"
 #include "tgfx/core/Surface.h"
 #include "tgfx/core/TileMode.h"

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -303,6 +303,7 @@
         "DrawImageRect": "9a80633b",
         "ImageMask": "9a80633b",
         "InvertPictureImageMask": "9a80633b",
+        "LayerDropShadow": "a78e535d",
         "PictureImageMask": "9a80633b"
     },
     "SVGTest": {

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -683,18 +683,10 @@ TGFX_TEST(SVGExportTest, DrawImageRect) {
   canvas->drawImageRect(image, srcRect, dstRect, SamplingOptions(FilterMode::Linear));
 
   exporter->close();
-  // EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/DrawImageRect"));
-
-  auto SVGString = SVGStream->readString();
-  auto path = ProjectPath::Absolute("resources/apitest/SVG/drawImageRect.svg");
-  auto readStream = Stream::MakeFromFile(path);
-  EXPECT_TRUE(readStream != nullptr);
-  Buffer buffer(readStream->size());
-  readStream->read(buffer.data(), buffer.size());
-  EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), SVGString);
+  EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/DrawImageRect"));
 }
 
-TGFX_TEST(SVGExportTest, LayerDropShadow) {
+TGFX_TEST(SVGExportTest, LayerShadow) {
   ContextScope scope;
   auto* context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -710,7 +702,6 @@ TGFX_TEST(SVGExportTest, LayerDropShadow) {
 
   auto dropShadowLayer = ShapeLayer::Make();
   auto dropShadowStyle = DropShadowStyle::Make(10, 10, 10, 10, Color::White(), false);
-  // auto style = InnerShadowStyle::Make(10, 10, 10, 10, Color::White());
   Path rect;
   rect.addRect(Rect::MakeWH(50, 50));
   dropShadowLayer->setPath(rect);

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -22,6 +22,7 @@
 #include "gtest/gtest.h"
 #include "tgfx/core/Buffer.h"
 #include "tgfx/core/Color.h"
+#include "tgfx/core/Matrix.h"
 #include "tgfx/core/Paint.h"
 #include "tgfx/core/Path.h"
 #include "tgfx/core/Recorder.h"
@@ -32,6 +33,7 @@
 #include "tgfx/layers/ShapeLayer.h"
 #include "tgfx/layers/SolidColor.h"
 #include "tgfx/layers/layerstyles/DropShadowStyle.h"
+#include "tgfx/layers/layerstyles/InnerShadowStyle.h"
 #include "tgfx/svg/SVGExporter.h"
 #include "utils/TestUtils.h"
 
@@ -719,10 +721,7 @@ TGFX_TEST(SVGExportTest, LayerDropShadow) {
   EXPECT_TRUE(context != nullptr);
 
   auto SVGStream = MemoryWriteStream::Make();
-
-  int width = 400;
-  int height = 400;
-  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(width, height));
+  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(400, 400));
   auto* canvas = exporter->getCanvas();
 
   auto displayList = std::make_unique<DisplayList>();
@@ -730,14 +729,23 @@ TGFX_TEST(SVGExportTest, LayerDropShadow) {
   auto rootLayer = Layer::Make();
   rootLayer->setMatrix(Matrix::MakeTrans(30, 30));
 
-  auto rectLayer = ShapeLayer::Make();
-  auto style = DropShadowStyle::Make(10, 10, 10, 10, Color::White(), false);
+  auto dropShadowLayer = ShapeLayer::Make();
+  auto dropShadowStyle = DropShadowStyle::Make(10, 10, 10, 10, Color::White(), false);
+  // auto style = InnerShadowStyle::Make(10, 10, 10, 10, Color::White());
   Path rect;
   rect.addRect(Rect::MakeWH(50, 50));
-  rectLayer->setPath(rect);
-  rectLayer->setFillStyle(SolidColor::Make(Color::Red()));
-  rectLayer->setLayerStyles({style});
-  rootLayer->addChild(rectLayer);
+  dropShadowLayer->setPath(rect);
+  dropShadowLayer->setFillStyle(SolidColor::Make(Color::Red()));
+  dropShadowLayer->setLayerStyles({dropShadowStyle});
+  rootLayer->addChild(dropShadowLayer);
+
+  auto innerShadowLayer = ShapeLayer::Make();
+  auto innerShadowStyle = InnerShadowStyle::Make(10, 10, 10, 10, Color::White());
+  innerShadowLayer->setMatrix(Matrix::MakeTrans(200, 0));
+  innerShadowLayer->setPath(rect);
+  innerShadowLayer->setFillStyle(SolidColor::Make(Color::Red()));
+  innerShadowLayer->setLayerStyles({innerShadowStyle});
+  rootLayer->addChild(innerShadowLayer);
 
   displayList->root()->addChild(rootLayer);
   displayList->root()->draw(canvas);


### PR DESCRIPTION
先将FilterImage、PictureImage等分解然后再导出为SVG，而不是将Image直接以位图导出为SVG元素。