### PR TITLE
Ensure the GLGPU::releaseAll() is called even if the context has not been created.

### DIFF
--- a/src/gpu/opengl/GLDevice.cpp
+++ b/src/gpu/opengl/GLDevice.cpp
@@ -77,6 +77,8 @@ GLDevice::~GLDevice() {
 void GLDevice::releaseAll() {
   std::lock_guard<std::mutex> autoLock(locker);
   if (context == nullptr) {
+    // make sure all resources are released even there is no context.
+    static_cast<GLGPU*>(_gpu)->releaseAll(false);
     return;
   }
   auto releaseGPU = onLockContext();


### PR DESCRIPTION
Call releaseAll on the GPU even if the device context has not been created，ensure all resources are released even if the context has not been created.