### PR TITLE
Reduce alpha for extremely thin strokes rendered as hairlines.

### DIFF
--- a/src/core/utils/ShapeUtils.cpp
+++ b/src/core/utils/ShapeUtils.cpp
@@ -17,7 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "ShapeUtils.h"
-#include <memory>
 #include "core/shapes/MatrixShape.h"
 #include "core/shapes/StrokeShape.h"
 #include "core/utils/StrokeUtils.h"

--- a/src/core/utils/ShapeUtils.cpp
+++ b/src/core/utils/ShapeUtils.cpp
@@ -17,6 +17,11 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "ShapeUtils.h"
+#include <memory>
+#include "core/shapes/MatrixShape.h"
+#include "core/shapes/StrokeShape.h"
+#include "core/utils/StrokeUtils.h"
+#include "tgfx/core/Shape.h"
 
 namespace tgfx {
 
@@ -25,6 +30,25 @@ Path ShapeUtils::GetShapeRenderingPath(std::shared_ptr<Shape> shape, float resol
     return {};
   }
   return shape->onGetPath(resolutionScale);
+}
+
+float ShapeUtils::CalculateAlphaReduceFactorIfHairline(std::shared_ptr<Shape> shape) {
+  if (shape->type() != Shape::Type::Matrix) {
+    return 1.f;
+  }
+
+  auto matrixShape = std::static_pointer_cast<MatrixShape>(shape);
+  if (matrixShape->shape->type() == Shape::Type::Stroke) {
+    auto strokeShape = std::static_pointer_cast<StrokeShape>(matrixShape->shape);
+    if (IsHairlineStroke(strokeShape->stroke)) {
+      return 1.f;
+    }
+    auto width = strokeShape->stroke.width * matrixShape->matrix.getMaxScale();
+    if (width < 1.f) {
+      return width;
+    }
+  }
+  return 1.f;
 }
 
 }  // namespace tgfx

--- a/src/core/utils/ShapeUtils.h
+++ b/src/core/utils/ShapeUtils.h
@@ -31,5 +31,7 @@ class ShapeUtils {
    * depending on the resolution scale.
    */
   static Path GetShapeRenderingPath(std::shared_ptr<Shape> shape, float resolutionScale);
+
+  static float CalculateAlphaReduceFactorIfHairline(std::shared_ptr<Shape> shape);
 };
 }  // namespace tgfx

--- a/src/gpu/OpsCompositor.cpp
+++ b/src/gpu/OpsCompositor.cpp
@@ -22,6 +22,7 @@
 #include "core/PathTriangulator.h"
 #include "core/utils/MathExtra.h"
 #include "core/utils/RectToRectMatrix.h"
+#include "core/utils/ShapeUtils.h"
 #include "gpu/DrawingManager.h"
 #include "gpu/ProxyProvider.h"
 #include "gpu/ops/AtlasTextOp.h"
@@ -173,10 +174,14 @@ void OpsCompositor::drawShape(std::shared_ptr<Shape> shape, const MCState& state
     deviceBounds = shape->isInverseFillType() ? clipBounds : shape->getBounds();
   }
   auto aaType = getAAType(fill);
+  auto shapeFill = fill;
+  if (aaType == AAType::Coverage) {
+    shapeFill.color.alpha *= ShapeUtils::CalculateAlphaReduceFactorIfHairline(shape);
+  }
   auto shapeProxy = proxyProvider()->createGPUShapeProxy(shape, aaType, clipBounds, renderFlags);
   auto drawOp =
-      ShapeDrawOp::Make(std::move(shapeProxy), fill.color.premultiply(), uvMatrix, aaType);
-  addDrawOp(std::move(drawOp), clip, fill, localBounds, deviceBounds, drawScale);
+      ShapeDrawOp::Make(std::move(shapeProxy), shapeFill.color.premultiply(), uvMatrix, aaType);
+  addDrawOp(std::move(drawOp), clip, shapeFill, localBounds, deviceBounds, drawScale);
 }
 
 void OpsCompositor::discardAll() {

--- a/src/gpu/OpsCompositor.cpp
+++ b/src/gpu/OpsCompositor.cpp
@@ -174,14 +174,11 @@ void OpsCompositor::drawShape(std::shared_ptr<Shape> shape, const MCState& state
     deviceBounds = shape->isInverseFillType() ? clipBounds : shape->getBounds();
   }
   auto aaType = getAAType(fill);
-  auto shapeFill = fill;
-  if (aaType == AAType::Coverage) {
-    shapeFill.color.alpha *= ShapeUtils::CalculateAlphaReduceFactorIfHairline(shape);
-  }
+  auto color = fill.color;
+  color.alpha *= ShapeUtils::CalculateAlphaReduceFactorIfHairline(shape);
   auto shapeProxy = proxyProvider()->createGPUShapeProxy(shape, aaType, clipBounds, renderFlags);
-  auto drawOp =
-      ShapeDrawOp::Make(std::move(shapeProxy), shapeFill.color.premultiply(), uvMatrix, aaType);
-  addDrawOp(std::move(drawOp), clip, shapeFill, localBounds, deviceBounds, drawScale);
+  auto drawOp = ShapeDrawOp::Make(std::move(shapeProxy), color.premultiply(), uvMatrix, aaType);
+  addDrawOp(std::move(drawOp), clip, fill, localBounds, deviceBounds, drawScale);
 }
 
 void OpsCompositor::discardAll() {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -161,7 +161,7 @@
         "ContourTest": "5ccc0507",
         "DirtyRegionTest1": "e1604824",
         "DirtyRegionTest10": "31250c62",
-        "DirtyRegionTest11": "5be7fc78",
+        "DirtyRegionTest11": "4bd4e0ad",
         "DirtyRegionTest2": "e1604824",
         "DirtyRegionTest3": "e1604824",
         "DirtyRegionTest4": "e1604824",
@@ -319,7 +319,7 @@
         "complex4": "a3179b14",
         "complex5": "a3179b14",
         "complex6": "a3179b14",
-        "complex7": "a3179b14",
+        "complex7": "4bd4e0ad",
         "jpg_image": "b1db872",
         "mask": "da364e8",
         "path": "a6ff60e1",
@@ -333,8 +333,8 @@
     "StrokeTest": {
         "DrawPathByHairlinePaint": "5be7fc78",
         "DrawShapeByHairlinePaint": "5be7fc78",
-        "ExtremelyThinStrokeLayer": "5be7fc78",
-        "ExtremelyThinStrokePath": "5be7fc78",
+        "ExtremelyThinStrokeLayer": "4bd4e0ad",
+        "ExtremelyThinStrokePath": "4bd4e0ad",
         "HairlineLayer": "5be7fc78",
         "ZoomUpTinyStrokeShape": "5be7fc78"
     },


### PR DESCRIPTION
以Hairline渲染极细的描边按线宽降低透明度。
拆解Shape计算当前渲染的描边宽度。