### PR TITLE
Fixed an assertion caused by converting hairline lines into rectangle with zero width for rendering.

### DIFF
--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -22,6 +22,7 @@
 #include "core/shapes/StrokeShape.h"
 #include "core/utils/Log.h"
 #include "core/utils/MathExtra.h"
+#include "core/utils/StrokeUtils.h"
 #include "core/utils/Types.h"
 #include "images/SubsetImage.h"
 #include "shapes/MatrixShape.h"
@@ -317,9 +318,10 @@ void Canvas::drawPath(const Path& path, const Paint& paint) {
   drawPath(path, *mcState, paint.getFill(), paint.getStroke());
 }
 
-/// Check if the line is axis-aligned and convert it to a rect
+// Checks if the line is axis-aligned and not a hairline stroke, allowing it to be converted to a
+// rect.
 static bool StrokeLineIsRect(const Stroke& stroke, const Point line[2], Rect* rect) {
-  if (stroke.cap == LineCap::Round) {
+  if (stroke.cap == LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
   // check if the line is axis-aligned

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -342,6 +342,7 @@
         "ExtremelyThinStrokeLayer": "4bd4e0ad",
         "ExtremelyThinStrokePath": "4bd4e0ad",
         "HairlineLayer": "5be7fc78",
+        "LineRenderAsHairline": "492105ac",
         "ZoomUpTinyStrokeShape": "5be7fc78"
     },
     "SurfaceTest": {

--- a/test/src/StrokeTest.cpp
+++ b/test/src/StrokeTest.cpp
@@ -225,4 +225,25 @@ TGFX_TEST(StrokeTest, HairlineUniqueKey) {
   auto normalStrokeShape2 = Shape::ApplyStroke(shape, &hairlineStroke2);
   EXPECT_NE(normalStrokeShape1->getUniqueKey(), normalStrokeShape2->getUniqueKey());
 }
+
+TGFX_TEST(StrokeTest, LineRenderAsHairline) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 200, 200);
+  auto canvas = surface->getCanvas();
+  canvas->clear();
+
+  tgfx::Paint paint1;
+  paint1.setColor(tgfx::Color::White());
+  paint1.setStyle(tgfx::PaintStyle::Stroke);
+  paint1.setStrokeWidth(0.0f);
+
+  canvas->drawLine(50, 20, 150, 20, paint1);   // horizontal line
+  canvas->drawLine(50, 40, 150, 140, paint1);  // 45 degree line
+  canvas->drawLine(50, 60, 50, 160, paint1);   // vertical line
+
+  EXPECT_TRUE(Baseline::Compare(surface, "StrokeTest/LineRenderAsHairline"));
+}
+
 }  // namespace tgfx


### PR DESCRIPTION
修复渲染正交的Hairline直线，转换成宽度为0的矩形渲染导致的断言问题