### PR TITLE
Optimized Canvas::drawLine() to render axis-aligned lines as rect or rrect

### DIFF
--- a/include/tgfx/core/Canvas.h
+++ b/include/tgfx/core/Canvas.h
@@ -480,6 +480,8 @@ class Canvas {
   std::unique_ptr<ClipStack> clipStack;
 
   explicit Canvas(DrawContext* drawContext, Surface* surface = nullptr);
+  void drawLine(const Point line[2], const Matrix& matrix, const ClipStack& clip,
+                const Brush& brush, const Stroke& stroke) const;
   void drawPath(const Path& path, const Matrix& matrix, const ClipStack& clip, const Brush& brush,
                 const Stroke* stroke = nullptr) const;
   void drawImage(std::shared_ptr<Image> image, const Brush& brush, const SamplingOptions& sampling,

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -215,12 +215,27 @@ void Canvas::drawPaint(const Paint& paint) {
 }
 
 void Canvas::drawLine(float x0, float y0, float x1, float y1, const Paint& paint) {
+  SaveLayerForImageFilter(paint.getImageFilter());
+  Stroke stroke(paint.getStrokeWidth(), paint.getLineCap(), paint.getLineJoin(),
+                paint.getMiterLimit());
+  Point line[2] = {{x0, y0}, {x1, y1}};
+  Rect rect = {};
+  if (StrokeLineToRect(stroke, line, &rect)) {
+    drawContext->drawRect(rect, _matrix, *clipStack, paint.getBrush(), nullptr);
+    return;
+  }
+  RRect rRect = {};
+  if (StrokeLineToRRect(stroke, line, &rRect)) {
+    drawContext->drawRRect(rRect, _matrix, *clipStack, paint.getBrush(), nullptr);
+    return;
+  }
   Path path = {};
   path.moveTo(x0, y0);
   path.lineTo(x1, y1);
-  auto realPaint = paint;
-  realPaint.setStyle(PaintStyle::Stroke);
-  drawPath(path, realPaint);
+  auto shape = Shape::MakeFrom(path);
+  if (shape) {
+    drawContext->drawShape(shape, _matrix, *clipStack, paint.getBrush(), &stroke);
+  }
 }
 
 void Canvas::drawRect(const Rect& rect, const Paint& paint) {

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -224,31 +224,14 @@ void Canvas::drawLine(float x0, float y0, float x1, float y1, const Paint& paint
 
 void Canvas::drawLine(const Point line[2], const Matrix& matrix, const ClipStack& clip,
                       const Brush& brush, const Stroke& stroke) const {
-  Matrix lineMatrix = {};
   Rect rect = {};
-  if (StrokeLineToRect(stroke, line, &rect, &lineMatrix)) {
-    auto drawBrush = brush;
-    if (!lineMatrix.isIdentity()) {
-      Matrix inverse = {};
-      if (lineMatrix.invert(&inverse)) {
-        drawBrush = brush.makeWithMatrix(inverse);
-      }
-    }
-    lineMatrix.postConcat(matrix);
-    drawContext->drawRect(rect, lineMatrix, clip, drawBrush, nullptr);
+  if (StrokeLineToRect(stroke, line, &rect)) {
+    drawContext->drawRect(rect, matrix, clip, brush, nullptr);
     return;
   }
   RRect rRect = {};
-  if (StrokeLineToRRect(stroke, line, &rRect, &lineMatrix)) {
-    auto drawBrush = brush;
-    if (!lineMatrix.isIdentity()) {
-      Matrix inverse = {};
-      if (lineMatrix.invert(&inverse)) {
-        drawBrush = brush.makeWithMatrix(inverse);
-      }
-    }
-    lineMatrix.postConcat(matrix);
-    drawContext->drawRRect(rRect, lineMatrix, clip, drawBrush, nullptr);
+  if (StrokeLineToRRect(stroke, line, &rRect)) {
+    drawContext->drawRRect(rRect, matrix, clip, brush, nullptr);
     return;
   }
   Path path = {};

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -227,14 +227,28 @@ void Canvas::drawLine(const Point line[2], const Matrix& matrix, const ClipStack
   Matrix lineMatrix = {};
   Rect rect = {};
   if (StrokeLineToRect(stroke, line, &rect, &lineMatrix)) {
+    auto drawBrush = brush;
+    if (!lineMatrix.isIdentity()) {
+      Matrix inverse = {};
+      if (lineMatrix.invert(&inverse)) {
+        drawBrush = brush.makeWithMatrix(inverse);
+      }
+    }
     lineMatrix.postConcat(matrix);
-    drawContext->drawRect(rect, lineMatrix, clip, brush, nullptr);
+    drawContext->drawRect(rect, lineMatrix, clip, drawBrush, nullptr);
     return;
   }
   RRect rRect = {};
   if (StrokeLineToRRect(stroke, line, &rRect, &lineMatrix)) {
+    auto drawBrush = brush;
+    if (!lineMatrix.isIdentity()) {
+      Matrix inverse = {};
+      if (lineMatrix.invert(&inverse)) {
+        drawBrush = brush.makeWithMatrix(inverse);
+      }
+    }
     lineMatrix.postConcat(matrix);
-    drawContext->drawRRect(rRect, lineMatrix, clip, brush, nullptr);
+    drawContext->drawRRect(rRect, lineMatrix, clip, drawBrush, nullptr);
     return;
   }
   Path path = {};

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -232,10 +232,7 @@ void Canvas::drawLine(float x0, float y0, float x1, float y1, const Paint& paint
   Path path = {};
   path.moveTo(x0, y0);
   path.lineTo(x1, y1);
-  auto shape = Shape::MakeFrom(path);
-  if (shape) {
-    drawContext->drawShape(shape, _matrix, *clipStack, paint.getBrush(), &stroke);
-  }
+  drawPath(path, _matrix, *clipStack, paint.getBrush(), &stroke);
 }
 
 void Canvas::drawRect(const Rect& rect, const Paint& paint) {

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -219,20 +219,31 @@ void Canvas::drawLine(float x0, float y0, float x1, float y1, const Paint& paint
   Stroke stroke(paint.getStrokeWidth(), paint.getLineCap(), paint.getLineJoin(),
                 paint.getMiterLimit());
   Point line[2] = {{x0, y0}, {x1, y1}};
+  drawLine(line, _matrix, *clipStack, paint.getBrush(), stroke);
+}
+
+void Canvas::drawLine(const Point line[2], const Matrix& matrix, const ClipStack& clip,
+                      const Brush& brush, const Stroke& stroke) const {
+  Matrix lineMatrix = {};
   Rect rect = {};
-  if (StrokeLineToRect(stroke, line, &rect)) {
-    drawContext->drawRect(rect, _matrix, *clipStack, paint.getBrush(), nullptr);
+  if (StrokeLineToRect(stroke, line, &rect, &lineMatrix)) {
+    lineMatrix.postConcat(matrix);
+    drawContext->drawRect(rect, lineMatrix, clip, brush, nullptr);
     return;
   }
   RRect rRect = {};
-  if (StrokeLineToRRect(stroke, line, &rRect)) {
-    drawContext->drawRRect(rRect, _matrix, *clipStack, paint.getBrush(), nullptr);
+  if (StrokeLineToRRect(stroke, line, &rRect, &lineMatrix)) {
+    lineMatrix.postConcat(matrix);
+    drawContext->drawRRect(rRect, lineMatrix, clip, brush, nullptr);
     return;
   }
   Path path = {};
-  path.moveTo(x0, y0);
-  path.lineTo(x1, y1);
-  drawPath(path, _matrix, *clipStack, paint.getBrush(), &stroke);
+  path.moveTo(line[0].x, line[0].y);
+  path.lineTo(line[1].x, line[1].y);
+  auto shape = Shape::MakeFrom(path);
+  if (shape) {
+    drawContext->drawShape(shape, matrix, clip, brush, &stroke);
+  }
 }
 
 void Canvas::drawRect(const Rect& rect, const Paint& paint) {
@@ -333,23 +344,18 @@ void Canvas::drawPath(const Path& path, const Paint& paint) {
   drawPath(path, _matrix, *clipStack, paint.getBrush(), paint.getStroke());
 }
 
-// Checks if the line is axis-aligned and not a hairline stroke, allowing it to be converted to a
-// rect.
 void Canvas::drawPath(const Path& path, const Matrix& matrix, const ClipStack& clip,
                       const Brush& brush, const Stroke* stroke) const {
   DEBUG_ASSERT(!path.isEmpty());
-  Rect rect = {};
   Point line[2] = {};
   if (path.isLine(line)) {
     if (!stroke) {
-      // a line has no fill to draw.
       return;
     }
-    if (StrokeLineToRect(*stroke, line, &rect)) {
-      drawContext->drawRect(rect, matrix, clip, brush, nullptr);
-      return;
-    }
+    drawLine(line, matrix, clip, brush, *stroke);
+    return;
   }
+  Rect rect = {};
   if (stroke == nullptr) {
     if (path.isRect(&rect)) {
       drawContext->drawRect(rect, matrix, clip, brush, nullptr);

--- a/src/core/utils/StrokeUtils.cpp
+++ b/src/core/utils/StrokeUtils.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include "core/utils/MathExtra.h"
+#include "tgfx/core/RRect.h"
 
 namespace tgfx {
 
@@ -107,6 +108,26 @@ bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect) {
     } else {
       rect->setLTRB(left, top - halfWidth, right, bottom + halfWidth);
     }
+  }
+  return true;
+}
+
+bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect) {
+  if (stroke.cap != LineCap::Round || IsHairlineStroke(stroke)) {
+    return false;
+  }
+  if (line[0].x != line[1].x && line[0].y != line[1].y) {
+    return false;
+  }
+  auto left = std::min(line[0].x, line[1].x);
+  auto top = std::min(line[0].y, line[1].y);
+  auto right = std::max(line[0].x, line[1].x);
+  auto bottom = std::max(line[0].y, line[1].y);
+  auto halfWidth = stroke.width / 2.0f;
+  if (rRect) {
+    Rect rect = {};
+    rect.setLTRB(left - halfWidth, top - halfWidth, right + halfWidth, bottom + halfWidth);
+    rRect->setRectXY(rect, halfWidth, halfWidth);
   }
   return true;
 }

--- a/src/core/utils/StrokeUtils.cpp
+++ b/src/core/utils/StrokeUtils.cpp
@@ -84,93 +84,56 @@ std::vector<float> SimplifyLineDashPattern(const std::vector<float>& pattern,
   return simplifiedDashes;
 }
 
-bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect, Matrix* matrix) {
+bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect) {
   if (stroke.cap == LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
   auto dx = line[1].x - line[0].x;
   auto dy = line[1].y - line[0].y;
+  if (dx != 0 && dy != 0) {
+    return false;
+  }
   auto halfWidth = stroke.width / 2.0f;
-  bool isAxisAligned = (dx == 0 || dy == 0);
-  if (isAxisAligned) {
-    auto left = std::min(line[0].x, line[1].x);
-    auto top = std::min(line[0].y, line[1].y);
-    auto right = std::max(line[0].x, line[1].x);
-    auto bottom = std::max(line[0].y, line[1].y);
-    if (stroke.cap == LineCap::Square) {
-      left -= halfWidth;
-      top -= halfWidth;
-      right += halfWidth;
-      bottom += halfWidth;
-    } else if (dx == 0) {
-      left -= halfWidth;
-      right += halfWidth;
-    } else {
-      top -= halfWidth;
-      bottom += halfWidth;
-    }
-    if (rect) {
-      rect->setLTRB(left, top, right, bottom);
-    }
-    if (matrix) {
-      matrix->setIdentity();
-    }
+  auto left = std::min(line[0].x, line[1].x);
+  auto top = std::min(line[0].y, line[1].y);
+  auto right = std::max(line[0].x, line[1].x);
+  auto bottom = std::max(line[0].y, line[1].y);
+  if (stroke.cap == LineCap::Square) {
+    left -= halfWidth;
+    top -= halfWidth;
+    right += halfWidth;
+    bottom += halfWidth;
+  } else if (dx == 0) {
+    left -= halfWidth;
+    right += halfWidth;
   } else {
-    auto length = std::sqrt(dx * dx + dy * dy);
-    auto halfLength = length / 2.0f;
-    if (stroke.cap == LineCap::Square) {
-      halfLength += halfWidth;
-    }
-    if (rect) {
-      rect->setLTRB(-halfLength, -halfWidth, halfLength, halfWidth);
-    }
-    if (matrix) {
-      auto centerX = (line[0].x + line[1].x) / 2.0f;
-      auto centerY = (line[0].y + line[1].y) / 2.0f;
-      float angle = std::atan2(dy, dx);
-      matrix->setRotate(RadiansToDegrees(angle), 0, 0);
-      matrix->postTranslate(centerX, centerY);
-    }
+    top -= halfWidth;
+    bottom += halfWidth;
+  }
+  if (rect) {
+    rect->setLTRB(left, top, right, bottom);
   }
   return true;
 }
 
-bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect, Matrix* matrix) {
+bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect) {
   if (stroke.cap != LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
   auto dx = line[1].x - line[0].x;
   auto dy = line[1].y - line[0].y;
+  if (dx != 0 && dy != 0) {
+    return false;
+  }
   auto halfWidth = stroke.width / 2.0f;
-  bool isAxisAligned = (dx == 0 || dy == 0);
-  if (isAxisAligned) {
-    auto left = std::min(line[0].x, line[1].x) - halfWidth;
-    auto top = std::min(line[0].y, line[1].y) - halfWidth;
-    auto right = std::max(line[0].x, line[1].x) + halfWidth;
-    auto bottom = std::max(line[0].y, line[1].y) + halfWidth;
-    if (rRect) {
-      Rect rect = {};
-      rect.setLTRB(left, top, right, bottom);
-      rRect->setRectXY(rect, halfWidth, halfWidth);
-    }
-    if (matrix) {
-      matrix->setIdentity();
-    }
-  } else {
-    auto length = std::sqrt(dx * dx + dy * dy);
-    auto halfLength = length / 2.0f + halfWidth;
-    if (rRect) {
-      Rect rect = {};
-      rect.setLTRB(-halfLength, -halfWidth, halfLength, halfWidth);
-      rRect->setRectXY(rect, halfWidth, halfWidth);
-    }
-    if (matrix) {
-      auto centerX = (line[0].x + line[1].x) / 2.0f;
-      auto centerY = (line[0].y + line[1].y) / 2.0f;
-      float angle = std::atan2(dy, dx);
-      matrix->setRotate(RadiansToDegrees(angle), 0, 0);
-      matrix->postTranslate(centerX, centerY);
-    }
+  auto left = std::min(line[0].x, line[1].x) - halfWidth;
+  auto top = std::min(line[0].y, line[1].y) - halfWidth;
+  auto right = std::max(line[0].x, line[1].x) + halfWidth;
+  auto bottom = std::max(line[0].y, line[1].y) + halfWidth;
+  if (rRect) {
+    Rect rect = {};
+    rect.setLTRB(left, top, right, bottom);
+    rRect->setRectXY(rect, halfWidth, halfWidth);
   }
   return true;
 }

--- a/src/core/utils/StrokeUtils.cpp
+++ b/src/core/utils/StrokeUtils.cpp
@@ -84,50 +84,93 @@ std::vector<float> SimplifyLineDashPattern(const std::vector<float>& pattern,
   return simplifiedDashes;
 }
 
-bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect) {
+bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect, Matrix* matrix) {
   if (stroke.cap == LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
-  if (line[0].x != line[1].x && line[0].y != line[1].y) {
-    return false;
-  }
-  auto left = std::min(line[0].x, line[1].x);
-  auto top = std::min(line[0].y, line[1].y);
-  auto right = std::max(line[0].x, line[1].x);
-  auto bottom = std::max(line[0].y, line[1].y);
+  auto dx = line[1].x - line[0].x;
+  auto dy = line[1].y - line[0].y;
   auto halfWidth = stroke.width / 2.0f;
-  if (stroke.cap == LineCap::Square) {
-    if (rect) {
-      rect->setLTRB(left - halfWidth, top - halfWidth, right + halfWidth, bottom + halfWidth);
-    }
-    return true;
-  }
-  if (rect) {
-    if (left == right) {
-      rect->setLTRB(left - halfWidth, top, right + halfWidth, bottom);
+  bool isAxisAligned = (dx == 0 || dy == 0);
+  if (isAxisAligned) {
+    auto left = std::min(line[0].x, line[1].x);
+    auto top = std::min(line[0].y, line[1].y);
+    auto right = std::max(line[0].x, line[1].x);
+    auto bottom = std::max(line[0].y, line[1].y);
+    if (stroke.cap == LineCap::Square) {
+      left -= halfWidth;
+      top -= halfWidth;
+      right += halfWidth;
+      bottom += halfWidth;
+    } else if (dx == 0) {
+      left -= halfWidth;
+      right += halfWidth;
     } else {
-      rect->setLTRB(left, top - halfWidth, right, bottom + halfWidth);
+      top -= halfWidth;
+      bottom += halfWidth;
+    }
+    if (rect) {
+      rect->setLTRB(left, top, right, bottom);
+    }
+    if (matrix) {
+      matrix->setIdentity();
+    }
+  } else {
+    auto length = std::sqrt(dx * dx + dy * dy);
+    auto halfLength = length / 2.0f;
+    if (stroke.cap == LineCap::Square) {
+      halfLength += halfWidth;
+    }
+    if (rect) {
+      rect->setLTRB(-halfLength, -halfWidth, halfLength, halfWidth);
+    }
+    if (matrix) {
+      auto centerX = (line[0].x + line[1].x) / 2.0f;
+      auto centerY = (line[0].y + line[1].y) / 2.0f;
+      float angle = std::atan2(dy, dx);
+      matrix->setRotate(RadiansToDegrees(angle), 0, 0);
+      matrix->postTranslate(centerX, centerY);
     }
   }
   return true;
 }
 
-bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect) {
+bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect, Matrix* matrix) {
   if (stroke.cap != LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
-  if (line[0].x != line[1].x && line[0].y != line[1].y) {
-    return false;
-  }
-  auto left = std::min(line[0].x, line[1].x);
-  auto top = std::min(line[0].y, line[1].y);
-  auto right = std::max(line[0].x, line[1].x);
-  auto bottom = std::max(line[0].y, line[1].y);
+  auto dx = line[1].x - line[0].x;
+  auto dy = line[1].y - line[0].y;
   auto halfWidth = stroke.width / 2.0f;
-  if (rRect) {
-    Rect rect = {};
-    rect.setLTRB(left - halfWidth, top - halfWidth, right + halfWidth, bottom + halfWidth);
-    rRect->setRectXY(rect, halfWidth, halfWidth);
+  bool isAxisAligned = (dx == 0 || dy == 0);
+  if (isAxisAligned) {
+    auto left = std::min(line[0].x, line[1].x) - halfWidth;
+    auto top = std::min(line[0].y, line[1].y) - halfWidth;
+    auto right = std::max(line[0].x, line[1].x) + halfWidth;
+    auto bottom = std::max(line[0].y, line[1].y) + halfWidth;
+    if (rRect) {
+      Rect rect = {};
+      rect.setLTRB(left, top, right, bottom);
+      rRect->setRectXY(rect, halfWidth, halfWidth);
+    }
+    if (matrix) {
+      matrix->setIdentity();
+    }
+  } else {
+    auto length = std::sqrt(dx * dx + dy * dy);
+    auto halfLength = length / 2.0f + halfWidth;
+    if (rRect) {
+      Rect rect = {};
+      rect.setLTRB(-halfLength, -halfWidth, halfLength, halfWidth);
+      rRect->setRectXY(rect, halfWidth, halfWidth);
+    }
+    if (matrix) {
+      auto centerX = (line[0].x + line[1].x) / 2.0f;
+      auto centerY = (line[0].y + line[1].y) / 2.0f;
+      float angle = std::atan2(dy, dx);
+      matrix->setRotate(RadiansToDegrees(angle), 0, 0);
+      matrix->postTranslate(centerX, centerY);
+    }
   }
   return true;
 }

--- a/src/core/utils/StrokeUtils.cpp
+++ b/src/core/utils/StrokeUtils.cpp
@@ -88,30 +88,26 @@ bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect) {
   if (stroke.cap == LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
-  auto dx = line[1].x - line[0].x;
-  auto dy = line[1].y - line[0].y;
-  if (dx != 0 && dy != 0) {
+  if (line[0].x != line[1].x && line[0].y != line[1].y) {
     return false;
   }
-  auto halfWidth = stroke.width / 2.0f;
   auto left = std::min(line[0].x, line[1].x);
   auto top = std::min(line[0].y, line[1].y);
   auto right = std::max(line[0].x, line[1].x);
   auto bottom = std::max(line[0].y, line[1].y);
+  auto halfWidth = stroke.width / 2.0f;
   if (stroke.cap == LineCap::Square) {
-    left -= halfWidth;
-    top -= halfWidth;
-    right += halfWidth;
-    bottom += halfWidth;
-  } else if (dx == 0) {
-    left -= halfWidth;
-    right += halfWidth;
-  } else {
-    top -= halfWidth;
-    bottom += halfWidth;
+    if (rect) {
+      rect->setLTRB(left - halfWidth, top - halfWidth, right + halfWidth, bottom + halfWidth);
+    }
+    return true;
   }
   if (rect) {
-    rect->setLTRB(left, top, right, bottom);
+    if (left == right) {
+      rect->setLTRB(left - halfWidth, top, right + halfWidth, bottom);
+    } else {
+      rect->setLTRB(left, top - halfWidth, right, bottom + halfWidth);
+    }
   }
   return true;
 }
@@ -120,20 +116,18 @@ bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect) 
   if (stroke.cap != LineCap::Round || IsHairlineStroke(stroke)) {
     return false;
   }
-  auto dx = line[1].x - line[0].x;
-  auto dy = line[1].y - line[0].y;
-  if (dx != 0 && dy != 0) {
+  if (line[0].x != line[1].x && line[0].y != line[1].y) {
     return false;
   }
+  auto left = std::min(line[0].x, line[1].x);
+  auto top = std::min(line[0].y, line[1].y);
+  auto right = std::max(line[0].x, line[1].x);
+  auto bottom = std::max(line[0].y, line[1].y);
   auto halfWidth = stroke.width / 2.0f;
-  auto left = std::min(line[0].x, line[1].x) - halfWidth;
-  auto top = std::min(line[0].y, line[1].y) - halfWidth;
-  auto right = std::max(line[0].x, line[1].x) + halfWidth;
-  auto bottom = std::max(line[0].y, line[1].y) + halfWidth;
   if (rRect) {
-    Rect rect = {};
-    rect.setLTRB(left, top, right, bottom);
-    rRect->setRectXY(rect, halfWidth, halfWidth);
+    rRect->setRectXY(
+        Rect::MakeLTRB(left - halfWidth, top - halfWidth, right + halfWidth, bottom + halfWidth),
+        halfWidth, halfWidth);
   }
   return true;
 }

--- a/src/core/utils/StrokeUtils.h
+++ b/src/core/utils/StrokeUtils.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "tgfx/core/Point.h"
+#include "tgfx/core/RRect.h"
 #include "tgfx/core/Rect.h"
 #include "tgfx/core/Stroke.h"
 
@@ -59,8 +60,14 @@ std::vector<float> SimplifyLineDashPattern(const std::vector<float>& pattern, co
 
 /**
  * Converts a stroked axis-aligned line to a filled rectangle. Returns true if the conversion is
- * possible (non-round cap, non-hairline, axis-aligned line), and writes the result to rect.
+ * possible (Butt or Square cap, non-hairline, axis-aligned line), and writes the result to rect.
  */
 bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect);
+
+/**
+ * Converts a stroked axis-aligned line to a filled round rectangle. Returns true if the conversion
+ * is possible (Round cap, non-hairline, axis-aligned line), and writes the result to rRect.
+ */
+bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect);
 
 }  // namespace tgfx

--- a/src/core/utils/StrokeUtils.h
+++ b/src/core/utils/StrokeUtils.h
@@ -59,17 +59,15 @@ float GetHairlineAlphaFactor(const Stroke& stroke, const Matrix& matrix);
 std::vector<float> SimplifyLineDashPattern(const std::vector<float>& pattern, const Stroke& stroke);
 
 /**
- * Converts a stroked line to a filled rectangle with a transformation matrix. Returns true if the
- * conversion is possible (Butt or Square cap, non-hairline), and writes the result to rect and
- * matrix. The rect is centered at origin and the matrix transforms it to the correct position.
+ * Converts a stroked axis-aligned line to a filled rectangle. Returns true if the conversion is
+ * possible (Butt or Square cap, non-hairline, axis-aligned line), and writes the result to rect.
  */
-bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect, Matrix* matrix);
+bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect);
 
 /**
- * Converts a stroked line to a filled round rectangle with a transformation matrix. Returns true if
- * the conversion is possible (Round cap, non-hairline), and writes the result to rRect and matrix.
- * The rRect is centered at origin and the matrix transforms it to the correct position.
+ * Converts a stroked axis-aligned line to a filled round rectangle. Returns true if the conversion
+ * is possible (Round cap, non-hairline, axis-aligned line), and writes the result to rRect.
  */
-bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect, Matrix* matrix);
+bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect);
 
 }  // namespace tgfx

--- a/src/core/utils/StrokeUtils.h
+++ b/src/core/utils/StrokeUtils.h
@@ -59,15 +59,17 @@ float GetHairlineAlphaFactor(const Stroke& stroke, const Matrix& matrix);
 std::vector<float> SimplifyLineDashPattern(const std::vector<float>& pattern, const Stroke& stroke);
 
 /**
- * Converts a stroked axis-aligned line to a filled rectangle. Returns true if the conversion is
- * possible (Butt or Square cap, non-hairline, axis-aligned line), and writes the result to rect.
+ * Converts a stroked line to a filled rectangle with a transformation matrix. Returns true if the
+ * conversion is possible (Butt or Square cap, non-hairline), and writes the result to rect and
+ * matrix. The rect is centered at origin and the matrix transforms it to the correct position.
  */
-bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect);
+bool StrokeLineToRect(const Stroke& stroke, const Point line[2], Rect* rect, Matrix* matrix);
 
 /**
- * Converts a stroked axis-aligned line to a filled round rectangle. Returns true if the conversion
- * is possible (Round cap, non-hairline, axis-aligned line), and writes the result to rRect.
+ * Converts a stroked line to a filled round rectangle with a transformation matrix. Returns true if
+ * the conversion is possible (Round cap, non-hairline), and writes the result to rRect and matrix.
+ * The rRect is centered at origin and the matrix transforms it to the correct position.
  */
-bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect);
+bool StrokeLineToRRect(const Stroke& stroke, const Point line[2], RRect* rRect, Matrix* matrix);
 
 }  // namespace tgfx

--- a/src/layers/LayerRecorder.cpp
+++ b/src/layers/LayerRecorder.cpp
@@ -188,18 +188,28 @@ bool LayerRecorder::tryAddSimplifiedPath(const Path& path, const LayerPaint& pai
     if (StrokeLineToRect(paint.stroke, line, &rect, &lineMatrix)) {
       LayerPaint fillPaint = paint;
       fillPaint.style = PaintStyle::Fill;
-      Matrix combinedMatrix = lineMatrix;
-      combinedMatrix.postConcat(matrix);
-      addRect(rect, fillPaint, combinedMatrix);
+      if (!lineMatrix.isIdentity() && fillPaint.shader) {
+        Matrix inverse = {};
+        if (lineMatrix.invert(&inverse)) {
+          fillPaint.shader = fillPaint.shader->makeWithMatrix(inverse);
+        }
+      }
+      lineMatrix.postConcat(matrix);
+      addRect(rect, fillPaint, lineMatrix);
       return true;
     }
     RRect rRect = {};
     if (StrokeLineToRRect(paint.stroke, line, &rRect, &lineMatrix)) {
       LayerPaint fillPaint = paint;
       fillPaint.style = PaintStyle::Fill;
-      Matrix combinedMatrix = lineMatrix;
-      combinedMatrix.postConcat(matrix);
-      addRRect(rRect, fillPaint, combinedMatrix);
+      if (!lineMatrix.isIdentity() && fillPaint.shader) {
+        Matrix inverse = {};
+        if (lineMatrix.invert(&inverse)) {
+          fillPaint.shader = fillPaint.shader->makeWithMatrix(inverse);
+        }
+      }
+      lineMatrix.postConcat(matrix);
+      addRRect(rRect, fillPaint, lineMatrix);
       return true;
     }
   }

--- a/src/layers/LayerRecorder.cpp
+++ b/src/layers/LayerRecorder.cpp
@@ -183,33 +183,18 @@ bool LayerRecorder::tryAddSimplifiedPath(const Path& path, const LayerPaint& pai
     if (paint.style != PaintStyle::Stroke) {
       return true;
     }
-    Matrix lineMatrix = {};
     Rect rect = {};
-    if (StrokeLineToRect(paint.stroke, line, &rect, &lineMatrix)) {
+    if (StrokeLineToRect(paint.stroke, line, &rect)) {
       LayerPaint fillPaint = paint;
       fillPaint.style = PaintStyle::Fill;
-      if (!lineMatrix.isIdentity() && fillPaint.shader) {
-        Matrix inverse = {};
-        if (lineMatrix.invert(&inverse)) {
-          fillPaint.shader = fillPaint.shader->makeWithMatrix(inverse);
-        }
-      }
-      lineMatrix.postConcat(matrix);
-      addRect(rect, fillPaint, lineMatrix);
+      addRect(rect, fillPaint, matrix);
       return true;
     }
     RRect rRect = {};
-    if (StrokeLineToRRect(paint.stroke, line, &rRect, &lineMatrix)) {
+    if (StrokeLineToRRect(paint.stroke, line, &rRect)) {
       LayerPaint fillPaint = paint;
       fillPaint.style = PaintStyle::Fill;
-      if (!lineMatrix.isIdentity() && fillPaint.shader) {
-        Matrix inverse = {};
-        if (lineMatrix.invert(&inverse)) {
-          fillPaint.shader = fillPaint.shader->makeWithMatrix(inverse);
-        }
-      }
-      lineMatrix.postConcat(matrix);
-      addRRect(rRect, fillPaint, lineMatrix);
+      addRRect(rRect, fillPaint, matrix);
       return true;
     }
   }

--- a/src/layers/LayerRecorder.cpp
+++ b/src/layers/LayerRecorder.cpp
@@ -181,14 +181,25 @@ bool LayerRecorder::tryAddSimplifiedPath(const Path& path, const LayerPaint& pai
   Point line[2] = {};
   if (path.isLine(line)) {
     if (paint.style != PaintStyle::Stroke) {
-      // A line cannot be filled.
       return true;
     }
+    Matrix lineMatrix = {};
     Rect rect = {};
-    if (StrokeLineToRect(paint.stroke, line, &rect)) {
+    if (StrokeLineToRect(paint.stroke, line, &rect, &lineMatrix)) {
       LayerPaint fillPaint = paint;
       fillPaint.style = PaintStyle::Fill;
-      addRect(rect, fillPaint, matrix);
+      Matrix combinedMatrix = lineMatrix;
+      combinedMatrix.postConcat(matrix);
+      addRect(rect, fillPaint, combinedMatrix);
+      return true;
+    }
+    RRect rRect = {};
+    if (StrokeLineToRRect(paint.stroke, line, &rRect, &lineMatrix)) {
+      LayerPaint fillPaint = paint;
+      fillPaint.style = PaintStyle::Fill;
+      Matrix combinedMatrix = lineMatrix;
+      combinedMatrix.postConcat(matrix);
+      addRRect(rRect, fillPaint, combinedMatrix);
       return true;
     }
   }

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -369,7 +369,7 @@
         "drawShape": "bf48e614",
         "inversePath_rect": "bf48e614",
         "inversePath_text": "c37a86c8",
-        "path": "bf48e614",
+        "path": "45fb9980",
         "roundRectRadii": "bf48e614",
         "roundRectRadiiStroke": "bf48e614",
         "shape": "cad4b77f"
@@ -471,7 +471,7 @@
         "complex3": "543054b5",
         "complex4": "5ff7fdca",
         "complex5": "880d5a6c",
-        "complex6": "cd158924",
+        "complex6": "45fb9980",
         "complex7": "cd158924",
         "jpg_image": "b1db872",
         "mask": "da364e8",


### PR DESCRIPTION
优化了 Canvas::drawLine() 的绘制性能，将轴对齐线条直接渲染为矩形或圆角矩形，避免走通用路径绘制流程。LayerRecorder 也同步支持了圆角线条的优化渲染。