### PR TITLE
iOS Hello2D: shared xcconfig for signing and Cursor symlinks to CodeBuddy.

### DIFF
--- a/.cursor/rlues
+++ b/.cursor/rlues
@@ -1,0 +1,1 @@
+../.codebuddy/rules

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.codebuddy/skills

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,2 @@
+/metal/xcconfigs/*.local.xcconfig
+/opengl/xcconfigs/*.local.xcconfig

--- a/ios/metal/Hello2D.xcodeproj/project.pbxproj
+++ b/ios/metal/Hello2D.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A1000001000000000000000A /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1000001000000000000000B /* MetalKit.framework */; };
 		E1BF1B702E44A64000F99C5E /* tgfx.png in Resources */ = {isa = PBXBuildFile; fileRef = E1BF1B6F2E44A64000F99C5E /* tgfx.png */; };
 		E61EC8172AF1FCAE00C82F9E /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E61EC8162AF1FCAE00C82F9E /* AppDelegate.m */; };
 		E61EC81A2AF1FCAE00C82F9E /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E61EC8192AF1FCAE00C82F9E /* SceneDelegate.m */; };
@@ -19,10 +20,10 @@
 		F25AD0712AF90ECD0017339D /* bridge.jpg in Resources */ = {isa = PBXBuildFile; fileRef = F25AD0702AF90ECD0017339D /* bridge.jpg */; };
 		F276A9802AF8D42200E482B7 /* TGFXView.mm in Sources */ = {isa = PBXBuildFile; fileRef = F276A97F2AF8D42200E482B7 /* TGFXView.mm */; };
 		F2F2CEFA2B0B51CD0092BD3B /* tgfx-hello2d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F2F2CEF92B0B51CD0092BD3B /* tgfx-hello2d.a */; };
