### PR TITLE
Fix forceAlignment using N gaps for closed paths instead of N-1.

### DIFF
--- a/src/layers/vectors/TextPath.cpp
+++ b/src/layers/vectors/TextPath.cpp
@@ -187,7 +187,8 @@ void TextPath::apply(VectorContext* context) {
     auto availableLength = pathLength + _lastMargin - _firstMargin;
     float extraSpacingPerGap = 0.0f;
     if (glyphCount > 1 && totalAdvance > 0.0f) {
-      extraSpacingPerGap = (availableLength - totalAdvance) / static_cast<float>(glyphCount - 1);
+      auto gapCount = static_cast<float>(isClosed ? glyphCount : glyphCount - 1);
+      extraSpacingPerGap = (availableLength - totalAdvance) / gapCount;
     }
 
     size_t glyphIndex = 0;


### PR DESCRIPTION
## Summary
- Fix TextPath `forceAlignment` distributing characters unevenly on closed paths (circles, ellipses). The previous code used `glyphCount - 1` gaps, which is correct for open paths where the first and last characters sit at the endpoints. On closed paths, the last character wraps around to meet the first, so `glyphCount` gaps are needed for uniform spacing.

## Test plan
- [x] Verify that characters are evenly distributed on closed circular and elliptical TextPaths with `forceAlignment=true`
- [x] Verify that open path TextPaths (arcs, lines, S-curves) are not affected
- [x] Verify that `reversed` + closed path + `forceAlignment` still works correctly