### PR TITLE
Add visibility guard to layer hit testing

### DIFF
--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -669,6 +669,9 @@ Point Layer::localToGlobal(const Point& localPoint) const {
 }
 
 bool Layer::hitTestPoint(float x, float y, bool shapeHitTest) {
+  if (!visible()) {
+    return false;
+  }
   if (auto content = getContent()) {
     Point localPoint = globalToLocal(Point::Make(x, y));
     if (shapeHitTest) {


### PR DESCRIPTION
1. Layer hitTest 应该优先检查自身 visible 更为合理