### PR TITLE
Fix cross-thread QSGTexture creation in QGLWindow

### DIFF
--- a/include/tgfx/gpu/opengl/qt/QGLWindow.h
+++ b/include/tgfx/gpu/opengl/qt/QGLWindow.h
@@ -68,14 +68,6 @@ class QGLWindow : public Window {
     bool available = true;
   };
 
-  struct PendingTextureInfo {
-    unsigned int textureId = 0;
-    int width = 0;
-    int height = 0;
-    bool valid = false;
-    std::shared_ptr<RenderTargetProxy> proxy = nullptr;
-  };
-
   std::weak_ptr<QGLWindow> weakThis;
   QQuickItem* quickItem = nullptr;
   int maxTextureCount = 2;
@@ -83,7 +75,7 @@ class QGLWindow : public Window {
   std::vector<TextureSlot> textureSlots = {};
   QGLDeviceCreator* deviceCreator = nullptr;
   QSGTexture* presentedQSGTexture = nullptr;
-  PendingTextureInfo pendingTextureInfo = {};
+  std::shared_ptr<RenderTargetProxy> pendingProxy = nullptr;
   std::shared_ptr<RenderTargetProxy> drawableProxy = nullptr;
   std::shared_ptr<RenderTargetProxy> presentingProxy = nullptr;
 

--- a/include/tgfx/gpu/opengl/qt/QGLWindow.h
+++ b/include/tgfx/gpu/opengl/qt/QGLWindow.h
@@ -56,7 +56,7 @@ class QGLWindow : public Window {
    * been presented yet. The returned QSGTexture is owned by this QGLWindow and should not be
    * deleted by the caller.
    */
-  QSGTexture* getQSGTexture() const;
+  QSGTexture* getQSGTexture();
 
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
@@ -68,6 +68,14 @@ class QGLWindow : public Window {
     bool available = true;
   };
 
+  struct PendingTextureInfo {
+    unsigned int textureId = 0;
+    int width = 0;
+    int height = 0;
+    bool valid = false;
+    std::shared_ptr<RenderTargetProxy> proxy = nullptr;
+  };
+
   std::weak_ptr<QGLWindow> weakThis;
   QQuickItem* quickItem = nullptr;
   int maxTextureCount = 2;
@@ -75,6 +83,7 @@ class QGLWindow : public Window {
   std::vector<TextureSlot> textureSlots = {};
   QGLDeviceCreator* deviceCreator = nullptr;
   QSGTexture* presentedQSGTexture = nullptr;
+  PendingTextureInfo pendingTextureInfo = {};
   std::shared_ptr<RenderTargetProxy> drawableProxy = nullptr;
   std::shared_ptr<RenderTargetProxy> presentingProxy = nullptr;
 

--- a/src/gpu/opengl/qt/QGLDevice.cpp
+++ b/src/gpu/opengl/qt/QGLDevice.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<QGLDevice> QGLDevice::Wrap(QOpenGLContext* qtContext, QSurface* 
   }
   if (oldContext != qtContext) {
     qtContext->doneCurrent();
-    if (oldContext != nullptr) {
+    if (oldContext != nullptr && oldContext->thread() == QThread::currentThread()) {
       oldContext->makeCurrent(oldSurface);
     }
   }

--- a/src/gpu/opengl/qt/QGLDevice.cpp
+++ b/src/gpu/opengl/qt/QGLDevice.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<QGLDevice> QGLDevice::Wrap(QOpenGLContext* qtContext, QSurface* 
   }
   if (oldContext != qtContext) {
     qtContext->doneCurrent();
-    if (oldContext != nullptr && oldContext->thread() == QThread::currentThread()) {
+    if (oldContext != nullptr) {
       oldContext->makeCurrent(oldSurface);
     }
   }

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -149,35 +149,36 @@ void QGLWindow::moveToThread(QThread* thread) {
 }
 
 QSGTexture* QGLWindow::getQSGTexture() {
-  PendingTextureInfo localInfo = {};
+  std::shared_ptr<RenderTargetProxy> localProxy = nullptr;
   {
     std::lock_guard<std::mutex> autoLock(locker);
-    localInfo = std::move(pendingTextureInfo);
-    pendingTextureInfo = {};
+    localProxy = std::move(pendingProxy);
   }
-  if (localInfo.valid) {
-    auto nativeWindow = quickItem->window();
-    if (nativeWindow != nullptr) {
-      delete presentedQSGTexture;
-      presentedQSGTexture = nullptr;
+  if (localProxy != nullptr) {
+    auto textureView = localProxy->getTextureView();
+    GLTextureInfo info = {};
+    if (textureView != nullptr && textureView->getBackendTexture().getGLTextureInfo(&info)) {
+      auto nativeWindow = quickItem->window();
+      if (nativeWindow != nullptr) {
+        delete presentedQSGTexture;
+        presentedQSGTexture = nullptr;
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-      presentedQSGTexture = QNativeInterface::QSGOpenGLTexture::fromNative(
-          localInfo.textureId, nativeWindow, QSize(localInfo.width, localInfo.height),
-          QQuickWindow::TextureHasAlphaChannel);
+        presentedQSGTexture = QNativeInterface::QSGOpenGLTexture::fromNative(
+            info.id, nativeWindow, QSize(localProxy->width(), localProxy->height()),
+            QQuickWindow::TextureHasAlphaChannel);
 #elif (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-      presentedQSGTexture = nativeWindow->createTextureFromNativeObject(
-          QQuickWindow::NativeObjectTexture, &localInfo.textureId, 0,
-          QSize(localInfo.width, localInfo.height), QQuickWindow::TextureHasAlphaChannel);
+        presentedQSGTexture = nativeWindow->createTextureFromNativeObject(
+            QQuickWindow::NativeObjectTexture, &info.id, 0,
+            QSize(localProxy->width(), localProxy->height()),
+            QQuickWindow::TextureHasAlphaChannel);
 #else
-      presentedQSGTexture = nativeWindow->createTextureFromId(
-          localInfo.textureId, QSize(localInfo.width, localInfo.height),
-          QQuickWindow::TextureHasAlphaChannel);
+        presentedQSGTexture = nativeWindow->createTextureFromId(
+            info.id, QSize(localProxy->width(), localProxy->height()),
+            QQuickWindow::TextureHasAlphaChannel);
 #endif
+      }
     }
-    // Release the texture back to the pool after QSGTexture has been created.
-    if (localInfo.proxy != nullptr) {
-      reuseTexture(localInfo.proxy);
-    }
+    reuseTexture(localProxy);
   }
   return presentedQSGTexture;
 }
@@ -205,31 +206,15 @@ void QGLWindow::onPresent(Context*) {
   }
   auto proxy = std::static_pointer_cast<QGLDrawableProxy>(presentingProxy);
   presentingProxy = nullptr;
-  auto textureView = proxy->getTextureView();
-  if (textureView == nullptr) {
-    proxy->releaseTexture();
-    return;
-  }
-  GLTextureInfo info = {};
-  if (!textureView->getBackendTexture().getGLTextureInfo(&info)) {
-    proxy->releaseTexture();
-    return;
-  }
-  auto nativeWindow = quickItem->window();
-  if (nativeWindow == nullptr) {
+  if (proxy->getTextureView() == nullptr) {
     proxy->releaseTexture();
     return;
   }
   std::shared_ptr<RenderTargetProxy> oldProxy = nullptr;
   {
     std::lock_guard<std::mutex> autoLock(locker);
-    // Take ownership of the previous pending proxy so we can release it outside the lock.
-    oldProxy = std::move(pendingTextureInfo.proxy);
-    pendingTextureInfo.textureId = info.id;
-    pendingTextureInfo.width = proxy->width();
-    pendingTextureInfo.height = proxy->height();
-    pendingTextureInfo.valid = true;
-    pendingTextureInfo.proxy = proxy->getTextureTargetProxy();
+    oldProxy = std::move(pendingProxy);
+    pendingProxy = proxy->getTextureTargetProxy();
   }
   // Release the proxy from the previous pending frame if it was not consumed.
   if (oldProxy != nullptr) {

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -148,7 +148,37 @@ void QGLWindow::moveToThread(QThread* thread) {
   }
 }
 
-QSGTexture* QGLWindow::getQSGTexture() const {
+QSGTexture* QGLWindow::getQSGTexture() {
+  PendingTextureInfo localInfo = {};
+  {
+    std::lock_guard<std::mutex> autoLock(locker);
+    localInfo = std::move(pendingTextureInfo);
+    pendingTextureInfo = {};
+  }
+  if (localInfo.valid) {
+    auto nativeWindow = quickItem->window();
+    if (nativeWindow != nullptr) {
+      delete presentedQSGTexture;
+      presentedQSGTexture = nullptr;
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
+      presentedQSGTexture = QNativeInterface::QSGOpenGLTexture::fromNative(
+          localInfo.textureId, nativeWindow, QSize(localInfo.width, localInfo.height),
+          QQuickWindow::TextureHasAlphaChannel);
+#elif (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+      presentedQSGTexture = nativeWindow->createTextureFromNativeObject(
+          QQuickWindow::NativeObjectTexture, &localInfo.textureId, 0,
+          QSize(localInfo.width, localInfo.height), QQuickWindow::TextureHasAlphaChannel);
+#else
+      presentedQSGTexture = nativeWindow->createTextureFromId(
+          localInfo.textureId, QSize(localInfo.width, localInfo.height),
+          QQuickWindow::TextureHasAlphaChannel);
+#endif
+    }
+    // Release the texture back to the pool after QSGTexture has been created.
+    if (localInfo.proxy != nullptr) {
+      reuseTexture(localInfo.proxy);
+    }
+  }
   return presentedQSGTexture;
 }
 
@@ -190,23 +220,21 @@ void QGLWindow::onPresent(Context*) {
     proxy->releaseTexture();
     return;
   }
-  auto textureWidth = proxy->width();
-  auto textureHeight = proxy->height();
-  delete presentedQSGTexture;
-  presentedQSGTexture = nullptr;
-#if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
-  presentedQSGTexture = QNativeInterface::QSGOpenGLTexture::fromNative(
-      info.id, nativeWindow, QSize(textureWidth, textureHeight),
-      QQuickWindow::TextureHasAlphaChannel);
-#elif (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-  presentedQSGTexture = nativeWindow->createTextureFromNativeObject(
-      QQuickWindow::NativeObjectTexture, &info.id, 0, QSize(textureWidth, textureHeight),
-      QQuickWindow::TextureHasAlphaChannel);
-#else
-  presentedQSGTexture = nativeWindow->createTextureFromId(
-      info.id, QSize(textureWidth, textureHeight), QQuickWindow::TextureHasAlphaChannel);
-#endif
-  proxy->releaseTexture();
+  std::shared_ptr<RenderTargetProxy> oldProxy = nullptr;
+  {
+    std::lock_guard<std::mutex> autoLock(locker);
+    // Take ownership of the previous pending proxy so we can release it outside the lock.
+    oldProxy = std::move(pendingTextureInfo.proxy);
+    pendingTextureInfo.textureId = info.id;
+    pendingTextureInfo.width = proxy->width();
+    pendingTextureInfo.height = proxy->height();
+    pendingTextureInfo.valid = true;
+    pendingTextureInfo.proxy = proxy->getTextureTargetProxy();
+  }
+  // Release the proxy from the previous pending frame if it was not consumed.
+  if (oldProxy != nullptr) {
+    reuseTexture(oldProxy);
+  }
   QMetaObject::invokeMethod(quickItem, "update", Qt::AutoConnection);
 }
 

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -169,8 +169,7 @@ QSGTexture* QGLWindow::getQSGTexture() {
 #elif (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
         presentedQSGTexture = nativeWindow->createTextureFromNativeObject(
             QQuickWindow::NativeObjectTexture, &info.id, 0,
-            QSize(localProxy->width(), localProxy->height()),
-            QQuickWindow::TextureHasAlphaChannel);
+            QSize(localProxy->width(), localProxy->height()), QQuickWindow::TextureHasAlphaChannel);
 #else
         presentedQSGTexture = nativeWindow->createTextureFromId(
             info.id, QSize(localProxy->width(), localProxy->height()),


### PR DESCRIPTION
## Summary
- Move `QSGTexture` creation from `onPresent()` (render thread) to `getQSGTexture()` (GUI thread), fixing cross-thread Qt GUI object access.
- `onPresent()` now stores the presenting proxy as `pendingProxy` without releasing texture. `getQSGTexture()` consumes the proxy, creates `QSGTexture` on the GUI thread, then returns the proxy to the texture pool.
- Mutex protection on `pendingProxy` ensures thread safety between render thread (`onPresent`) and GUI thread (`getQSGTexture`).

## Test plan
- [x] Qt project compiles successfully
- [x] Hello2D demo runs without crash
- [x] Code format check passes
- [ ] Verify QSGTexture displays correctly in multi-frame rendering scenarios
- [ ] Verify no texture corruption when texture pool is under pressure