### PR TITLE
Exclude italic variants when generating the stroke glyph atlas.

### DIFF
--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -108,7 +108,14 @@ static std::shared_ptr<ImageCodec> GetGlyphCodec(
                                              stroke);
   }
 
-  auto shape = Shape::MakeFrom(font, glyphID);
+  std::shared_ptr<Shape> shape = nullptr;
+  if (!font.isFauxItalic()) {
+    shape = Shape::MakeFrom(font, glyphID);
+  }else {
+    auto noItalicFont = font;
+    noItalicFont.setFauxItalic(false);
+    shape = Shape::MakeFrom(std::move(noItalicFont), glyphID);
+  }
   if (shape == nullptr) {
     return nullptr;
   }

--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -42,7 +42,7 @@ static void ComputeAtlasKey(const Font& font, const std::shared_ptr<ScalerContex
                             uint32_t typefaceID, GlyphID glyphID, const Stroke* stroke,
                             BytesKey& key) {
   key.write(typefaceID);
-  key.write(std::roundf(scalerContext->getBackingSize()));
+  key.write(scalerContext->getBackingSize());
   if (font.hasColor()) {
     key.write(glyphID);
     return;
@@ -111,7 +111,7 @@ static std::shared_ptr<ImageCodec> GetGlyphCodec(
   std::shared_ptr<Shape> shape = nullptr;
   if (!font.isFauxItalic()) {
     shape = Shape::MakeFrom(font, glyphID);
-  }else {
+  } else {
     auto noItalicFont = font;
     noItalicFont.setFauxItalic(false);
     shape = Shape::MakeFrom(std::move(noItalicFont), glyphID);


### PR DESCRIPTION
1.斜体描边文字生成图集是忽略斜体
2.修改之前重构引入的图集 key 计算的一处笔误