### PR TITLE
Add Shape::ApplyReverse method to reverse path direction.

### DIFF
--- a/include/tgfx/core/Shape.h
+++ b/include/tgfx/core/Shape.h
@@ -110,6 +110,12 @@ class Shape {
    */
   static std::shared_ptr<Shape> ApplyFillType(std::shared_ptr<Shape> shape, PathFillType fillType);
 
+  /**
+   * Creates a new Shape by reversing the path direction of the given Shape. Returns nullptr if the
+   * shape is nullptr.
+   */
+  static std::shared_ptr<Shape> ApplyReverse(std::shared_ptr<Shape> shape);
+
   virtual ~Shape();
 
   /**
@@ -150,6 +156,7 @@ class Shape {
     Matrix,
     Merge,
     Path,
+    Reverse,
     Stroke,
     Provider,
     Glyph,
@@ -186,6 +193,7 @@ class Shape {
   friend class MatrixShape;
   friend class Matrix3DShape;
   friend class FillTypeShape;
+  friend class ReverseShape;
   friend class MergeShape;
   friend class EffectShape;
   friend class ShapeDrawOp;

--- a/src/core/Path.cpp
+++ b/src/core/Path.cpp
@@ -545,8 +545,10 @@ void Path::transform3D(const Matrix3D& matrix) {
 
 void Path::reverse() {
   auto& path = writableRef()->path;
+  auto fillType = path.getFillType();
   SkPath tempPath;
   tempPath.reverseAddPath(path);
+  tempPath.setFillType(fillType);
   path = tempPath;
 }
 

--- a/src/core/shapes/ReverseShape.cpp
+++ b/src/core/shapes/ReverseShape.cpp
@@ -1,0 +1,45 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ReverseShape.h"
+#include "core/shapes/PathShape.h"
+
+namespace tgfx {
+
+std::shared_ptr<Shape> Shape::ApplyReverse(std::shared_ptr<Shape> shape) {
+  if (shape == nullptr) {
+    return nullptr;
+  }
+  if (shape->type() == Type::Path) {
+    auto path = std::static_pointer_cast<PathShape>(shape)->path;
+    path.reverse();
+    return std::make_shared<PathShape>(std::move(path));
+  }
+  if (shape->type() == Type::Reverse) {
+    auto reverseShape = std::static_pointer_cast<ReverseShape>(shape);
+    return reverseShape->shape;
+  }
+  return std::make_shared<ReverseShape>(std::move(shape));
+}
+
+Path ReverseShape::onGetPath(float resolutionScale) const {
+  auto path = shape->onGetPath(resolutionScale);
+  path.reverse();
+  return path;
+}
+}  // namespace tgfx

--- a/src/core/shapes/ReverseShape.h
+++ b/src/core/shapes/ReverseShape.h
@@ -1,0 +1,49 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2025 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "core/shapes/UniqueKeyShape.h"
+
+namespace tgfx {
+class ReverseShape : public UniqueKeyShape {
+ public:
+  explicit ReverseShape(std::shared_ptr<Shape> shape) : shape(std::move(shape)) {
+  }
+
+  PathFillType fillType() const override {
+    return shape->fillType();
+  }
+
+  Rect onGetBounds() const override {
+    return shape->onGetBounds();
+  }
+
+ protected:
+  Type type() const override {
+    return Type::Reverse;
+  }
+
+  Path onGetPath(float resolutionScale) const override;
+
+ private:
+  std::shared_ptr<Shape> shape = nullptr;
+
+  friend class Shape;
+};
+}  // namespace tgfx

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -1048,6 +1048,39 @@ TGFX_TEST(CanvasTest, MergeShapeFillType) {
   EXPECT_EQ(merged->fillType(), PathFillType::EvenOdd);
 }
 
+TGFX_TEST(CanvasTest, ReverseShape) {
+  Path path;
+  path.moveTo(0, 0);
+  path.lineTo(100, 0);
+  path.lineTo(100, 100);
+  path.close();
+
+  auto shape = Shape::MakeFrom(path);
+  ASSERT_TRUE(shape != nullptr);
+  EXPECT_EQ(shape->fillType(), PathFillType::Winding);
+
+  // Apply reverse
+  auto reversedShape = Shape::ApplyReverse(shape);
+  ASSERT_TRUE(reversedShape != nullptr);
+  EXPECT_EQ(reversedShape->fillType(), PathFillType::Winding);
+  EXPECT_EQ(reversedShape->getBounds(), shape->getBounds());
+
+  // Reverse with inverse fill type
+  auto inverseShape = Shape::ApplyFillType(shape, PathFillType::InverseWinding);
+  auto reversedInverse = Shape::ApplyReverse(inverseShape);
+  EXPECT_EQ(reversedInverse->fillType(), PathFillType::InverseWinding);
+
+  // Double reverse on ReverseShape should return the inner shape
+  auto matrixShape = Shape::ApplyMatrix(shape, Matrix::MakeTrans(10, 10));
+  auto reversedMatrix = Shape::ApplyReverse(matrixShape);
+  auto doubleReversed = Shape::ApplyReverse(reversedMatrix);
+  EXPECT_EQ(doubleReversed, matrixShape);
+
+  // Reverse nullptr should return nullptr
+  auto nullReversed = Shape::ApplyReverse(nullptr);
+  EXPECT_EQ(nullReversed, nullptr);
+}
+
 TGFX_TEST(CanvasTest, image) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
为 Shape 类新增 ApplyReverse 静态方法，用于反转路径方向。

主要变更：
- 新增 Shape::ApplyReverse 公开 API
- 新增 ReverseShape 类实现路径方向反转
- 修复 Path::reverse() 方法，保留原有的 fillType
- 新增单元测试验证功能正确性

优化处理：
- 对 PathShape 直接操作 Path 避免额外包装
- 双重 reverse 时返回内部 shape 避免冗余嵌套