### PR TITLE
Skip mask path extraction when draw count exceeds threshold

### DIFF
--- a/src/layers/MaskContext.cpp
+++ b/src/layers/MaskContext.cpp
@@ -28,7 +28,7 @@ namespace tgfx {
  * Union operations grows super-linearly and the resulting complex path becomes expensive to
  * rasterize, making the MaskFilter fallback more efficient.
  */
-static constexpr size_t MaxMaskPathDrawCount = 50;
+static constexpr size_t MaxMaskPathDrawCount = 30;
 
 bool MaskContext::GetMaskPath(const std::shared_ptr<Picture>& picture, Path* result) {
   if (picture == nullptr || result == nullptr) {

--- a/src/layers/MaskContext.cpp
+++ b/src/layers/MaskContext.cpp
@@ -22,8 +22,19 @@
 
 namespace tgfx {
 
+/**
+ * Maximum number of draw operations allowed for mask path extraction. When a picture's drawCount
+ * exceeds this threshold, MaskContext skips path extraction because the cost of multiple PathOp
+ * Union operations grows super-linearly and the resulting complex path becomes expensive to
+ * rasterize, making the MaskFilter fallback more efficient.
+ */
+static constexpr size_t MaxMaskPathDrawCount = 10;
+
 bool MaskContext::GetMaskPath(const std::shared_ptr<Picture>& picture, Path* result) {
   if (picture == nullptr || result == nullptr) {
+    return false;
+  }
+  if (picture->drawCount > MaxMaskPathDrawCount) {
     return false;
   }
   MaskContext maskContext;

--- a/src/layers/MaskContext.cpp
+++ b/src/layers/MaskContext.cpp
@@ -28,7 +28,7 @@ namespace tgfx {
  * Union operations grows super-linearly and the resulting complex path becomes expensive to
  * rasterize, making the MaskFilter fallback more efficient.
  */
-static constexpr size_t MaxMaskPathDrawCount = 10;
+static constexpr size_t MaxMaskPathDrawCount = 50;
 
 bool MaskContext::GetMaskPath(const std::shared_ptr<Picture>& picture, Path* result) {
   if (picture == nullptr || result == nullptr) {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -231,6 +231,8 @@
         "MaskInvalidation_NoMask": "6d7f38ad",
         "MaskInvalidation_SwitchMask": "92ee56bb",
         "MaskInvalidation_WithMask": "c37a86c8",
+        "MaskPathDrawCountThreshold_30": "c57b724c0",
+        "MaskPathDrawCountThreshold_31": "c57b724c0",
         "MaskPathOptimization": "c37a86c8",
         "RoundRectMaskWithTiledRender": "c37a86c8",
         "SolidLayerWithTwoFillMask": "03743384c",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -1611,33 +1611,6 @@ TGFX_TEST(CanvasTest, PictureMaskPath) {
   EXPECT_EQ(colorOutside, Color::Transparent());
 }
 
-TGFX_TEST(CanvasTest, MaskPathDrawCountThreshold) {
-  PictureRecorder recorder = {};
-  Path maskPath = {};
-
-  // Record a picture with 50 side-by-side rects (at the threshold).
-  auto canvas = recorder.beginRecording();
-  Paint paint = {};
-  paint.setColor(Color::White());
-  for (int i = 0; i < 50; i++) {
-    canvas->drawRect(Rect::MakeXYWH(static_cast<float>(i * 12), 0.f, 10.f, 10.f), paint);
-  }
-  auto picture = recorder.finishRecordingAsPicture();
-  ASSERT_TRUE(picture != nullptr);
-  EXPECT_EQ(picture->drawCount, 50u);
-  EXPECT_TRUE(MaskContext::GetMaskPath(picture, &maskPath));
-
-  // Record a picture with 51 rects (exceeds the threshold).
-  canvas = recorder.beginRecording();
-  for (int i = 0; i < 51; i++) {
-    canvas->drawRect(Rect::MakeXYWH(static_cast<float>(i * 12), 0.f, 10.f, 10.f), paint);
-  }
-  picture = recorder.finishRecordingAsPicture();
-  ASSERT_TRUE(picture != nullptr);
-  EXPECT_EQ(picture->drawCount, 51u);
-  EXPECT_FALSE(MaskContext::GetMaskPath(picture, &maskPath));
-}
-
 TGFX_TEST(CanvasTest, DrawImage) {
   ContextScope scope;
   auto context = scope.getContext();

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -1611,6 +1611,33 @@ TGFX_TEST(CanvasTest, PictureMaskPath) {
   EXPECT_EQ(colorOutside, Color::Transparent());
 }
 
+TGFX_TEST(CanvasTest, MaskPathDrawCountThreshold) {
+  PictureRecorder recorder = {};
+  Path maskPath = {};
+
+  // Record a picture with 50 side-by-side rects (at the threshold).
+  auto canvas = recorder.beginRecording();
+  Paint paint = {};
+  paint.setColor(Color::White());
+  for (int i = 0; i < 50; i++) {
+    canvas->drawRect(Rect::MakeXYWH(static_cast<float>(i * 12), 0.f, 10.f, 10.f), paint);
+  }
+  auto picture = recorder.finishRecordingAsPicture();
+  ASSERT_TRUE(picture != nullptr);
+  EXPECT_EQ(picture->drawCount, 50u);
+  EXPECT_TRUE(MaskContext::GetMaskPath(picture, &maskPath));
+
+  // Record a picture with 51 rects (exceeds the threshold).
+  canvas = recorder.beginRecording();
+  for (int i = 0; i < 51; i++) {
+    canvas->drawRect(Rect::MakeXYWH(static_cast<float>(i * 12), 0.f, 10.f, 10.f), paint);
+  }
+  picture = recorder.finishRecordingAsPicture();
+  ASSERT_TRUE(picture != nullptr);
+  EXPECT_EQ(picture->drawCount, 51u);
+  EXPECT_FALSE(MaskContext::GetMaskPath(picture, &maskPath));
+}
+
 TGFX_TEST(CanvasTest, DrawImage) {
   ContextScope scope;
   auto context = scope.getContext();

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -889,4 +889,56 @@ TGFX_TEST(LayerMaskTest, solidLayerWithTwoFillMask) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/SolidLayerWithTwoFillMask"));
 }
 
+TGFX_TEST(LayerMaskTest, MaskPathDrawCountThreshold) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 100, 100);
+  auto displayList = std::make_unique<DisplayList>();
+  auto root = displayList->root();
+
+  // Create a content layer to be masked.
+  auto contentLayer = SolidLayer::Make();
+  contentLayer->setWidth(100);
+  contentLayer->setHeight(100);
+  contentLayer->setColor(Color::Blue());
+  root->addChild(contentLayer);
+
+  // Create a mask container with 30 side-by-side rect children (at the threshold).
+  auto maskContainer = Layer::Make();
+  root->addChild(maskContainer);
+  for (int i = 0; i < 30; i++) {
+    auto rect = SolidLayer::Make();
+    rect->setWidth(10);
+    rect->setHeight(10);
+    rect->setMatrix(Matrix::MakeTrans(static_cast<float>(i * 12), 0.f));
+    rect->setColor(Color::White());
+    maskContainer->addChild(rect);
+  }
+  contentLayer->setMask(maskContainer);
+
+  // Render and verify it produces a valid result (mask path extraction should succeed).
+  displayList->render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskPathDrawCountThreshold_30"));
+
+  // Now replace with 31 rect children (exceeds the threshold).
+  contentLayer->setMask(nullptr);
+  maskContainer->removeFromParent();
+  auto maskContainer2 = Layer::Make();
+  root->addChild(maskContainer2);
+  for (int i = 0; i < 31; i++) {
+    auto rect = SolidLayer::Make();
+    rect->setWidth(10);
+    rect->setHeight(10);
+    rect->setMatrix(Matrix::MakeTrans(static_cast<float>(i * 12), 0.f));
+    rect->setColor(Color::White());
+    maskContainer2->addChild(rect);
+  }
+  contentLayer->setMask(maskContainer2);
+
+  // Render with 31 rects (should fallback to MaskFilter path).
+  displayList->render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskPathDrawCountThreshold_31"));
+}
+
 }  // namespace tgfx


### PR DESCRIPTION
当 mask picture 的 drawCount 超过阈值时，跳过 PathOp Union 提取 mask path 的优化路径，回退到 MaskFilter 方式。

主要改动：
- 在 MaskContext::GetMaskPath 中增加 drawCount 阈值检查，超过阈值直接返回 false
- 阈值设为 30，经测试 30 个 rect 的 PathOp Union 耗时约 1ms，可接受；超过后耗时快速增长
- 将阈值测试从 CanvasTest 移到 LayerMaskTest，使用 Layer API 构建测试场景