-		A1000001000000000000000A /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1000001000000000000000B /* MetalKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		A1000001000000000000000B /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 		E1BF1B6F2E44A64000F99C5E /* tgfx.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tgfx.png; sourceTree = "<group>"; };
 		E61EC8122AF1FCAE00C82F9E /* Hello2D.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hello2D.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E61EC8152AF1FCAE00C82F9E /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -41,8 +42,11 @@
 		F276A97E2AF8D3EB00E482B7 /* TGFXView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TGFXView.h; sourceTree = "<group>"; };
 		F276A97F2AF8D42200E482B7 /* TGFXView.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = TGFXView.mm; sourceTree = "<group>"; };
 		F2F2CEF92B0B51CD0092BD3B /* tgfx-hello2d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "tgfx-hello2d.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A1000001000000000000000B /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = System/Library/Frameworks/MetalKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		3CF6DF782F7CBE9D004C64FE /* xcconfigs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = xcconfigs; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		E61EC80F2AF1FCAE00C82F9E /* Frameworks */ = {
@@ -61,6 +65,7 @@
 		E61EC8092AF1FCAE00C82F9E = {
 			isa = PBXGroup;
 			children = (
+				3CF6DF782F7CBE9D004C64FE /* xcconfigs */,
 				E61EC8142AF1FCAE00C82F9E /* Hello2D */,
 				E61EC8132AF1FCAE00C82F9E /* Products */,
 				E61EC82E2AF1FEAE00C82F9E /* Frameworks */,
@@ -220,6 +225,8 @@
 /* Begin XCBuildConfiguration section */
 		E61EC8292AF1FCB000C82F9E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3CF6DF782F7CBE9D004C64FE /* xcconfigs */;
+			baseConfigurationReferenceRelativePath = Base.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -282,6 +289,8 @@
 		};
 		E61EC82A2AF1FCB000C82F9E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3CF6DF782F7CBE9D004C64FE /* xcconfigs */;
+			baseConfigurationReferenceRelativePath = Base.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -342,10 +351,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 36588GHG2N;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Hello2D/Info.plist;
@@ -362,9 +371,9 @@
 				LIBRARY_SEARCH_PATHS = "";
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = org.tgfx.hello2d;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "$(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = (
@@ -381,10 +390,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 36588GHG2N;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Hello2D/Info.plist;
@@ -401,9 +410,9 @@
 				LIBRARY_SEARCH_PATHS = "";
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = org.tgfx.hello2d;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "$(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = (

--- a/ios/metal/xcconfigs/Base.xcconfig
+++ b/ios/metal/xcconfigs/Base.xcconfig
@@ -1,0 +1,17 @@
+//
+//  Base.xcconfig
+//  Hello2D
+//
+//  Created by king on 2026/4/1.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+CODE_SIGN_STYLE = Automatic
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = 36588GHG2N
+PRODUCT_BUNDLE_IDENTIFIER = org.tgfx.hello2d
+PROVISIONING_PROFILE_SPECIFIER =
+
+#include? "Development.local.xcconfig"

--- a/ios/opengl/Hello2D.xcodeproj/project.pbxproj
+++ b/ios/opengl/Hello2D.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -42,6 +42,10 @@
 		F2F2CEF92B0B51CD0092BD3B /* tgfx-hello2d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "tgfx-hello2d.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		3CF6DF7C2F7CC021004C64FE /* xcconfigs */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = xcconfigs; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		E61EC80F2AF1FCAE00C82F9E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -58,6 +62,7 @@
 		E61EC8092AF1FCAE00C82F9E = {
 			isa = PBXGroup;
 			children = (
+				3CF6DF7C2F7CC021004C64FE /* xcconfigs */,
 				E61EC8142AF1FCAE00C82F9E /* Hello2D */,
 				E61EC8132AF1FCAE00C82F9E /* Products */,
 				E61EC82E2AF1FEAE00C82F9E /* Frameworks */,
@@ -216,6 +221,8 @@
 /* Begin XCBuildConfiguration section */
 		E61EC8292AF1FCB000C82F9E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3CF6DF7C2F7CC021004C64FE /* xcconfigs */;
+			baseConfigurationReferenceRelativePath = Base.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -278,6 +285,8 @@
 		};
 		E61EC82A2AF1FCB000C82F9E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 3CF6DF7C2F7CC021004C64FE /* xcconfigs */;
+			baseConfigurationReferenceRelativePath = Base.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -338,10 +347,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 36588GHG2N;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"GLES_SILENCE_DEPRECATION=1",
@@ -362,9 +371,9 @@
 				LIBRARY_SEARCH_PATHS = "";
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = org.tgfx.hello2d;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "$(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = (
@@ -381,10 +390,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "$(inherited)";
+				CODE_SIGN_STYLE = "$(inherited)";
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 36588GHG2N;
+				DEVELOPMENT_TEAM = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = "GLES_SILENCE_DEPRECATION=1";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";
@@ -402,9 +411,9 @@
 				LIBRARY_SEARCH_PATHS = "";
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = org.tgfx.hello2d;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "$(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = (

--- a/ios/opengl/xcconfigs/Base.xcconfig
+++ b/ios/opengl/xcconfigs/Base.xcconfig
@@ -1,0 +1,17 @@
+//
+//  Base.xcconfig
+//  Hello2D
+//
+//  Created by king on 2026/4/1.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+CODE_SIGN_STYLE = Automatic
+CODE_SIGN_IDENTITY = Apple Development
+DEVELOPMENT_TEAM = 36588GHG2N
+PRODUCT_BUNDLE_IDENTIFIER = org.tgfx.hello2d
+PROVISIONING_PROFILE_SPECIFIER =
+
+#include? "Development.local.xcconfig"


### PR DESCRIPTION
1. iOS Metal 与 OpenGL 的 Hello2D 示例改为通过 Base.xcconfig 集中管理代码签名、开发团队与 bundle identifier，工程设置里改为继承这些值。可在各 xcconfigs 目录下使用 Development.local.xcconfig 做本地覆盖 实现使用自己的开发者账号进行真机调试。而不会产生git变更 例如
```
CODE_SIGN_STYLE = Manual
CODE_SIGN_IDENTITY = Apple Development
DEVELOPMENT_TEAM = xxx
PRODUCT_BUNDLE_IDENTIFIER = xxxx
PROVISIONING_PROFILE_SPECIFIER = match Development xxxx
```

2. 新增 .cursor 下指向 CodeBuddy 规则与 skills 的符号链接，便于在 Cursor 中复用既有配置。