### PR TITLE
Fixed seams in fallback tile rendering by adjusting rect rounding logic.

### DIFF
--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -954,7 +954,6 @@ void DisplayList::drawScreenTasks(std::vector<DrawTask> screenTasks, Surface* su
                           SrcRectConstraint::Strict);
     tileRect.join(task.tileRect());
   }
-  tileRect.roundOut();
 
   auto screenRect = Rect::MakeWH(surface->width(), surface->height());
   screenRect.offset(-_contentOffset.x, -_contentOffset.y);

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -91,12 +91,19 @@ class DrawTask {
     }));
     auto& tile = tiles.front();
     _tileRect = drawRect.isEmpty() ? tile->getTileRect(tileSize) : drawRect;
+    // For fallback rendering, round to integers to ensure precise pixel mapping with sourceRect.
+    if (!_identityScale) {
+      _tileRect.roundOut();
+    }
     _sourceRect = _tileRect;
     auto offsetX = (tile->sourceX - tile->tileX) * tileSize;
     auto offsetY = (tile->sourceY - tile->tileY) * tileSize;
     _sourceRect.offset(static_cast<float>(offsetX), static_cast<float>(offsetY));
     _tileRect.scale(scale, scale);
-    _tileRect.round();
+    // Round to pixel boundaries for 1:1 mapping; fallback uses linear sampling with float coords.
+    if (_identityScale) {
+      _tileRect.round();
+    }
   }
 };
 
@@ -947,13 +954,20 @@ void DisplayList::drawScreenTasks(std::vector<DrawTask> screenTasks, Surface* su
                           SrcRectConstraint::Strict);
     tileRect.join(task.tileRect());
   }
+  tileRect.roundOut();
 
   auto screenRect = Rect::MakeWH(surface->width(), surface->height());
   screenRect.offset(-_contentOffset.x, -_contentOffset.y);
-  screenRect.roundOut();
   if (tileRect.contains(screenRect)) {
     return;
   }
+
+  const auto currentZoomScale = ToZoomScaleFloat(_zoomScaleInt, _zoomScalePrecision);
+  auto renderBounds = _root->renderBounds;
+  renderBounds.scale(currentZoomScale, currentZoomScale);
+  renderBounds.roundOut();
+  // Clip to render bounds because fallback tiles may extend beyond content due to roundOut.
+  tileRect.intersect(renderBounds);
 
   paint.setColor(_root->backgroundColor());
   auto backgroundRect = GetNonIntersectingRects(screenRect, tileRect);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -195,7 +195,7 @@
         "DirtyRegionTest5": "bf48e614",
         "DirtyRegionTest6": "bf48e614",
         "DirtyRegionTest7": "bf48e614",
-        "DirtyRegionTest8": "d551b898",
+        "DirtyRegionTest8": "937ddada",
         "DirtyRegionTest9": "bf48e614",
         "LayerCacheWithEffects": "2ce762fb",
         "TileClear_PartialTile": "bf48e614",


### PR DESCRIPTION
Fix visual seams that appeared between fallback tiles during zoom transitions.

The root cause was a mismatch between how tileRect and sourceRect were rounded:
for fallback (non-identity-scale) tiles, tileRect was not rounded before sourceRect
was derived from it, causing sub-pixel misalignment between the source and
destination rectangles during drawImageRect.

Changes:
- In DrawTask::calculateRects, round tileRect out to integers before copying to
  sourceRect when rendering at non-identity scale, ensuring precise pixel mapping.
- Skip the post-scale round() for non-identity-scale tiles since linear sampling
  handles float coordinates correctly.
- In drawScreenTasks, move roundOut to after all tile rects are joined, and clip
  the joined tileRect against renderBounds to prevent fallback tiles that extend
  slightly beyond content (due to roundOut) from incorrectly blocking background
  fill in empty regions.