### PR TITLE
Remove the optimizeMemory parameter from PictureRecorder and related shrinkToFit logic.

### DIFF
--- a/include/tgfx/core/Canvas.h
+++ b/include/tgfx/core/Canvas.h
@@ -461,12 +461,10 @@ class Canvas {
  private:
   DrawContext* drawContext = nullptr;
   Surface* surface = nullptr;
-  bool optimizeMemoryForLayer = false;
   std::unique_ptr<MCState> mcState;
   std::stack<std::unique_ptr<CanvasState>> stateStack;
 
-  explicit Canvas(DrawContext* drawContext, Surface* surface = nullptr,
-                  bool optimizeMemoryForLayer = false);
+  explicit Canvas(DrawContext* drawContext, Surface* surface = nullptr);
   void drawPath(const Path& path, const MCState& state, const Brush& brush,
                 const Stroke* stroke = nullptr) const;
   void drawImage(std::shared_ptr<Image> image, const Brush& brush, const SamplingOptions& sampling,

--- a/include/tgfx/core/PictureRecorder.h
+++ b/include/tgfx/core/PictureRecorder.h
@@ -30,21 +30,6 @@ class PictureContext;
  */
 class PictureRecorder {
  public:
-  /**
-   * Constructs a PictureRecorder object. If optimizeMemory is true, the recorder will optimize the
-   * Picture generated to use minimal memory, which may involve copying and a slight overhead. This
-   * is recommended for long-lived Pictures. If false, memory is transferred directly for better
-   * performance, making it ideal for short-lived Pictures.
-   */
-  explicit PictureRecorder(bool optimizeMemory) : optimizeMemory(optimizeMemory) {
-  }
-
-  /**
-   * Constructs a PictureRecorder object with memory optimization disabled.
-   */
-  PictureRecorder() : PictureRecorder(false) {
-  }
-
   ~PictureRecorder();
 
   /**
@@ -67,7 +52,6 @@ class PictureRecorder {
   std::shared_ptr<Picture> finishRecordingAsPicture();
 
  private:
-  bool optimizeMemory = false;
   bool activelyRecording = false;
   PictureContext* pictureContext = nullptr;
   Canvas* canvas = nullptr;

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -69,8 +69,8 @@ static Brush GetBrushForImage(const Paint* paint, const Image* image) {
   return brush;
 }
 
-Canvas::Canvas(DrawContext* drawContext, Surface* surface, bool optimizeMemoryForLayer)
-    : drawContext(drawContext), surface(surface), optimizeMemoryForLayer(optimizeMemoryForLayer) {
+Canvas::Canvas(DrawContext* drawContext, Surface* surface)
+    : drawContext(drawContext), surface(surface) {
   mcState = std::make_unique<MCState>();
 }
 
@@ -103,7 +103,7 @@ void Canvas::restore() {
   if (layer != nullptr) {
     drawContext = layer->drawContext;
     auto layerContext = reinterpret_cast<PictureContext*>(layer->layerContext.get());
-    auto picture = layerContext->finishRecordingAsPicture(optimizeMemoryForLayer);
+    auto picture = layerContext->finishRecordingAsPicture();
     if (picture != nullptr) {
       drawLayer(std::move(picture), {}, layer->layerPaint.getBrush(),
                 layer->layerPaint.getImageFilter());

--- a/src/core/PictureContext.h
+++ b/src/core/PictureContext.h
@@ -35,12 +35,8 @@ class PictureContext : public DrawContext {
    * Signals that the caller is done recording and returns a Picture object that captures all the
    * drawing commands made to the context. Returns nullptr if no recording is active or no commands
    * were recorded.
-   * @param shrinkToFit If true, optimizes the Picture to use minimal memory, which may involve
-   * copying and a slight overhead. This is recommended for long-lived Pictures. If false, memory is
-   * transferred directly for better performance, making it ideal for short-lived Pictures. The
-   * default value is true.
    */
-  std::shared_ptr<Picture> finishRecordingAsPicture(bool shrinkToFit = true);
+  std::shared_ptr<Picture> finishRecordingAsPicture();
 
   void drawFill(const Brush& brush) override;
 

--- a/src/core/PictureRecorder.cpp
+++ b/src/core/PictureRecorder.cpp
@@ -28,7 +28,7 @@ PictureRecorder::~PictureRecorder() {
 Canvas* PictureRecorder::beginRecording() {
   if (canvas == nullptr) {
     pictureContext = new PictureContext();
-    canvas = new Canvas(pictureContext, nullptr, optimizeMemory);
+    canvas = new Canvas(pictureContext);
   } else {
     canvas->resetStateStack();
     pictureContext->clear();
@@ -46,6 +46,6 @@ std::shared_ptr<Picture> PictureRecorder::finishRecordingAsPicture() {
     return nullptr;
   }
   activelyRecording = false;
-  return pictureContext->finishRecordingAsPicture(optimizeMemory);
+  return pictureContext->finishRecordingAsPicture();
 }
 }  // namespace tgfx

--- a/src/core/utils/BlockAllocator.cpp
+++ b/src/core/utils/BlockAllocator.cpp
@@ -34,14 +34,6 @@ BlockBuffer::~BlockBuffer() {
   }
 }
 
-void* BlockBuffer::shrinkLastBlockTo(size_t newSize) {
-  auto& lastBlock = blocks.back();
-  if (auto resizedBlock = static_cast<uint8_t*>(realloc(lastBlock, newSize))) {
-    lastBlock = resizedBlock;
-  }
-  return lastBlock;
-}
-
 BlockAllocator::BlockAllocator(size_t initBlockSize, size_t maxBlockSize)
     : initBlockSize(initBlockSize), maxBlockSize(maxBlockSize) {
   DEBUG_ASSERT(initBlockSize > 0);

--- a/src/core/utils/BlockAllocator.h
+++ b/src/core/utils/BlockAllocator.h
@@ -40,11 +40,6 @@ class BlockBuffer {
 
   ~BlockBuffer();
 
-  /**
-   * Shrinks the last memory block to the specified size. Returns a pointer to the resized block.
-   */
-  void* shrinkLastBlockTo(size_t newSize);
-
  private:
   std::vector<uint8_t*> blocks = {};
 };

--- a/src/core/utils/PlacementPtr.h
+++ b/src/core/utils/PlacementPtr.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <type_traits>
 
 namespace tgfx {
@@ -165,14 +164,6 @@ class PlacementPtr {
     T* temp = pointer;
     pointer = nullptr;
     return temp;
-  }
-
-  void remap(const void* oldBlock, const void* newBlock) {
-    if (pointer) {
-      auto oldPointer = reinterpret_cast<uint8_t*>(pointer);
-      pointer = reinterpret_cast<T*>(reinterpret_cast<uint8_t*>(const_cast<void*>(newBlock)) +
-                                     (oldPointer - reinterpret_cast<const uint8_t*>(oldBlock)));
-    }
   }
 
   T& operator*() const {

--- a/src/layers/LayerRecorder.cpp
+++ b/src/layers/LayerRecorder.cpp
@@ -26,7 +26,7 @@ Canvas* LayerRecorder::getCanvas(LayerContentType contentType) {
   Canvas* canvas = nullptr;
   auto& recorder = recorders[static_cast<size_t>(contentType)];
   if (recorder == nullptr) {
-    recorder = std::make_unique<PictureRecorder>(true);
+    recorder = std::make_unique<PictureRecorder>();
     canvas = recorder->beginRecording();
   } else {
     canvas = recorder->getRecordingCanvas();

--- a/src/svg/xml/XMLDOM.cpp
+++ b/src/svg/xml/XMLDOM.cpp
@@ -93,7 +93,7 @@ DOMNode::~DOMNode() {
   if (nextSibling) {
     stack.emplace_back(std::move(nextSibling));
   }
-  
+
   while (!stack.empty()) {
     auto node = std::move(stack.back());
     stack.pop_back();


### PR DESCRIPTION
移除 PictureRecorder 的 optimizeMemory 参数及所有相关代码：

- 移除 PictureRecorder 构造函数的 optimizeMemory 参数和成员变量
- 移除 Canvas 的 optimizeMemoryForLayer 成员变量和构造函数参数
- 移除 PictureContext::finishRecordingAsPicture 的 shrinkToFit 参数及相关逻辑
- 移除 BlockBuffer::shrinkLastBlockTo 方法
- 移除 PlacementPtr::remap 方法