### PR TITLE
Add EGL robustness support and GPU reset detection for OpenGL contexts.

### DIFF
--- a/include/tgfx/gpu/Device.h
+++ b/include/tgfx/gpu/Device.h
@@ -40,10 +40,11 @@ class Device {
   }
 
   /**
-   * Locks the rendering context associated with this device, if another thread has already locked
+   * Locks the rendering context associated with this device. If another thread has already locked
    * the device by lockContext(), a call to lockContext() will block execution until the device
-   * is available. The returned context can be used to draw graphics. A nullptr is returned If the
-   * context can not be locked on the calling thread, and leaves the device unlocked.
+   * is available. The returned context can be used to draw graphics. A nullptr is returned if the
+   * context cannot be locked on the calling thread (e.g., the GPU context has been permanently lost
+   * due to a GPU reset), and leaves the device unlocked.
    */
   Context* lockContext();
 
@@ -58,6 +59,7 @@ class Device {
   GPU* _gpu = nullptr;
   Context* context = nullptr;
   std::weak_ptr<Device> weakThis;
+  bool _contextLost = false;
 
   explicit Device(std::unique_ptr<GPU> gpu);
   virtual bool onLockContext();

--- a/include/tgfx/gpu/Device.h
+++ b/include/tgfx/gpu/Device.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 
@@ -59,7 +60,11 @@ class Device {
   GPU* _gpu = nullptr;
   Context* context = nullptr;
   std::weak_ptr<Device> weakThis;
-  bool _contextLost = false;
+  /**
+   * A permanent one-way flag indicating the GPU context has been irreversibly lost (e.g., due to a
+   * GPU reset). Once set to true, lockContext() will always return nullptr.
+   */
+  std::atomic<bool> _contextLost{false};
 
   explicit Device(std::unique_ptr<GPU> gpu);
   virtual bool onLockContext();

--- a/include/tgfx/gpu/opengl/GLDevice.h
+++ b/include/tgfx/gpu/opengl/GLDevice.h
@@ -69,12 +69,10 @@ class GLDevice : public Device {
 
   void releaseAll();
 
-  /**
-   * Marks all registered GLDevice instances as context lost. This is used on EGL platforms where a
-   * GPU reset causes all contexts to become invalid simultaneously.
-   */
+ private:
   static void MarkAllContextsLost();
 
+  friend class EGLDevice;
   friend class GLContext;
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/GLDevice.h
+++ b/include/tgfx/gpu/opengl/GLDevice.h
@@ -69,6 +69,12 @@ class GLDevice : public Device {
 
   void releaseAll();
 
+  /**
+   * Marks all registered GLDevice instances as context lost. This is used on EGL platforms where a
+   * GPU reset causes all contexts to become invalid simultaneously.
+   */
+  static void MarkAllContextsLost();
+
   friend class GLContext;
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/egl/EGLDevice.h
+++ b/include/tgfx/gpu/opengl/egl/EGLDevice.h
@@ -62,6 +62,7 @@ class EGLDevice : public GLDevice {
   EGLSurface oldEglReadSurface = nullptr;
   EGLSurface oldEglDrawSurface = nullptr;
   std::shared_ptr<ColorSpace> colorSpace = nullptr;
+  unsigned graphicsResetStatus = 0;  // GL_NO_ERROR
 
   static std::shared_ptr<EGLDevice> MakeFrom(EGLNativeWindowType nativeWindow,
                                              EGLContext sharedContext = nullptr,
@@ -76,6 +77,10 @@ class EGLDevice : public GLDevice {
             std::shared_ptr<ColorSpace> colorSpace = nullptr);
 
   bool recreateSurfaceIfNeeded(EGLNativeWindowType nativeWindow);
+
+  void markContextLost();
+
+  bool checkGraphicsResetStatus();
 
   friend class GLDevice;
 

--- a/include/tgfx/gpu/opengl/egl/EGLDevice.h
+++ b/include/tgfx/gpu/opengl/egl/EGLDevice.h
@@ -78,7 +78,7 @@ class EGLDevice : public GLDevice {
 
   bool recreateSurfaceIfNeeded(EGLNativeWindowType nativeWindow);
 
-  void markContextLost();
+  void handleContextLost();
 
   bool checkGraphicsResetStatus();
 

--- a/include/tgfx/gpu/opengl/egl/EGLGlobals.h
+++ b/include/tgfx/gpu/opengl/egl/EGLGlobals.h
@@ -48,6 +48,6 @@ class EGLGlobals {
    * Indicates whether the EGL display supports the EGL_EXT_create_context_robustness extension,
    * which enables GPU reset detection and loss-of-context notification.
    */
-  bool hasContextRobustness = false;
+  bool contextRobustnessSupported = false;
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/egl/EGLGlobals.h
+++ b/include/tgfx/gpu/opengl/egl/EGLGlobals.h
@@ -44,5 +44,6 @@ class EGLGlobals {
   EGLConfig pbufferConfig = nullptr;
   std::vector<EGLint> windowSurfaceAttributes = {};
   std::vector<EGLint> pbufferSurfaceAttributes = {};
+  bool hasContextRobustness = false;
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/egl/EGLGlobals.h
+++ b/include/tgfx/gpu/opengl/egl/EGLGlobals.h
@@ -44,6 +44,10 @@ class EGLGlobals {
   EGLConfig pbufferConfig = nullptr;
   std::vector<EGLint> windowSurfaceAttributes = {};
   std::vector<EGLint> pbufferSurfaceAttributes = {};
+  /**
+   * Indicates whether the EGL display supports the EGL_EXT_create_context_robustness extension,
+   * which enables GPU reset detection and loss-of-context notification.
+   */
   bool hasContextRobustness = false;
 };
 }  // namespace tgfx

--- a/src/gpu/Device.cpp
+++ b/src/gpu/Device.cpp
@@ -35,6 +35,10 @@ Device::~Device() {
 
 Context* Device::lockContext() {
   locker.lock();
+  if (_contextLost) {
+    locker.unlock();
+    return nullptr;
+  }
   contextLocked = onLockContext();
   if (!contextLocked) {
     locker.unlock();

--- a/src/gpu/opengl/GLDefines.h
+++ b/src/gpu/opengl/GLDefines.h
@@ -168,11 +168,6 @@ namespace tgfx {
 #define GL_CONTEXT_LOST 0x300E
 #define GL_INVALID_INDEX 0xFFFFFFFF
 
-// GL_KHR_robustness / GL_EXT_robustness
-#define GL_GUILTY_CONTEXT_RESET 0x8253
-#define GL_INNOCENT_CONTEXT_RESET 0x8254
-#define GL_UNKNOWN_CONTEXT_RESET 0x8255
-
 // FrontFaceDirection
 #define GL_CW 0x0900
 #define GL_CCW 0x0901

--- a/src/gpu/opengl/GLDefines.h
+++ b/src/gpu/opengl/GLDefines.h
@@ -168,6 +168,11 @@ namespace tgfx {
 #define GL_CONTEXT_LOST 0x300E
 #define GL_INVALID_INDEX 0xFFFFFFFF
 
+// GL_KHR_robustness / GL_EXT_robustness
+#define GL_GUILTY_CONTEXT_RESET 0x8253
+#define GL_INNOCENT_CONTEXT_RESET 0x8254
+#define GL_UNKNOWN_CONTEXT_RESET 0x8255
+
 // FrontFaceDirection
 #define GL_CW 0x0900
 #define GL_CCW 0x0901

--- a/src/gpu/opengl/GLDevice.cpp
+++ b/src/gpu/opengl/GLDevice.cpp
@@ -77,6 +77,15 @@ GLDevice::~GLDevice() {
   deviceMap.erase(nativeHandle);
 }
 
+void GLDevice::MarkAllContextsLost() {
+  std::lock_guard<std::mutex> autoLock(deviceMapLocker);
+  for (auto& item : deviceMap) {
+    item.second->_contextLost = true;
+  }
+  LOGE("GLDevice::MarkAllContextsLost() All %zu GL contexts have been marked as lost.",
+       deviceMap.size());
+}
+
 void GLDevice::releaseAll() {
   std::lock_guard<std::mutex> autoLock(locker);
   if (context == nullptr) {

--- a/src/gpu/opengl/GLFunctions.h
+++ b/src/gpu/opengl/GLFunctions.h
@@ -104,6 +104,7 @@ using GLGenerateMipmap = void GL_FUNCTION_TYPE(unsigned target);
 using GLGenRenderbuffers = void GL_FUNCTION_TYPE(int n, unsigned* renderbuffers);
 using GLGenTextures = void GL_FUNCTION_TYPE(int n, unsigned* textures);
 using GLGetError = unsigned GL_FUNCTION_TYPE();
+using GLGetGraphicsResetStatus = unsigned GL_FUNCTION_TYPE();
 using GLGetIntegerv = void GL_FUNCTION_TYPE(unsigned pname, int* params);
 using GLGetInternalformativ = void GL_FUNCTION_TYPE(unsigned target, unsigned internalformat,
                                                     unsigned pname, int bufSize, int* params);
@@ -241,6 +242,7 @@ class GLFunctions {
   GLGenTextures* genTextures = nullptr;
   GLGenVertexArrays* genVertexArrays = nullptr;
   GLGetError* getError = nullptr;
+  GLGetGraphicsResetStatus* getGraphicsResetStatus = nullptr;
   GLGetIntegerv* getIntegerv = nullptr;
   GLGetInternalformativ* getInternalformativ = nullptr;
   GLGetProgramInfoLog* getProgramInfoLog = nullptr;

--- a/src/gpu/opengl/GLInterface.cpp
+++ b/src/gpu/opengl/GLInterface.cpp
@@ -158,6 +158,21 @@ std::shared_ptr<GLInterface> GLInterface::MakeNativeInterface(const GLProcGetter
   functions->genVertexArrays =
       reinterpret_cast<GLGenVertexArrays*>(getter->getProcAddress("glGenVertexArrays"));
   functions->getError = reinterpret_cast<GLGetError*>(getter->getProcAddress("glGetError"));
+  // Try to get glGetGraphicsResetStatus from various extensions.
+  functions->getGraphicsResetStatus = reinterpret_cast<GLGetGraphicsResetStatus*>(
+      getter->getProcAddress("glGetGraphicsResetStatus"));
+  if (functions->getGraphicsResetStatus == nullptr) {
+    functions->getGraphicsResetStatus = reinterpret_cast<GLGetGraphicsResetStatus*>(
+        getter->getProcAddress("glGetGraphicsResetStatusKHR"));
+  }
+  if (functions->getGraphicsResetStatus == nullptr) {
+    functions->getGraphicsResetStatus = reinterpret_cast<GLGetGraphicsResetStatus*>(
+        getter->getProcAddress("glGetGraphicsResetStatusARB"));
+  }
+  if (functions->getGraphicsResetStatus == nullptr) {
+    functions->getGraphicsResetStatus = reinterpret_cast<GLGetGraphicsResetStatus*>(
+        getter->getProcAddress("glGetGraphicsResetStatusEXT"));
+  }
   functions->getIntegerv =
       reinterpret_cast<GLGetIntegerv*>(getter->getProcAddress("glGetIntegerv"));
   functions->getInternalformativ =

--- a/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/src/gpu/opengl/egl/EGLDevice.cpp
@@ -336,7 +336,7 @@ bool EGLDevice::checkGraphicsResetStatus() {
   if (status != GL_NO_ERROR) {
     graphicsResetStatus = status;
     LOGE("EGLDevice::checkGraphicsResetStatus() GPU reset detected: status=0x%x", status);
-    markContextLost();
+    handleContextLost();
     return true;
   }
   return false;

--- a/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/src/gpu/opengl/egl/EGLDevice.cpp
@@ -304,6 +304,8 @@ void EGLDevice::onUnlockContext() {
     if (error == EGL_CONTEXT_LOST) {
       LOGE("EGLDevice::onUnlockContext() EGL_CONTEXT_LOST detected.");
       markContextLost();
+    } else {
+      LOGE("EGLDevice::onUnlockContext() failure error=%d", error);
     }
   }
   if (oldEglDisplay) {

--- a/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/src/gpu/opengl/egl/EGLDevice.cpp
@@ -19,11 +19,22 @@
 #include "tgfx/gpu/opengl/egl/EGLDevice.h"
 #include <cstring>
 #include "core/utils/Log.h"
+#include "gpu/opengl/GLDefines.h"
+#include "gpu/opengl/GLFunctions.h"
+#include "gpu/opengl/GLGPU.h"
 #include "gpu/opengl/egl/EGLGPU.h"
 #include "tgfx/gpu/opengl/egl/EGLGlobals.h"
 
 #ifndef EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT
 #define EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT -1
+#endif
+
+#ifndef EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT
+#define EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT 0x3138
+#endif
+
+#ifndef EGL_LOSE_CONTEXT_ON_RESET_EXT
+#define EGL_LOSE_CONTEXT_ON_RESET_EXT 0x31BF
 #endif
 
 namespace tgfx {
@@ -37,7 +48,26 @@ static std::vector<EGLint> GetValidAttributes(const std::vector<EGLint>& attribu
 }
 
 static EGLContext CreateContext(EGLContext sharedContext, EGLDisplay eglDisplay,
-                                EGLConfig eglConfig) {
+                                EGLConfig eglConfig, bool hasContextRobustness) {
+  // Try ES 3 with robustness if supported.
+  if (hasContextRobustness) {
+    static const EGLint robust3Attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 3,
+                                               EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT,
+                                               EGL_LOSE_CONTEXT_ON_RESET_EXT, EGL_NONE};
+    auto eglContext = eglCreateContext(eglDisplay, eglConfig, sharedContext, robust3Attributes);
+    if (eglContext != EGL_NO_CONTEXT) {
+      return eglContext;
+    }
+    // Try ES 2 with robustness.
+    static const EGLint robust2Attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2,
+                                               EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT,
+                                               EGL_LOSE_CONTEXT_ON_RESET_EXT, EGL_NONE};
+    eglContext = eglCreateContext(eglDisplay, eglConfig, sharedContext, robust2Attributes);
+    if (eglContext != EGL_NO_CONTEXT) {
+      return eglContext;
+    }
+    // Robustness creation failed, fall through to non-robust path.
+  }
   static const EGLint context3Attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 3, EGL_NONE};
   auto eglContext = eglCreateContext(eglDisplay, eglConfig, sharedContext, context3Attributes);
   if (eglContext != EGL_NO_CONTEXT) {
@@ -95,7 +125,8 @@ std::shared_ptr<GLDevice> GLDevice::Make(void* sharedContext) {
     return nullptr;
   }
   auto eglShareContext = reinterpret_cast<EGLContext>(sharedContext);
-  auto eglContext = CreateContext(eglShareContext, eglGlobals->display, eglGlobals->pbufferConfig);
+  auto eglContext = CreateContext(eglShareContext, eglGlobals->display, eglGlobals->pbufferConfig,
+                                  eglGlobals->hasContextRobustness);
   if (eglContext == nullptr) {
     eglDestroySurface(eglGlobals->display, eglSurface);
     return nullptr;
@@ -153,7 +184,8 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
     LOGE("EGLDevice::MakeFrom() eglCreateWindowSurface error=%d", eglGetError());
     return nullptr;
   }
-  auto eglContext = CreateContext(sharedContext, eglGlobals->display, eglGlobals->windowConfig);
+  auto eglContext = CreateContext(sharedContext, eglGlobals->display, eglGlobals->windowConfig,
+                                  eglGlobals->hasContextRobustness);
   if (eglContext == EGL_NO_CONTEXT) {
     eglDestroySurface(eglGlobals->display, eglSurface);
     return nullptr;
@@ -243,11 +275,20 @@ bool EGLDevice::onLockContext() {
   if (oldEglContext == eglContext) {
     // If the current context is already set by external, we don't need to switch it again.
     // The read/draw surface may be different.
-    return true;
+    return !checkGraphicsResetStatus();
   }
   auto result = eglMakeCurrent(eglDisplay, eglSurface, eglSurface, eglContext);
   if (!result) {
-    LOGE("EGLDevice::onLockContext() failure result = %d error= %d", result, eglGetError());
+    auto error = eglGetError();
+    if (error == EGL_CONTEXT_LOST) {
+      LOGE("EGLDevice::onLockContext() EGL_CONTEXT_LOST detected.");
+      markContextLost();
+    } else {
+      LOGE("EGLDevice::onLockContext() failure result = %d error= %d", result, error);
+    }
+    return false;
+  }
+  if (checkGraphicsResetStatus()) {
     return false;
   }
   return true;
@@ -257,11 +298,46 @@ void EGLDevice::onUnlockContext() {
   if (oldEglContext == eglContext) {
     return;
   }
-  eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  auto result = eglMakeCurrent(eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  if (!result) {
+    auto error = eglGetError();
+    if (error == EGL_CONTEXT_LOST) {
+      LOGE("EGLDevice::onUnlockContext() EGL_CONTEXT_LOST detected.");
+      markContextLost();
+    }
+  }
   if (oldEglDisplay) {
     // 可能失败。
     eglMakeCurrent(oldEglDisplay, oldEglDrawSurface, oldEglReadSurface, oldEglContext);
   }
+}
+
+void EGLDevice::markContextLost() {
+  if (_contextLost) {
+    return;
+  }
+  LOGE("EGLDevice::markContextLost() Context [%p] has been permanently lost.", eglContext);
+  // On EGL platforms, a GPU reset affects all contexts. Notify all registered devices.
+  MarkAllContextsLost();
+}
+
+bool EGLDevice::checkGraphicsResetStatus() {
+  if (graphicsResetStatus != GL_NO_ERROR) {
+    return true;
+  }
+  auto glGPU = static_cast<GLGPU*>(_gpu);
+  auto getGraphicsResetStatus = glGPU->functions()->getGraphicsResetStatus;
+  if (getGraphicsResetStatus == nullptr) {
+    return false;
+  }
+  auto status = getGraphicsResetStatus();
+  if (status != GL_NO_ERROR) {
+    graphicsResetStatus = status;
+    LOGE("EGLDevice::checkGraphicsResetStatus() GPU reset detected: status=0x%x", status);
+    markContextLost();
+    return true;
+  }
+  return false;
 }
 
 bool EGLDevice::recreateSurfaceIfNeeded(EGLNativeWindowType nativeWindow) {

--- a/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/src/gpu/opengl/egl/EGLDevice.cpp
@@ -48,9 +48,9 @@ static std::vector<EGLint> GetValidAttributes(const std::vector<EGLint>& attribu
 }
 
 static EGLContext CreateContext(EGLContext sharedContext, EGLDisplay eglDisplay,
-                                EGLConfig eglConfig, bool hasContextRobustness) {
+                                EGLConfig eglConfig, bool contextRobustnessSupported) {
   // Try ES 3 with robustness if supported.
-  if (hasContextRobustness) {
+  if (contextRobustnessSupported) {
     static const EGLint robust3Attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 3,
                                                EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT,
                                                EGL_LOSE_CONTEXT_ON_RESET_EXT, EGL_NONE};
@@ -126,7 +126,7 @@ std::shared_ptr<GLDevice> GLDevice::Make(void* sharedContext) {
   }
   auto eglShareContext = reinterpret_cast<EGLContext>(sharedContext);
   auto eglContext = CreateContext(eglShareContext, eglGlobals->display, eglGlobals->pbufferConfig,
-                                  eglGlobals->hasContextRobustness);
+                                  eglGlobals->contextRobustnessSupported);
   if (eglContext == nullptr) {
     eglDestroySurface(eglGlobals->display, eglSurface);
     return nullptr;
@@ -185,7 +185,7 @@ std::shared_ptr<EGLDevice> EGLDevice::MakeFrom(EGLNativeWindowType nativeWindow,
     return nullptr;
   }
   auto eglContext = CreateContext(sharedContext, eglGlobals->display, eglGlobals->windowConfig,
-                                  eglGlobals->hasContextRobustness);
+                                  eglGlobals->contextRobustnessSupported);
   if (eglContext == EGL_NO_CONTEXT) {
     eglDestroySurface(eglGlobals->display, eglSurface);
     return nullptr;
@@ -282,7 +282,7 @@ bool EGLDevice::onLockContext() {
     auto error = eglGetError();
     if (error == EGL_CONTEXT_LOST) {
       LOGE("EGLDevice::onLockContext() EGL_CONTEXT_LOST detected.");
-      markContextLost();
+      handleContextLost();
     } else {
       LOGE("EGLDevice::onLockContext() failure result = %d error= %d", result, error);
     }
@@ -303,7 +303,7 @@ void EGLDevice::onUnlockContext() {
     auto error = eglGetError();
     if (error == EGL_CONTEXT_LOST) {
       LOGE("EGLDevice::onUnlockContext() EGL_CONTEXT_LOST detected.");
-      markContextLost();
+      handleContextLost();
     } else {
       LOGE("EGLDevice::onUnlockContext() failure error=%d", error);
     }
@@ -314,11 +314,11 @@ void EGLDevice::onUnlockContext() {
   }
 }
 
-void EGLDevice::markContextLost() {
+void EGLDevice::handleContextLost() {
   if (_contextLost) {
     return;
   }
-  LOGE("EGLDevice::markContextLost() Context [%p] has been permanently lost.", eglContext);
+  LOGE("EGLDevice::handleContextLost() Context [%p] has been permanently lost.", eglContext);
   // On EGL platforms, a GPU reset affects all contexts. Notify all registered devices.
   MarkAllContextsLost();
 }

--- a/src/gpu/opengl/egl/EGLGlobals.cpp
+++ b/src/gpu/opengl/egl/EGLGlobals.cpp
@@ -19,6 +19,7 @@
 #include "tgfx/gpu/opengl/egl/EGLGlobals.h"
 #include <EGL/eglext.h>
 #include <atomic>
+#include <cstring>
 #if defined(_WIN32)
 #include "EGLDisplayWrapper.h"
 #endif
@@ -41,6 +42,10 @@ EGLGlobals InitializeEGL() {
   globals.pbufferSurfaceAttributes = {EGL_WIDTH,           1,        EGL_HEIGHT, 1,
                                       EGL_LARGEST_PBUFFER, EGL_TRUE, EGL_NONE};
   eglBindAPI(EGL_OPENGL_ES_API);
+  auto extensions = eglQueryString(globals.display, EGL_EXTENSIONS);
+  if (extensions && strstr(extensions, "EGL_EXT_create_context_robustness")) {
+    globals.hasContextRobustness = true;
+  }
   EGLint numConfigs = 0;
   const EGLint configAttribs[] = {EGL_SURFACE_TYPE,
                                   EGL_WINDOW_BIT,

--- a/src/gpu/opengl/egl/EGLGlobals.cpp
+++ b/src/gpu/opengl/egl/EGLGlobals.cpp
@@ -44,7 +44,7 @@ EGLGlobals InitializeEGL() {
   eglBindAPI(EGL_OPENGL_ES_API);
   auto extensions = eglQueryString(globals.display, EGL_EXTENSIONS);
   if (extensions && strstr(extensions, "EGL_EXT_create_context_robustness")) {
-    globals.hasContextRobustness = true;
+    globals.contextRobustnessSupported = true;
   }
   EGLint numConfigs = 0;
   const EGLint configAttribs[] = {EGL_SURFACE_TYPE,


### PR DESCRIPTION
为 OpenGL EGL 上下文添加 GPU robustness 扩展支持，实现 GPU 重置检测机制。

主要变更：
- 在 EGLDevice 中添加 EGL_EXT_create_context_robustness 扩展支持，创建 robust context
- 实现 glGetGraphicsResetStatus 接口，检测 GPU 是否发生重置
- 在 Device 基类中添加 _contextLost 标志，GPU 重置后 lockContext() 将始终返回 nullptr
- 使用 std::atomic 保护 _contextLost 标志，修复潜在的数据竞争问题
- 改进 EGL 错误处理，在 eglMakeCurrent 失败时检查 GPU 重置状态