### PR TITLE
Add a hitTestPoint() method to TextBlob and optimize glyph hit testing.

### DIFF
--- a/include/tgfx/core/TextBlob.h
+++ b/include/tgfx/core/TextBlob.h
@@ -73,6 +73,14 @@ class TextBlob {
    */
   Rect getTightBounds(const Matrix* matrix = nullptr) const;
 
+  /**
+   * Tests if the specified point hits any glyph in this TextBlob. Each glyph is tested
+   * individually using its actual path for precise hit testing. For color glyphs (e.g., emoji),
+   * bounds are used instead since they don't have outlines. If a stroke is provided, it will be
+   * applied to the glyph path or bounds before testing.
+   */
+  bool hitTestPoint(float localX, float localY, const Stroke* stroke = nullptr) const;
+
  private:
   std::vector<std::shared_ptr<GlyphRunList>> glyphRunLists = {};
 

--- a/src/core/GlyphRunList.h
+++ b/src/core/GlyphRunList.h
@@ -88,6 +88,14 @@ class GlyphRunList {
    */
   bool getPath(Path* path, const Matrix* matrix = nullptr) const;
 
+  /**
+   * Tests if the specified point hits any glyph in this run list. Each glyph is tested
+   * individually using its actual path for precise hit testing. For color glyphs (e.g., emoji),
+   * bounds are used instead since they don't have outlines. If a stroke is provided, it will be
+   * applied to the glyph path or bounds before testing.
+   */
+  bool hitTestPoint(float localX, float localY, const Stroke* stroke = nullptr) const;
+
  private:
   std::vector<GlyphRun> _glyphRuns = {};
   LazyBounds bounds = {};

--- a/src/core/HitTestContext.cpp
+++ b/src/core/HitTestContext.cpp
@@ -181,34 +181,25 @@ void HitTestContext::drawGlyphRunList(std::shared_ptr<GlyphRunList> glyphRunList
   if (FloatNearlyZero(maxScale)) {
     return;
   }
-  if (shapeHitTest && glyphRunList->hasOutlines()) {
-    Path glyphPath = {};
-    if (stroke) {
-      glyphRunList->getPath(&glyphPath);
-      stroke->applyToPath(&glyphPath);
-      glyphPath.transform(state.matrix);
-    } else {
-      glyphRunList->getPath(&glyphPath, &state.matrix);
-    }
-    if (!glyphPath.contains(deviceX, deviceY)) {
-      return;
+  Point local = {};
+  if (!GetLocalPoint(state.matrix, deviceX, deviceY, &local)) {
+    return;
+  }
+  if (!checkClip(state.clip, local)) {
+    return;
+  }
+  if (shapeHitTest) {
+    if (glyphRunList->hitTestPoint(local.x, local.y, stroke)) {
+      hit = true;
     }
   } else {
     auto localBounds = glyphRunList->getBounds();
     if (stroke) {
       ApplyStrokeToBounds(*stroke, &localBounds);
     }
-    auto deviceBounds = state.matrix.mapRect(localBounds);
-    if (!deviceBounds.contains(deviceX, deviceY)) {
-      return;
+    if (localBounds.contains(local.x, local.y)) {
+      hit = true;
     }
-  }
-  Point local = {};
-  if (!GetLocalPoint(state.matrix, deviceX, deviceY, &local)) {
-    return;
-  }
-  if (checkClip(state.clip, local)) {
-    hit = true;
   }
 }
 

--- a/src/core/TextBlob.cpp
+++ b/src/core/TextBlob.cpp
@@ -137,4 +137,13 @@ Rect TextBlob::getTightBounds(const Matrix* matrix) const {
   }
   return bounds;
 }
+
+bool TextBlob::hitTestPoint(float localX, float localY, const Stroke* stroke) const {
+  for (auto& runList : glyphRunLists) {
+    if (runList->hitTestPoint(localX, localY, stroke)) {
+      return true;
+    }
+  }
+  return false;
+}
 }  // namespace tgfx


### PR DESCRIPTION
给TextBlob增加了一个hitTestPoint方法作为精确碰撞使用。修改HitTestContext内部的实现，即使GlyphRunList无法获取Path，也逐字判断bounds是否命中，避免文字间隙被命中。