### PR TITLE
Fix sign-conversion warnings in JpegCodec scaled dimensions calculation

### DIFF
--- a/src/core/codecs/jpeg/JpegCodec.cpp
+++ b/src/core/codecs/jpeg/JpegCodec.cpp
@@ -218,8 +218,9 @@ std::pair<int, int> JpegCodec::getScaledDimensions(float scale) const {
       // Replicate libjpeg-turbo's output dimension formula:
       // output_dim = (image_dim * scale_num + scale_denom - 1) / scale_denom
       auto denom = static_cast<long>(JPEG_SCALE_DENOM);
-      auto outputWidth = static_cast<int>((static_cast<long>(width()) * n + denom - 1) / denom);
-      auto outputHeight = static_cast<int>((static_cast<long>(height()) * n + denom - 1) / denom);
+      auto numLong = static_cast<long>(n);
+      auto outputWidth = static_cast<int>((static_cast<long>(width()) * numLong + denom - 1) / denom);
+      auto outputHeight = static_cast<int>((static_cast<long>(height()) * numLong + denom - 1) / denom);
       return {outputWidth, outputHeight};
     }
   }

--- a/src/core/codecs/jpeg/JpegCodec.cpp
+++ b/src/core/codecs/jpeg/JpegCodec.cpp
@@ -219,8 +219,10 @@ std::pair<int, int> JpegCodec::getScaledDimensions(float scale) const {
       // output_dim = (image_dim * scale_num + scale_denom - 1) / scale_denom
       auto denom = static_cast<long>(JPEG_SCALE_DENOM);
       auto numLong = static_cast<long>(n);
-      auto outputWidth = static_cast<int>((static_cast<long>(width()) * numLong + denom - 1) / denom);
-      auto outputHeight = static_cast<int>((static_cast<long>(height()) * numLong + denom - 1) / denom);
+      auto outputWidth =
+          static_cast<int>((static_cast<long>(width()) * numLong + denom - 1) / denom);
+      auto outputHeight =
+          static_cast<int>((static_cast<long>(height()) * numLong + denom - 1) / denom);
       return {outputWidth, outputHeight};
     }
   }


### PR DESCRIPTION
Explicitly cast the scale numerator to long type to prevent implicit sign-conversion warnings when performing arithmetic operations with long denominator values.