### PR TITLE
Fix ClipStack uniqueID not updating on Empty state transition.

### DIFF
--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -36,6 +36,10 @@ enum class ClipGeometry {
   Both
 };
 
+/**
+ * Resolves which clip elements to keep when combining two clip elements. Returns BOnly when A and B
+ * are equivalent.
+ */
 static ClipGeometry ResolveClipGeometry(const ClipElement& a, const ClipElement& b) {
   const auto boundsA = a.bounds();
   const auto boundsB = b.bounds();
@@ -55,6 +59,9 @@ static ClipGeometry ResolveClipGeometry(const ClipElement& a, const ClipElement&
 
   // Complex paths cannot be simplified, keep both.
   if (!a.isRect() && !b.isRect()) {
+    if (a.path().isSame(b.path())) {
+      return ClipGeometry::BOnly;
+    }
     return ClipGeometry::Both;
   }
 

--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -59,7 +59,7 @@ static ClipGeometry ResolveClipGeometry(const ClipElement& a, const ClipElement&
 
   // Complex paths cannot be simplified, keep both.
   if (!a.isRect() && !b.isRect()) {
-    if (a.path().isSame(b.path())) {
+    if (a.path().isSame(b.path()) && a.isAntiAlias() == b.isAntiAlias()) {
       return ClipGeometry::BOnly;
     }
     return ClipGeometry::Both;

--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -230,10 +230,12 @@ bool ClipStack::addElement(ClipElement&& toAdd) {
   }
   if (toAdd.bounds().isEmpty()) {
     cur.state = ClipState::Empty;
+    cur.uniqueID = UniqueID::Next();
     return true;
   }
   if (!Rect::Intersects(toAdd.bounds(), cur.bounds)) {
     cur.state = ClipState::Empty;
+    cur.uniqueID = UniqueID::Next();
     return true;
   }
   // The new element completely contains current clip, so it's redundant.

--- a/src/gpu/OpsCompositor.cpp
+++ b/src/gpu/OpsCompositor.cpp
@@ -806,13 +806,19 @@ std::shared_ptr<TextureProxy> OpsCompositor::makeClipTexture(
     DEBUG_ASSERT(element->isValid());
     const auto aaType = element->isAntiAlias() ? AAType::Coverage : AAType::None;
     auto clipBounds = Rect::MakeWH(width, height);
-    auto shape = Shape::MakeFrom(element->path());
+    auto path = element->path();
+    if (i > 0) {
+      // Modulate blend erases the mask when hasCoverage is true (source coefficient becomes zero).
+      // Use inverse fill + DstOut to erase areas outside each clip shape instead.
+      path.toggleInverseFillType();
+    }
+    auto shape = Shape::MakeFrom(path);
     shape = Shape::ApplyMatrix(std::move(shape), rasterizeMatrix);
     auto shapeProxy = proxyProvider()->createGPUShapeProxy(shape, aaType, clipBounds, renderFlags);
     auto uvMatrix = Matrix::MakeTrans(bounds.left, bounds.top);
     auto drawOp = ShapeDrawOp::Make(std::move(shapeProxy), {}, uvMatrix, aaType);
     if (i > 0) {
-      drawOp->setBlendMode(BlendMode::Modulate);
+      drawOp->setBlendMode(BlendMode::DstOut);
     }
     clipDrawOps.emplace_back(std::move(drawOp));
   }

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -48,6 +48,7 @@
         "DrawShapeAutoBatch_WithShader": "4df17714",
         "DrawTextBlob": "29dde9e0",
         "DuplicateClipPath": "f870cce1",
+        "EmptyClipMerge": "23eac4df",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",
         "LumaFilterToSRGB": "82494664",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -47,6 +47,7 @@
         "DrawShapeAutoBatch_Stroke": "4df17714",
         "DrawShapeAutoBatch_WithShader": "4df17714",
         "DrawTextBlob": "29dde9e0",
+        "DuplicateClipPath": "f870cce1",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",
         "LumaFilterToSRGB": "82494664",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -191,7 +191,18 @@ TGFX_TEST(CanvasTest, Clip) {
   canvas->clipStack->transform(Matrix::MakeRotate(45.0f));
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
 
-  // ========== 13. Screenshot: AA vs non-AA ==========
+  // ========== 13. Duplicate non-rect clipPath elimination ==========
+  surface = Surface::Make(context, 100, 100);
+  canvas = surface->getCanvas();
+  Path rrectPath = {};
+  rrectPath.addRoundRect(Rect::MakeLTRB(10, 10, 90, 90), 10, 10);
+  canvas->clipPath(rrectPath);
+  EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+  canvas->clipPath(rrectPath);
+  EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+
+  // ========== 14. Screenshot: AA vs non-AA ==========
   // Note: When the path bounds are small, texture-based rasterization is used internally
   // for performance reasons. In this case, setting antiAlias to false may not completely
   // eliminate edge smoothing due to texture sampling characteristics.
@@ -218,6 +229,27 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->restore();
   }
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/ClipAntiAlias"));
+
+  // ========== 15. Screenshot: duplicate non-rect clipPath rendering ==========
+  // Use two separately constructed paths with identical data to bypass isSame() elimination,
+  // ensuring the makeClipTexture inverse-fill + DstOut logic is exercised.
+  surface = Surface::Make(context, 200, 200);
+  canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+  {
+    canvas->save();
+    Path rrPath1 = {};
+    rrPath1.addRoundRect(Rect::MakeLTRB(20, 20, 180, 180), 20, 20);
+    Path rrPath2 = {};
+    rrPath2.addRoundRect(Rect::MakeLTRB(20, 20, 180, 180), 20, 20);
+    canvas->clipPath(rrPath1);
+    canvas->clipPath(rrPath2);
+    Paint paint = {};
+    paint.setColor(Color::Blue());
+    canvas->drawRect(Rect::MakeWH(200, 200), paint);
+    canvas->restore();
+  }
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/DuplicateClipPath"));
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -252,6 +252,29 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->restore();
   }
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/DuplicateClipPath"));
+
+  // Verify that ClipStack updates its uniqueID when transitioning to Empty state, preventing
+  // incorrect draw op batching due to stale uniqueID comparison.
+  surface = Surface::Make(context, 100, 100);
+  canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+  canvas->clipRect(Rect::MakeWH(100, 100));
+  {
+    canvas->save();
+    Path nonIntersecting;
+    nonIntersecting.addRect(Rect::MakeXYWH(300, 300, 50, 50));
+    canvas->clipPath(nonIntersecting);
+    Paint paint;
+    paint.setColor(Color::Green());
+    canvas->drawRect(Rect::MakeXYWH(10, 10, 40, 40), paint);
+    canvas->restore();
+  }
+  {
+    Paint paint;
+    paint.setColor(Color::Green());
+    canvas->drawRect(Rect::MakeXYWH(25, 25, 50, 50), paint);
+  }
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyClipMerge"));
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -201,6 +201,8 @@ TGFX_TEST(CanvasTest, Clip) {
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
   canvas->clipPath(rrectPath);
   EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+  canvas->clipPath(rrectPath, false);
+  EXPECT_EQ(canvas->clipStack->elements().size(), 2u);
 
   // ========== 14. Screenshot: AA vs non-AA ==========
   // Note: When the path bounds are small, texture-based rasterization is used internally


### PR DESCRIPTION
修复 ClipStack::addElement 中裁剪区域变为 Empty 状态时未更新 uniqueID 的问题。当 clipPath
  与当前裁剪区域不相交时，ClipStack 状态被设为 Empty 但 uniqueID 保持不变，导致 OpsCompositor 的 canAppend 通过 isSame
  比较时误判不同裁剪状态的绘制操作为相同，触发错误合批。在 Tiled 渲染模式下，有 mask 的子层使裁剪区域变为 Empty
  后，后续子层的绘制操作被错误合并到 Empty 裁剪的批次中，最终内容丢失。