### PR TITLE
Fix hasCoverage() to return correct value for ShapeDrawOp.

### DIFF
--- a/src/gpu/ops/ShapeDrawOp.cpp
+++ b/src/gpu/ops/ShapeDrawOp.cpp
@@ -100,7 +100,11 @@ void ShapeDrawOp::onDraw(RenderPass* renderPass) {
 }
 
 bool ShapeDrawOp::hasCoverage() const {
-  return true;
+  // Return true only if we have actual dynamic coverage:
+  // - AAType::Coverage means we have per-vertex coverage
+  // - Having coverage FragmentProcessors also means dynamic coverage
+  // When aaType is None and no coverage FP, the coverage is constant vec4(1.0)
+  return aaType == AAType::Coverage || !coverages.empty();
 }
 
 }  // namespace tgfx

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -85,6 +85,7 @@
         "RRectBlendMode": "1d1a7afb",
         "ScaleMatrixShader": "00bc6d75",
         "ScaleTest": "eefb7a46",
+        "ShapeBlendMode": "119a81f8",
         "SingleImageRect1": "4edccb64",
         "SingleImageRectWithMipmap": "4edccb64",
         "blendMode": "0cfb8996",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -1110,6 +1110,55 @@ TGFX_TEST(CanvasTest, RRectBlendMode) {
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/RRectBlendMode"));
 }
 
+TGFX_TEST(CanvasTest, ShapeBlendMode) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 300, 200);
+  ASSERT_TRUE(surface != nullptr);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+
+  // Draw a green background rect on the left half
+  Paint bgPaint;
+  bgPaint.setColor(Color::Green());
+  canvas->drawRect(Rect::MakeXYWH(0, 0, 150, 200), bgPaint);
+
+  // Draw a blue background rect on the right half
+  bgPaint.setColor(Color::Blue());
+  canvas->drawRect(Rect::MakeXYWH(150, 0, 150, 200), bgPaint);
+
+  // Create a complex path that will use ShapeDrawOp with coverage (antiAlias=true)
+  Path path;
+  path.moveTo(50, 30);
+  path.lineTo(100, 170);
+  path.lineTo(0, 70);
+  path.lineTo(100, 70);
+  path.lineTo(0, 170);
+  path.close();
+
+  // Left: Shape with BlendMode::Src and antiAlias (has coverage)
+  // BlendMode::Src uses different blend formula with/without coverage
+  auto shape = Shape::MakeFrom(path);
+  Paint paint;
+  paint.setColor(Color::FromRGBA(255, 0, 0, 200));
+  paint.setAntiAlias(true);
+  paint.setBlendMode(BlendMode::Src);
+  canvas->save();
+  canvas->translate(25, 15);
+  canvas->drawShape(shape, paint);
+  canvas->restore();
+
+  // Right: Shape with BlendMode::Src and antiAlias=false (no coverage)
+  paint.setAntiAlias(false);
+  canvas->save();
+  canvas->translate(175, 15);
+  canvas->drawShape(shape, paint);
+  canvas->restore();
+
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/ShapeBlendMode"));
+}
+
 TGFX_TEST(CanvasTest, MatrixShapeStroke) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
修复 ShapeDrawOp::hasCoverage() 返回值不正确的问题。

原实现无条件返回 true，但当 aaType 为 None 或 MSAA 且没有 coverage FragmentProcessor 时，DefaultGeometryProcessor 实际输出的是常量 vec4(1.0)，不需要使用带 coverage 的 blend formula。

修改后的实现根据实际情况判断：
- aaType == AAType::Coverage 时有顶点 coverage
- coverages 非空时有 coverage FP
- 其他情况返回 false