### PR TITLE
Add ColorSpace check when reusing tile caches in tiled rendering mode.

### DIFF
--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -407,7 +407,9 @@ std::vector<Rect> DisplayList::renderPartial(Surface* surface, bool autoClear,
 
 std::vector<Rect> DisplayList::renderTiled(Surface* surface, bool autoClear,
                                            const std::vector<Rect>& dirtyRegions) {
-  if (!surfaceCaches.empty() && surfaceCaches.front()->getContext() != surface->getContext()) {
+  if (!surfaceCaches.empty() && (surfaceCaches.front()->getContext() != surface->getContext() ||
+                                 !ColorSpace::Equals(surfaceCaches.front()->colorSpace().get(),
+                                                     surface->colorSpace().get()))) {
     resetCaches();
   }
   checkTileCount(surface);


### PR DESCRIPTION
当使用不同 ColorSpace 的 Surface 进行渲染时（例如先用 sRGB Surface 渲染，再用 Display P3 Surface 渲染），会复用旧 ColorSpace 创建的 atlas Surface 进行绘制，导致颜色显示错误。本次修改在 renderTiled 中增加了 ColorSpace 一致性检查，当 ColorSpace 不匹配时，清空所有缓存并重新渲染，确保颜色正确。