### PR TITLE
Fix background content disappearing in PDF export when BackgroundBlurStyle uses BlendMode Src.

### DIFF
--- a/src/pdf/PDFExportContext.cpp
+++ b/src/pdf/PDFExportContext.cpp
@@ -1412,6 +1412,16 @@ void PDFExportContext::drawPathWithFilter(const Matrix& matrix, const ClipStack&
   if (!matrix.isIdentity() && paint.shader) {
     paint.shader = paint.shader->makeWithMatrix(pathExtraMatrix);
   }
+  // A non-inverted ShaderMaskFilter produces fully transparent pixels outside the mask shape
+  // (TileMode::Decal). For those pixels, BlendMode::Src (write transparent) and SrcOver (keep
+  // destination) differ only in theory — visually identical when drawn on top of existing content.
+  // However, BlendMode::Src triggers the non-regular blend mode path in PDF export, which packages
+  // all previously drawn content into a Form XObject and may cause it to become invisible under the
+  // subsequent SMask compositing. Downgrading to SrcOver avoids this destructive packaging while
+  // preserving correct visual output.
+  if (paint.blendMode == BlendMode::Src && !shaderMaskFilter->isInverted()) {
+    paint.blendMode = BlendMode::SrcOver;
+  }
   ScopedContentEntry contentEntry(this, matrix, clip, Matrix::I(), paint);
   if (!contentEntry) {
     return;

--- a/test/src/PDFExportTest.cpp
+++ b/test/src/PDFExportTest.cpp
@@ -28,11 +28,14 @@
 #include "tgfx/core/Rect.h"
 #include "tgfx/core/Shader.h"
 #include "tgfx/core/Stroke.h"
+#include "tgfx/core/Surface.h"
 #include "tgfx/core/TileMode.h"
 #include "tgfx/core/WriteStream.h"
 #include "tgfx/layers/DisplayList.h"
 #include "tgfx/layers/ShapeLayer.h"
 #include "tgfx/layers/ShapeStyle.h"
+#include "tgfx/layers/SolidLayer.h"
+#include "tgfx/layers/layerstyles/BackgroundBlurStyle.h"
 #include "tgfx/layers/layerstyles/DropShadowStyle.h"
 #include "tgfx/pdf/PDFDocument.h"
 #include "tgfx/pdf/PDFMetadata.h"
@@ -897,6 +900,57 @@ TGFX_TEST(PDFExportTest, NonRegularBlendMode) {
   PDFStream->flush();
 
   EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/NonRegularBlendMode"));
+}
+
+TGFX_TEST(PDFExportTest, BackgroundBlurLayer) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+
+  auto PDFStream = MemoryWriteStream::Make();
+  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
+  ASSERT_TRUE(document != nullptr);
+
+  float pageW = 822.f;
+  float pageH = 1663.f;
+
+  auto rootLayer = Layer::Make();
+
+  auto background = SolidLayer::Make();
+  background->setColor(Color::White());
+  background->setWidth(static_cast<int>(pageW));
+  background->setHeight(static_cast<int>(pageH));
+  rootLayer->addChild(background);
+
+  auto redLayer = SolidLayer::Make();
+  redLayer->setColor(Color::Red());
+  redLayer->setWidth(624);
+  redLayer->setHeight(48);
+  redLayer->setPosition(Point{99.f, 381.f});
+  rootLayer->addChild(redLayer);
+
+  auto blurLayer = SolidLayer::Make();
+  blurLayer->setColor(Color::FromRGBA(139, 239, 200));
+  blurLayer->setWidth(822);
+  blurLayer->setHeight(300);
+  blurLayer->setPosition(Point{0.f, 469.f});
+  blurLayer->setLayerStyles({BackgroundBlurStyle::Make(10.f, 10.f)});
+  rootLayer->addChild(blurLayer);
+
+  auto surface = Surface::Make(context, static_cast<int>(pageW), static_cast<int>(pageH));
+  auto surfaceCanvas = surface->getCanvas();
+  rootLayer->draw(surfaceCanvas);
+  EXPECT_TRUE(Baseline::Compare(surface, "PDFTest/BackgroundBlurLayer"));
+
+  auto canvas = document->beginPage(pageW, pageH);
+  ASSERT_TRUE(canvas != nullptr);
+  rootLayer->draw(canvas);
+  document->endPage();
+
+  document->close();
+  PDFStream->flush();
+
+  EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/BackgroundBlurLayer_pdf"));
 }
 
 }  // namespace tgfx


### PR DESCRIPTION
当 Layer 使用 BackgroundBlurStyle 时，PDF 导出会丢失背景中已绘制的兄弟层内容（如红色矩形不可见）。

根因：BackgroundBlurStyle 在绘制模糊背景时使用 BlendMode::Src，这是 PDF 原生不支持的混合模式。PDFExportContext::setUpContentEntry 会将之前已绘制的所有内容打包为 Form XObject 并清空 content stream，导致这些内容在后续的 SMask 合成中丢失。

修复：在 drawPathWithFilter 中，当检测到非反转的 ShaderMaskFilter 配合 BlendMode::Src 时，安全降级为 SrcOver。非反转 mask 在 mask 外区域产生全透明像素（TileMode::Decal），对这些像素 Src 和 SrcOver 视觉效果等价，但 SrcOver 不会触发破坏性的 Form XObject 打包。

同时新增 BackgroundBlurLayer 单测复现此场景。