### PR TITLE
Rename GPURenderPipeline to RenderPipeline and GPUShaderModule to ShaderModule.

### DIFF
--- a/src/gpu/GPU.h
+++ b/src/gpu/GPU.h
@@ -21,9 +21,9 @@
 #include <memory>
 #include "gpu/CommandEncoder.h"
 #include "gpu/CommandQueue.h"
-#include "gpu/GPURenderPipeline.h"
 #include "gpu/GPUSampler.h"
-#include "gpu/GPUShaderModule.h"
+#include "gpu/RenderPipeline.h"
+#include "gpu/ShaderModule.h"
 #include "gpu/YUVFormat.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Caps.h"
@@ -141,18 +141,18 @@ class GPU {
   virtual std::shared_ptr<GPUSampler> createSampler(const GPUSamplerDescriptor& descriptor) = 0;
 
   /**
-   * Creates a GPUShaderModule from the provided shader code. The shader code must be valid and
+   * Creates a ShaderModule from the provided shader code. The shader code must be valid and
    * compatible with the GPU backend. Returns nullptr if the shader module creation fails.
    */
-  virtual std::shared_ptr<GPUShaderModule> createShaderModule(
-      const GPUShaderModuleDescriptor& descriptor) = 0;
+  virtual std::shared_ptr<ShaderModule> createShaderModule(
+      const ShaderModuleDescriptor& descriptor) = 0;
 
   /**
-   * Creates a GPURenderPipeline that manages the vertex and fragment shader stages for use in a
+   * Creates a RenderPipeline that manages the vertex and fragment shader stages for use in a
    * RenderPass. Returns nullptr if pipeline creation fails.
    */
-  virtual std::shared_ptr<GPURenderPipeline> createRenderPipeline(
-      const GPURenderPipelineDescriptor& descriptor) = 0;
+  virtual std::shared_ptr<RenderPipeline> createRenderPipeline(
+      const RenderPipelineDescriptor& descriptor) = 0;
 
   /**
    * Creates a command encoder that can be used to encode commands to be issued to the GPU.

--- a/src/gpu/ProgramInfo.h
+++ b/src/gpu/ProgramInfo.h
@@ -19,8 +19,8 @@
 #pragma once
 
 #include <unordered_map>
-#include "gpu/GPURenderPipeline.h"
 #include "gpu/RenderPass.h"
+#include "gpu/RenderPipeline.h"
 #include "gpu/processors/EmptyXferProcessor.h"
 #include "gpu/processors/FragmentProcessor.h"
 #include "gpu/processors/GeometryProcessor.h"

--- a/src/gpu/RenderPass.h
+++ b/src/gpu/RenderPass.h
@@ -20,9 +20,9 @@
 
 #include "core/utils/Log.h"
 #include "gpu/GPUBuffer.h"
-#include "gpu/GPURenderPipeline.h"
 #include "gpu/GPUSampler.h"
 #include "gpu/GPUTexture.h"
+#include "gpu/RenderPipeline.h"
 #include "tgfx/core/Color.h"
 
 namespace tgfx {
@@ -266,7 +266,7 @@ class RenderPass {
    * Sets the render pipeline to be used for subsequent draw calls. The pipeline defines the shader
    * programs and fixed-function state used during rendering.
    */
-  virtual void setPipeline(std::shared_ptr<GPURenderPipeline> pipeline) = 0;
+  virtual void setPipeline(std::shared_ptr<RenderPipeline> pipeline) = 0;
 
   /**
    * Sets the uniform data to a specified binding index in the shader's UBO table.

--- a/src/gpu/RenderPipeline.cpp
+++ b/src/gpu/RenderPipeline.cpp
@@ -16,7 +16,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "GPURenderPipeline.h"
+#include "RenderPipeline.h"
 
 namespace tgfx {
 VertexDescriptor::VertexDescriptor(std::vector<Attribute> attribs, size_t stride)

--- a/src/gpu/RenderPipeline.h
+++ b/src/gpu/RenderPipeline.h
@@ -26,7 +26,7 @@
 #include "gpu/BlendOperation.h"
 #include "gpu/ColorWriteMask.h"
 #include "gpu/CompareFunction.h"
-#include "gpu/GPUShaderModule.h"
+#include "gpu/ShaderModule.h"
 #include "gpu/StencilOperation.h"
 #include "gpu/Uniform.h"
 #include "tgfx/gpu/PixelFormat.h"
@@ -95,9 +95,9 @@ class PipelineColorAttachment {
 class FragmentDescriptor {
  public:
   /**
-   * A GPUShaderModule object containing the fragment shader code.
+   * A ShaderModule object containing the fragment shader code.
    */
-  std::shared_ptr<GPUShaderModule> module = nullptr;
+  std::shared_ptr<ShaderModule> module = nullptr;
 
   /**
    * The name of the entry point function in the shader code.
@@ -129,9 +129,9 @@ class VertexDescriptor {
   VertexDescriptor(std::vector<Attribute> attributes, size_t vertexStride = 0);
 
   /**
-   * A GPUShaderModule object containing the vertex shader code.
+   * A ShaderModule object containing the vertex shader code.
    */
-  std::shared_ptr<GPUShaderModule> module = nullptr;
+  std::shared_ptr<ShaderModule> module = nullptr;
 
   /**
    * The name of the entry point function in the shader code.
@@ -263,7 +263,7 @@ class DepthStencilDescriptor {
 /**
  * Options you provide to a GPU device to create a render pipeline state.
  */
-class GPURenderPipelineDescriptor {
+class RenderPipelineDescriptor {
  public:
   /**
    * The vertex shader entry point and its input buffer layouts.
@@ -289,11 +289,11 @@ class GPURenderPipelineDescriptor {
 };
 
 /**
- * GPURenderPipeline represents a graphics pipeline configuration for a render pass, which the pass
+ * RenderPipeline represents a graphics pipeline configuration for a render pass, which the pass
  * applies to the draw commands you encode.
  */
-class GPURenderPipeline {
+class RenderPipeline {
  public:
-  virtual ~GPURenderPipeline() = default;
+  virtual ~RenderPipeline() = default;
 };
 }  // namespace tgfx

--- a/src/gpu/ShaderModule.h
+++ b/src/gpu/ShaderModule.h
@@ -23,12 +23,12 @@
 
 namespace tgfx {
 /**
- * GPUShaderModuleDescriptor describes the properties required to create a GPUShaderModule.
+ * ShaderModuleDescriptor describes the properties required to create a ShaderModule.
  */
-class GPUShaderModuleDescriptor {
+class ShaderModuleDescriptor {
  public:
   /**
-   * The shader code to be compiled into a GPUShaderModule.
+   * The shader code to be compiled into a ShaderModule.
    */
   std::string code;
 
@@ -40,11 +40,11 @@ class GPUShaderModuleDescriptor {
 };
 
 /**
- * GPUShaderModule is an internal object that serves as a container for shader code，allowing it to
+ * ShaderModule is an internal object that serves as a container for shader code，allowing it to
  * be submitted to the GPU for execution within a pipeline.
  */
-class GPUShaderModule {
+class ShaderModule {
  public:
-  virtual ~GPUShaderModule() = default;
+  virtual ~ShaderModule() = default;
 };
 }  // namespace tgfx

--- a/src/gpu/glsl/GLSLProgramBuilder.cpp
+++ b/src/gpu/glsl/GLSLProgramBuilder.cpp
@@ -173,21 +173,21 @@ std::shared_ptr<PipelineProgram> GLSLProgramBuilder::finalize() {
   }
   finalizeShaders();
   auto gpu = context->gpu();
-  GPUShaderModuleDescriptor vertexModule = {};
+  ShaderModuleDescriptor vertexModule = {};
   vertexModule.code = vertexShaderBuilder()->shaderString();
   vertexModule.stage = ShaderStage::Vertex;
   auto vertexShader = gpu->createShaderModule(vertexModule);
   if (vertexShader == nullptr) {
     return nullptr;
   }
-  GPUShaderModuleDescriptor fragmentModule = {};
+  ShaderModuleDescriptor fragmentModule = {};
   fragmentModule.code = fragmentShaderBuilder()->shaderString();
   fragmentModule.stage = ShaderStage::Fragment;
   auto fragmentShader = gpu->createShaderModule(fragmentModule);
   if (fragmentShader == nullptr) {
     return nullptr;
   }
-  GPURenderPipelineDescriptor descriptor = {};
+  RenderPipelineDescriptor descriptor = {};
   descriptor.vertex = {programInfo->getVertexAttributes()};
   descriptor.vertex.module = vertexShader;
   descriptor.fragment.module = fragmentShader;

--- a/src/gpu/opengl/GLGPU.cpp
+++ b/src/gpu/opengl/GLGPU.cpp
@@ -225,8 +225,7 @@ std::shared_ptr<GPUSampler> GLGPU::createSampler(const GPUSamplerDescriptor& des
                                      ToGLWrap(descriptor.addressModeY), minFilter, magFilter);
 }
 
-std::shared_ptr<GPUShaderModule> GLGPU::createShaderModule(
-    const GPUShaderModuleDescriptor& descriptor) {
+std::shared_ptr<ShaderModule> GLGPU::createShaderModule(const ShaderModuleDescriptor& descriptor) {
   if (descriptor.code.empty()) {
     LOGE("GLGPU::createShaderModule() shader code is empty!");
     return nullptr;
@@ -260,8 +259,8 @@ std::shared_ptr<GPUShaderModule> GLGPU::createShaderModule(
   return makeResource<GLShaderModule>(shader);
 }
 
-std::shared_ptr<GPURenderPipeline> GLGPU::createRenderPipeline(
-    const GPURenderPipelineDescriptor& descriptor) {
+std::shared_ptr<RenderPipeline> GLGPU::createRenderPipeline(
+    const RenderPipelineDescriptor& descriptor) {
   auto vertexModule = static_cast<GLShaderModule*>(descriptor.vertex.module.get());
   auto fragmentModule = static_cast<GLShaderModule*>(descriptor.fragment.module.get());
   if (vertexModule == nullptr || vertexModule->shader() == 0 || vertexModule == nullptr ||

--- a/src/gpu/opengl/GLGPU.h
+++ b/src/gpu/opengl/GLGPU.h
@@ -71,11 +71,11 @@ class GLGPU : public GPU {
 
   std::shared_ptr<GPUSampler> createSampler(const GPUSamplerDescriptor& descriptor) override;
 
-  std::shared_ptr<GPUShaderModule> createShaderModule(
-      const GPUShaderModuleDescriptor& descriptor) override;
+  std::shared_ptr<ShaderModule> createShaderModule(
+      const ShaderModuleDescriptor& descriptor) override;
 
-  std::shared_ptr<GPURenderPipeline> createRenderPipeline(
-      const GPURenderPipelineDescriptor& descriptor) override;
+  std::shared_ptr<RenderPipeline> createRenderPipeline(
+      const RenderPipelineDescriptor& descriptor) override;
 
   std::shared_ptr<CommandEncoder> createCommandEncoder() override;
 

--- a/src/gpu/opengl/GLRenderPass.cpp
+++ b/src/gpu/opengl/GLRenderPass.cpp
@@ -84,7 +84,7 @@ void GLRenderPass::setScissorRect(int x, int y, int width, int height) {
   }
 }
 
-void GLRenderPass::setPipeline(std::shared_ptr<GPURenderPipeline> pipeline) {
+void GLRenderPass::setPipeline(std::shared_ptr<RenderPipeline> pipeline) {
   if (renderPipeline == pipeline) {
     return;
   }

--- a/src/gpu/opengl/GLRenderPass.h
+++ b/src/gpu/opengl/GLRenderPass.h
@@ -36,7 +36,7 @@ class GLRenderPass : public RenderPass {
 
   void setScissorRect(int x, int y, int width, int height) override;
 
-  void setPipeline(std::shared_ptr<GPURenderPipeline> pipeline) override;
+  void setPipeline(std::shared_ptr<RenderPipeline> pipeline) override;
 
   void setUniformBytes(unsigned binding, const void* data, size_t size) override;
 

--- a/src/gpu/opengl/GLRenderPipeline.cpp
+++ b/src/gpu/opengl/GLRenderPipeline.cpp
@@ -272,7 +272,7 @@ static std::unique_ptr<GLDepthState> MakeDepthState(const DepthStencilDescriptor
 }
 
 bool GLRenderPipeline::setPipelineDescriptor(GLGPU* gpu,
-                                             const GPURenderPipelineDescriptor& descriptor) {
+                                             const RenderPipelineDescriptor& descriptor) {
   auto gl = gpu->functions();
   ClearGLError(gl);
   auto state = gpu->state();

--- a/src/gpu/opengl/GLRenderPipeline.h
+++ b/src/gpu/opengl/GLRenderPipeline.h
@@ -20,7 +20,7 @@
 
 #include <memory>
 #include <unordered_map>
-#include "gpu/GPURenderPipeline.h"
+#include "gpu/RenderPipeline.h"
 #include "gpu/opengl/GLBuffer.h"
 #include "gpu/opengl/GLResource.h"
 #include "gpu/opengl/GLState.h"
@@ -47,11 +47,11 @@ struct GLUniformBlock {
 };
 
 /**
- * GLRenderPipeline is the OpenGL implementation of the GPURenderPipeline interface. It encapsulates
+ * GLRenderPipeline is the OpenGL implementation of the RenderPipeline interface. It encapsulates
  * an OpenGL shader program along with its associated state, such as vertex attributes and blending
  * settings.
  */
-class GLRenderPipeline : public GPURenderPipeline, public GLResource {
+class GLRenderPipeline : public RenderPipeline, public GLResource {
  public:
   explicit GLRenderPipeline(unsigned programID);
 
@@ -96,7 +96,7 @@ class GLRenderPipeline : public GPURenderPipeline, public GLResource {
   std::unique_ptr<GLDepthState> depthState = nullptr;
   std::unique_ptr<GLBlendState> blendState = nullptr;
 
-  bool setPipelineDescriptor(GLGPU* gpu, const GPURenderPipelineDescriptor& descriptor);
+  bool setPipelineDescriptor(GLGPU* gpu, const RenderPipelineDescriptor& descriptor);
 
   friend class GLGPU;
 };

--- a/src/gpu/opengl/GLShaderModule.h
+++ b/src/gpu/opengl/GLShaderModule.h
@@ -18,11 +18,11 @@
 
 #pragma once
 
-#include "gpu/GPUShaderModule.h"
+#include "gpu/ShaderModule.h"
 #include "gpu/opengl/GLResource.h"
 
 namespace tgfx {
-class GLShaderModule : public GPUShaderModule, public GLResource {
+class GLShaderModule : public ShaderModule, public GLResource {
  public:
   explicit GLShaderModule(unsigned shader) : _shader(shader) {
   }

--- a/src/gpu/resources/PipelineProgram.h
+++ b/src/gpu/resources/PipelineProgram.h
@@ -23,19 +23,19 @@
 namespace tgfx {
 class PipelineProgram : public Program {
  public:
-  explicit PipelineProgram(std::shared_ptr<GPURenderPipeline> pipeline,
+  explicit PipelineProgram(std::shared_ptr<RenderPipeline> pipeline,
                            std::unique_ptr<UniformBuffer> vertexUniformBuffer,
                            std::unique_ptr<UniformBuffer> fragmentUniformBuffer)
       : pipeline(std::move(pipeline)), vertexUniformBuffer(std::move(vertexUniformBuffer)),
         fragmentUniformBuffer(std::move(fragmentUniformBuffer)) {
   }
 
-  std::shared_ptr<GPURenderPipeline> getPipeline() const {
+  std::shared_ptr<RenderPipeline> getPipeline() const {
     return pipeline;
   }
 
  private:
-  std::shared_ptr<GPURenderPipeline> pipeline = nullptr;
+  std::shared_ptr<RenderPipeline> pipeline = nullptr;
   std::unique_ptr<UniformBuffer> vertexUniformBuffer = nullptr;
   std::unique_ptr<UniformBuffer> fragmentUniformBuffer = nullptr;
 

--- a/src/gpu/resources/Program.h
+++ b/src/gpu/resources/Program.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "gpu/GPURenderPipeline.h"
+#include "gpu/RenderPipeline.h"
 #include "gpu/UniformBuffer.h"
 #include "gpu/resources/Resource.h"
 #include "tgfx/core/BytesKey.h"


### PR DESCRIPTION
去掉几个类的GPU命名前缀，因为现在统一使用了智能指针管理对象，不需要显式靠GPU前缀来区分哪些是需要手动管理的GPU对象了。