### PR TITLE
Add inverted parameter to PathEffect::MakeTrim for complement trimming.

### DIFF
--- a/include/tgfx/core/PathEffect.h
+++ b/include/tgfx/core/PathEffect.h
@@ -48,14 +48,18 @@ class PathEffect {
   static std::shared_ptr<PathEffect> MakeCorner(float radius);
 
   /**
-   * Creates a path effect that returns a segment of the input path based on the given start and
-   * stop "t" values. The startT and stopT values must be between 0 and 1, inclusive. If they are
-   * outside this range, they will be clamped to the nearest valid value. If either value is NaN,
-   * nullptr will be returned.
-   * @param startT The starting point of the path segment to be returned.
-   * @param stopT The ending point of the path segment to be returned.
+   * Creates a path effect that returns a subset of the input path based on the given startT and
+   * stopT values. The trim values apply to the entire path, so if it contains several contours,
+   * all of them are included in the calculation. The startT and stopT values must be in the range
+   * of 0 to 1 (inclusive). If they are outside this range, they will be clamped to the nearest
+   * valid value. Returns nullptr if either value is NaN, or if the result would be the full path
+   * (no trimming needed).
+   * @param startT The starting "t" value for the segment.
+   * @param stopT The ending "t" value for the segment.
+   * @param inverted If false (default), returns the subset [startT, stopT]. If true, returns the
+   * complement [0, startT] + [stopT, 1].
    */
-  static std::shared_ptr<PathEffect> MakeTrim(float startT, float stopT);
+  static std::shared_ptr<PathEffect> MakeTrim(float startT, float stopT, bool inverted = false);
 
   virtual ~PathEffect() = default;
 

--- a/src/core/TrimPathEffect.h
+++ b/src/core/TrimPathEffect.h
@@ -23,7 +23,8 @@
 namespace tgfx {
 class TrimPathEffect : public PathEffect {
  public:
-  TrimPathEffect(float startT, float stopT) : startT(startT), stopT(stopT) {
+  TrimPathEffect(float startT, float stopT, bool inverted)
+      : startT(startT), stopT(stopT), inverted(inverted) {
   }
 
   bool filterPath(Path* path) const override;
@@ -31,5 +32,6 @@ class TrimPathEffect : public PathEffect {
  private:
   float startT = 0.0f;
   float stopT = 1.0f;
+  bool inverted = false;
 };
 }  // namespace tgfx

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -74,6 +74,7 @@
         "StrokeShape": "fa6d7439",
         "StrokeShape_miter": "cd6a8dff",
         "TileModeFallback": "2931d737",
+        "TrimPathEffect": "5cb6297a",
         "YUVImage": "6b4e5ce0",
         "YUVImage_RGBAA": "6b4e5ce0",
         "altas": "6b4e5ce0",


### PR DESCRIPTION
为 `PathEffect::MakeTrim` 添加 `inverted` 参数，支持返回路径的补集部分。

- 当 `inverted = false`（默认）时，返回 `[startT, stopT]` 区间的路径段
- 当 `inverted = true` 时，返回补集 `[0, startT] + [stopT, 1]` 两段路径

同时优化了边界条件处理：
- 当结果为完整路径（无需裁剪）时返回 nullptr
- 使用 `std::isnan` 替代 `isnan`

新增测试用例覆盖正常裁剪、反转裁剪及各种边界条件。