### PR TITLE
Add a stealBackendSemaphore() method to GPU and remove Semaphore's stealBackend() method.

### DIFF
--- a/include/tgfx/gpu/Window.h
+++ b/include/tgfx/gpu/Window.h
@@ -39,7 +39,7 @@ class Window {
    * Returns the Surface associated with this Window. If the queryOnly is true, it will not create
    * a new surface if it doesn't exist.
    */
-  std::shared_ptr<tgfx::Surface> getSurface(Context* context, bool queryOnly = false);
+  std::shared_ptr<Surface> getSurface(Context* context, bool queryOnly = false);
 
   /**
    * Applies all pending graphics changes to the window. On the Android platform, the

--- a/src/gpu/Context.cpp
+++ b/src/gpu/Context.cpp
@@ -60,7 +60,7 @@ Backend Context::backend() const {
 }
 
 bool Context::wait(const BackendSemaphore& waitSemaphore) {
-  auto semaphore = gpu()->importExternalSemaphore(waitSemaphore);
+  auto semaphore = gpu()->importBackendSemaphore(waitSemaphore);
   if (semaphore == nullptr) {
     return false;
   }
@@ -78,7 +78,7 @@ bool Context::flush(BackendSemaphore* signalSemaphore) {
   if (signalSemaphore != nullptr) {
     auto semaphore = gpu()->queue()->insertSemaphore();
     if (semaphore != nullptr) {
-      *signalSemaphore = semaphore->stealBackend();
+      *signalSemaphore = gpu()->stealBackendSemaphore(std::move(semaphore));
     }
   }
   _atlasManager->postFlush();

--- a/src/gpu/GPU.h
+++ b/src/gpu/GPU.h
@@ -110,16 +110,16 @@ class GPU {
    * @return A unique pointer to the created GPUTexture. Returns nullptr if the backend texture is
    * invalid or not supported by the GPU backend.
    */
-  virtual std::shared_ptr<GPUTexture> importExternalTexture(const BackendTexture& backendTexture,
-                                                            uint32_t usage,
-                                                            bool adopted = false) = 0;
+  virtual std::shared_ptr<GPUTexture> importBackendTexture(const BackendTexture& backendTexture,
+                                                           uint32_t usage,
+                                                           bool adopted = false) = 0;
 
   /**
    * Creates a GPUTexture that wraps the given backend render target. The caller must ensure the
    * backend render target is valid for the lifetime of the returned GPUTexture. Returns nullptr
    * if the backend render target is invalid.
    */
-  virtual std::shared_ptr<GPUTexture> importExternalTexture(
+  virtual std::shared_ptr<GPUTexture> importBackendRenderTarget(
       const BackendRenderTarget& backendRenderTarget) = 0;
 
   /**
@@ -127,7 +127,15 @@ class GPU {
    * ownership of the BackendSemaphore and will destroy it when no longer needed. Returns nullptr
    * if the BackendSemaphore is invalid or not supported by the GPU backend.
    */
-  virtual std::shared_ptr<Semaphore> importExternalSemaphore(const BackendSemaphore& semaphore) = 0;
+  virtual std::shared_ptr<Semaphore> importBackendSemaphore(const BackendSemaphore& semaphore) = 0;
+
+  /**
+   * Transfers ownership of the BackendSemaphore from a uniquely owned Semaphore to the caller.
+   * After this call, the caller is responsible for managing the returned BackendSemaphore. You must
+   * use std::move() to pass the Semaphore, and it will be released during this process. Returns an
+   * empty BackendSemaphore if the Semaphore is nullptr or not uniquely owned.
+   */
+  virtual BackendSemaphore stealBackendSemaphore(std::shared_ptr<Semaphore> semaphore) = 0;
 
   /**
    * Creates a GPUSampler with the specified descriptor.

--- a/src/gpu/Semaphore.h
+++ b/src/gpu/Semaphore.h
@@ -30,9 +30,8 @@ class Semaphore {
   virtual ~Semaphore() = default;
 
   /**
-   * Returns the BackendSemaphore object and transfers ownership to the caller, who must manage its
-   * lifetime. If the Semaphore is invalid, an empty BackendSemaphore is returned.
+   * Returns a BackendSemaphore representing the underlying backend-specific semaphore.
    */
-  virtual BackendSemaphore stealBackend() = 0;
+  virtual BackendSemaphore getBackendSemaphore() const = 0;
 };
 }  // namespace tgfx

