### PR TITLE
Fix memory leak in DisplayList partial rendering mode when resizing window.

### DIFF
--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -357,6 +357,7 @@ std::vector<Rect> DisplayList::renderPartial(Surface* surface, bool autoClear,
   if (partialCache == nullptr || partialCache->getContext() != context ||
       partialCache->width() != surface->width() || partialCache->height() != surface->height() ||
       !ColorSpace::Equals(partialCache->colorSpace().get(), surface->colorSpace().get())) {
+    surfaceCaches.clear();
     partialCache = Surface::Make(context, surface->width(), surface->height(), ColorType::RGBA_8888,
                                  1, false, surface->renderFlags(), surface->colorSpace());
     if (partialCache == nullptr) {


### PR DESCRIPTION
## 问题描述

在 Partial 渲染模式下（DisplayList 的默认模式），连续拖动窗口缩放会导致内存持续增长，最终导致触发 OOM

## 根本原因

在 `DisplayList::renderPartial()` 方法中，当检测到窗口大小变化时：
- 会创建新的 `partialCache` Surface 来匹配新的窗口尺寸
- 新 Surface 被添加到 `surfaceCaches` 容器中
- **但旧的 Surface 从未被清理**，导致内存泄漏

每次窗口大小改变都会创建一个新的 Surface，这些缓存不断累积，最终导致内存暴涨。

## 复现
- 在 Hello2D 示例中添加一个 displayList 不需要添加任何内容，drawer 部分也可以注释。
- 运行拖动窗口缩放即可复现