### PR TITLE
Make resource cleanup more efficient by using a pending purge queue to check only released resources.

### DIFF
--- a/src/gpu/ResourceCache.h
+++ b/src/gpu/ResourceCache.h
@@ -27,6 +27,7 @@
 
 namespace tgfx {
 class Resource;
+class PendingPurgeResourceQueue;
 
 /**
  * Manages the lifetime of all Resource instances.
@@ -127,6 +128,7 @@ class ResourceCache {
   size_t _expirationFrames = 120;
   std::chrono::steady_clock::time_point currentFrameTime = {};
   std::deque<std::chrono::steady_clock::time_point> frameTimes = {};
+  std::shared_ptr<PendingPurgeResourceQueue> unreferencedResourceQueue;
   std::list<Resource*> nonpurgeableResources = {};
   std::list<Resource*> purgeableResources = {};
   ResourceKeyMap<std::vector<Resource*>> scratchKeyMap = {};
@@ -135,10 +137,12 @@ class ResourceCache {
   static void AddToList(std::list<Resource*>& list, Resource* resource);
   static void RemoveFromList(std::list<Resource*>& list, Resource* resource);
   static bool InList(const std::list<Resource*>& list, Resource* resource);
+  static void NotifyReferenceReachedZero(Resource* resource);
 
   void releaseAll(bool releaseGPU);
   void purgeAsNeeded();
   void processUnreferencedResources();
+  std::shared_ptr<Resource> wrapResource(Resource* resource);
   std::shared_ptr<Resource> addResource(Resource* resource, const ScratchKey& scratchKey);
   std::shared_ptr<Resource> refResource(Resource* resource);
   void removeResource(Resource* resource);

--- a/src/gpu/resources/PendingPurgeResourceQueue.cpp
+++ b/src/gpu/resources/PendingPurgeResourceQueue.cpp
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making tgfx available.
 //
-//  Copyright (C) 2023 Tencent. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at
@@ -16,29 +16,20 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "Resource.h"
+#include "PendingPurgeResourceQueue.h"
+#include "gpu/resources/Resource.h"
 
 namespace tgfx {
-void Resource::assignUniqueKey(const UniqueKey& newKey) {
-  if (newKey.empty()) {
-    removeUniqueKey();
-    return;
-  }
-  if (newKey != uniqueKey) {
-    context->resourceCache()->changeUniqueKey(this, newKey);
+
+PendingPurgeResourceQueue::~PendingPurgeResourceQueue() {
+  Resource* resource = nullptr;
+  while (pendingQueue.try_dequeue(resource)) {
+    delete resource;
   }
 }
 
-void Resource::removeUniqueKey() {
-  if (!uniqueKey.empty()) {
-    context->resourceCache()->removeUniqueKey(this);
-  }
+void PendingPurgeResourceQueue::add(Resource* resource) {
+  pendingQueue.enqueue(resource);
 }
 
-void Resource::release(bool releaseGPU) {
-  if (releaseGPU) {
-    onReleaseGPU();
-  }
-  context = nullptr;
-}
 }  // namespace tgfx

--- a/src/gpu/resources/PendingPurgeResourceQueue.h
+++ b/src/gpu/resources/PendingPurgeResourceQueue.h
@@ -2,7 +2,7 @@
 //
 //  Tencent is pleased to support the open source community by making tgfx available.
 //
-//  Copyright (C) 2023 Tencent. All rights reserved.
+//  Copyright (C) 2025 Tencent. All rights reserved.
 //
 //  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
 //  in compliance with the License. You may obtain a copy of the License at
@@ -16,29 +16,29 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "Resource.h"
+#pragma once
+
+#include <concurrentqueue.h>
 
 namespace tgfx {
-void Resource::assignUniqueKey(const UniqueKey& newKey) {
-  if (newKey.empty()) {
-    removeUniqueKey();
-    return;
-  }
-  if (newKey != uniqueKey) {
-    context->resourceCache()->changeUniqueKey(this, newKey);
-  }
-}
+class Resource;
 
-void Resource::removeUniqueKey() {
-  if (!uniqueKey.empty()) {
-    context->resourceCache()->removeUniqueKey(this);
-  }
-}
+/**
+ * Manages resources whose references are released by `shared_ptr`.
+ */
+class PendingPurgeResourceQueue {
+ public:
+  /** Default constructor. */
+  PendingPurgeResourceQueue() = default;
 
-void Resource::release(bool releaseGPU) {
-  if (releaseGPU) {
-    onReleaseGPU();
-  }
-  context = nullptr;
-}
+  /** Destructor that cleans up all pending resources. */
+  ~PendingPurgeResourceQueue();
+
+  /**
+   * Adds a resource whose references are released by `shared_ptr`.
+   */
+  void add(Resource* resource);
+
+  moodycamel::ConcurrentQueue<Resource*> pendingQueue;
+};
 }  // namespace tgfx

--- a/src/gpu/resources/Resource.h
+++ b/src/gpu/resources/Resource.h
@@ -84,7 +84,8 @@ class Resource {
 
  protected:
   Context* context = nullptr;
-  std::shared_ptr<Resource> reference = nullptr;
+  std::shared_ptr<PendingPurgeResourceQueue> pendingPurgeQueue;
+  std::weak_ptr<Resource> weakThis;
 
   /**
    * Overridden to free GPU resources in the backend API.
@@ -99,7 +100,7 @@ class Resource {
   std::chrono::steady_clock::time_point lastUsedTime = {};
 
   bool isPurgeable() const {
-    return reference.use_count() <= 1;
+    return weakThis.expired();
   }
 
   bool hasExternalReferences() const {

--- a/src/gpu/resources/TextureRenderTarget.h
+++ b/src/gpu/resources/TextureRenderTarget.h
@@ -45,11 +45,11 @@ class TextureRenderTarget : public DefaultTextureView, public RenderTarget {
   }
 
   std::shared_ptr<TextureView> asTextureView() const override {
-    return std::static_pointer_cast<TextureView>(reference);
+    return std::static_pointer_cast<TextureView>(weakThis.lock());
   }
 
   std::shared_ptr<RenderTarget> asRenderTarget() const override {
-    return std::static_pointer_cast<TextureRenderTarget>(reference);
+    return std::static_pointer_cast<TextureRenderTarget>(weakThis.lock());
   }
 
   void onReleaseGPU() override;


### PR DESCRIPTION
When a resource is released, move it to the pending purge queue. When checking if cleanup is needed, only traverse the pending purge queue instead of all resources.