--- a/src/gpu/opengl/GLGPU.h
+++ b/src/gpu/opengl/GLGPU.h
@@ -73,13 +73,15 @@ class GLGPU : public GPU {
 
   std::shared_ptr<GPUTexture> createTexture(const GPUTextureDescriptor& descriptor) override;
 
-  std::shared_ptr<GPUTexture> importExternalTexture(const BackendTexture& backendTexture,
-                                                    uint32_t usage, bool adopted) override;
+  std::shared_ptr<GPUTexture> importBackendTexture(const BackendTexture& backendTexture,
+                                                   uint32_t usage, bool adopted) override;
 
-  std::shared_ptr<GPUTexture> importExternalTexture(
+  std::shared_ptr<GPUTexture> importBackendRenderTarget(
       const BackendRenderTarget& renderTarget) override;
 
-  std::shared_ptr<Semaphore> importExternalSemaphore(const BackendSemaphore& semaphore) override;
+  std::shared_ptr<Semaphore> importBackendSemaphore(const BackendSemaphore& semaphore) override;
+
+  BackendSemaphore stealBackendSemaphore(std::shared_ptr<Semaphore> semaphore) override;
 
   std::shared_ptr<GPUSampler> createSampler(const GPUSamplerDescriptor& descriptor) override;
 

--- a/src/gpu/opengl/GLSemaphore.cpp
+++ b/src/gpu/opengl/GLSemaphore.cpp
@@ -21,13 +21,12 @@
 #include "tgfx/gpu/opengl/GLFunctions.h"
 
 namespace tgfx {
-BackendSemaphore GLSemaphore::stealBackend() {
+BackendSemaphore GLSemaphore::getBackendSemaphore() const {
   if (_glSync == nullptr) {
     return {};
   }
   GLSyncInfo glSyncInfo = {};
   glSyncInfo.sync = _glSync;
-  _glSync = nullptr;
   return {glSyncInfo};
 }
 

--- a/src/gpu/opengl/GLSemaphore.h
+++ b/src/gpu/opengl/GLSemaphore.h
@@ -34,12 +34,14 @@ class GLSemaphore : public Semaphore, public GLResource {
     return _glSync;
   }
 
-  BackendSemaphore stealBackend() override;
+  BackendSemaphore getBackendSemaphore() const override;
 
  protected:
   void onRelease(GLGPU* gpu) override;
 
  private:
   void* _glSync = nullptr;
+
+  friend class GLGPU;
 };
 }  // namespace tgfx

--- a/src/gpu/resources/ExternalRenderTarget.cpp
+++ b/src/gpu/resources/ExternalRenderTarget.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<RenderTarget> RenderTarget::MakeFrom(Context* context,
   if (context == nullptr) {
     return nullptr;
   }
-  auto texture = context->gpu()->importExternalTexture(backendRenderTarget);
+  auto texture = context->gpu()->importBackendRenderTarget(backendRenderTarget);
   if (!texture) {
     return nullptr;
   }

--- a/src/gpu/resources/TextureRenderTarget.cpp
+++ b/src/gpu/resources/TextureRenderTarget.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<RenderTarget> RenderTarget::MakeFrom(Context* context,
     return nullptr;
   }
   uint32_t usage = GPUTextureUsage::TEXTURE_BINDING | GPUTextureUsage::RENDER_ATTACHMENT;
-  auto texture = context->gpu()->importExternalTexture(backendTexture, usage, adopted);
+  auto texture = context->gpu()->importBackendTexture(backendTexture, usage, adopted);
   if (texture == nullptr) {
     return nullptr;
   }

--- a/src/gpu/resources/TextureView.cpp
+++ b/src/gpu/resources/TextureView.cpp
@@ -92,8 +92,8 @@ std::shared_ptr<TextureView> TextureView::MakeFrom(Context* context,
   if (context == nullptr) {
     return nullptr;
   }
-  auto texture = context->gpu()->importExternalTexture(backendTexture,
-                                                       GPUTextureUsage::TEXTURE_BINDING, adopted);
+  auto texture = context->gpu()->importBackendTexture(backendTexture,
+                                                      GPUTextureUsage::TEXTURE_BINDING, adopted);
   if (texture == nullptr) {
     return nullptr;
   }

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3063,6 +3063,20 @@ TGFX_TEST(CanvasTest, uninvertibleStateMatrix) {
   canvas->drawPath(path, paint);
 }
 
+TGFX_TEST(CanvasTest, FlushSemaphore) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 128, 128);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+  BackendSemaphore backendSemaphore = {};
+  context->flush(&backendSemaphore);
+  EXPECT_TRUE(backendSemaphore.isInitialized());
+  auto semaphore = context->gpu()->importBackendSemaphore(backendSemaphore);
+  EXPECT_TRUE(semaphore != nullptr);
+}
+
 TGFX_TEST(CanvasTest, ScaleMatrixShader) {
   auto image = MakeImage("resources/apitest/imageReplacement.png");
   ASSERT_TRUE(image != nullptr);


### PR DESCRIPTION
把stealBackendSemaphore方法移动到GPU上，并且判断当semaphore没有其他外部引用时才允许转移所有权，避免持有不安全的空资源。