### PR TITLE
Fix PDF src blend mode rendering with correct stream routing and SMask inversion.

### DIFF
--- a/src/pdf/PDFExportContext.cpp
+++ b/src/pdf/PDFExportContext.cpp
@@ -841,8 +841,15 @@ void PDFExportContext::onDrawPath(const Matrix& matrix, const ClipStack& clip, c
     return;
   }
 
-  PDFUtils::EmitPath(path, false, content);
-  PDFUtils::PaintPath(path.getFillType(), content);
+  if (scopedContent.needShape()) {
+    Path shape(path);
+    shape.transform(matrix);
+    scopedContent.setShape(shape);
+  }
+
+  auto stream = scopedContent.stream();
+  PDFUtils::EmitPath(path, false, stream);
+  PDFUtils::PaintPath(path.getFillType(), stream);
 }
 
 void PDFExportContext::onDrawImageRect(std::shared_ptr<Image> image, const Rect& rect,
@@ -1095,6 +1102,8 @@ std::shared_ptr<MemoryWriteStream> PDFExportContext::setUpContentEntry(
 
   if (!TreatAsRegularPDFBlendMode(blendMode) && blendMode != BlendMode::DstOver) {
     if (!isContentEmpty()) {
+      activeStackState.drainStack();
+      activeStackState = PDFGraphicStackState();
       *destination = this->makeFormXObjectFromDevice();
       DEBUG_ASSERT(isContentEmpty());
     } else if (blendMode != BlendMode::Src && blendMode != BlendMode::SrcOut) {
@@ -1267,7 +1276,7 @@ void PDFExportContext::drawFormXObject(PDFIndirectReference xObject,
 
   DEBUG_ASSERT(xObject);
   PDFWriteResourceName(stream, PDFResourceType::XObject, add_resource(xObjectResources, xObject));
-  content->writeText(" Do\n");
+  stream->writeText(" Do\n");
 }
 
 void PDFExportContext::clearMaskOnGraphicState(const std::shared_ptr<MemoryWriteStream>& stream) {

--- a/src/pdf/PDFGraphicState.cpp
+++ b/src/pdf/PDFGraphicState.cpp
@@ -21,6 +21,8 @@
 #include "pdf/PDFTypes.h"
 #include "pdf/PDFUtils.h"
 #include "tgfx/core/BlendMode.h"
+#include "tgfx/core/Data.h"
+#include "tgfx/core/Stream.h"
 
 namespace tgfx {
 
@@ -57,8 +59,8 @@ PDFIndirectReference PDFGraphicState::GetGraphicStateForPaint(PDFDocumentImpl* d
   return reference;
 }
 
-PDFIndirectReference PDFGraphicState::GetSMaskGraphicState(PDFIndirectReference sMask,
-                                                           bool /*invert*/, SMaskMode sMaskMode,
+PDFIndirectReference PDFGraphicState::GetSMaskGraphicState(PDFIndirectReference sMask, bool invert,
+                                                           SMaskMode sMaskMode,
                                                            PDFDocumentImpl* doc) {
   // The practical chances of using the same mask more than once are unlikely
   // enough that it's not worth canonicalizing.
@@ -69,6 +71,18 @@ PDFIndirectReference PDFGraphicState::GetSMaskGraphicState(PDFIndirectReference 
     sMaskDict->insertName("S", "Luminosity");
   }
   sMaskDict->insertRef("G", sMask);
+  if (invert) {
+    // PDF Type 4 (PostScript Calculator) function: f(x) = 1 - x
+    auto fnDict = PDFDictionary::Make();
+    fnDict->insertInt("FunctionType", 4);
+    fnDict->insertObject("Domain", MakePDFArray(0.f, 1.f));
+    fnDict->insertObject("Range", MakePDFArray(0.f, 1.f));
+    std::string fnBody = "{ 1 exch sub }";
+    auto fnStream = Stream::MakeFromData(Data::MakeWithCopy(fnBody.data(), fnBody.size()));
+    auto fnRef =
+        PDFStreamOut(std::move(fnDict), std::move(fnStream), doc, PDFSteamCompressionEnabled::No);
+    sMaskDict->insertRef("TR", fnRef);
+  }
   auto result = PDFDictionary::Make("ExtGState");
   result->insertObject("SMask", std::move(sMaskDict));
   return doc->emit(*result);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -334,8 +334,9 @@
         "LayerDiamondGradient": "87b290333",
         "LayerLinearGradient": "23582ded6",
         "LayerRadialGradient": "23582ded6",
-        "NonRegularBlendMode": "3230001c6",
-        "SimpleText": "c13eac52"
+        "NonRegularBlendMode": "fb7474423",
+        "SimpleText": "c13eac52",
+        "SrcBlendOverlap": "fb7474423"
     },
     "PathShapeTest": {
         "AdaptiveDashEffect": "0448e0fe",

--- a/test/src/PDFExportTest.cpp
+++ b/test/src/PDFExportTest.cpp
@@ -33,6 +33,8 @@
 #include "tgfx/layers/DisplayList.h"
 #include "tgfx/layers/ShapeLayer.h"
 #include "tgfx/layers/ShapeStyle.h"
+#include "tgfx/layers/SolidLayer.h"
+#include "tgfx/layers/layerstyles/BackgroundBlurStyle.h"
 #include "tgfx/layers/layerstyles/DropShadowStyle.h"
 #include "tgfx/pdf/PDFDocument.h"
 #include "tgfx/pdf/PDFMetadata.h"
@@ -897,6 +899,99 @@ TGFX_TEST(PDFExportTest, NonRegularBlendMode) {
   PDFStream->flush();
 
   EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/NonRegularBlendMode"));
+}
+
+namespace {
+void DrawSrcBlendOverlap(Canvas* canvas) {
+  // Bottom rectangle: blue, drawn with default SrcOver blend mode.
+  Paint basePaint;
+  basePaint.setColor(Color::Blue());
+  canvas->drawRect(Rect::MakeXYWH(50, 50, 150, 150), basePaint);
+
+  // Top rectangle: semi-transparent red, drawn with Src blend mode.
+  // Src replaces the destination entirely, so the overlap region should show only the red color
+  // (including its alpha), with no blue bleed-through.
+  Paint srcPaint;
+  srcPaint.setColor(Color::FromRGBA(255, 0, 0, 128));
+  srcPaint.setBlendMode(BlendMode::Src);
+  canvas->drawRect(Rect::MakeXYWH(100, 100, 150, 150), srcPaint);
+}
+}  // namespace
+
+TGFX_TEST(PDFExportTest, SrcBlendOverlap) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+
+  float width = 300.f;
+  float height = 300.f;
+
+  auto PDFStream = MemoryWriteStream::Make();
+  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
+  ASSERT_TRUE(document != nullptr);
+  auto canvas = document->beginPage(width, height);
+  ASSERT_TRUE(canvas != nullptr);
+  DrawSrcBlendOverlap(canvas);
+  document->endPage();
+  document->close();
+  PDFStream->flush();
+  EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/SrcBlendOverlap"));
+
+  auto surface = Surface::Make(context, static_cast<int>(width), static_cast<int>(height));
+  auto surfaceCanvas = surface->getCanvas();
+  DrawSrcBlendOverlap(surfaceCanvas);
+  EXPECT_TRUE(Baseline::Compare(surface, "PDFTest/SrcBlendOverlap"));
+}
+
+TGFX_TEST(PDFExportTest, BackgroundBlurLayer) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+
+  auto PDFStream = MemoryWriteStream::Make();
+  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
+  ASSERT_TRUE(document != nullptr);
+
+  float pageW = 822.f;
+  float pageH = 1663.f;
+
+  auto rootLayer = Layer::Make();
+
+  auto background = SolidLayer::Make();
+  background->setColor(Color::White());
+  background->setWidth(static_cast<int>(pageW));
+  background->setHeight(static_cast<int>(pageH));
+  rootLayer->addChild(background);
+
+  auto redLayer = SolidLayer::Make();
+  redLayer->setColor(Color::Red());
+  redLayer->setWidth(624);
+  redLayer->setHeight(48);
+  redLayer->setPosition(Point{99.f, 381.f});
+  rootLayer->addChild(redLayer);
+
+  auto blurLayer = SolidLayer::Make();
+  blurLayer->setColor(Color::FromRGBA(139, 239, 200));
+  blurLayer->setWidth(822);
+  blurLayer->setHeight(300);
+  blurLayer->setPosition(Point{0.f, 469.f});
+  blurLayer->setLayerStyles({BackgroundBlurStyle::Make(10.f, 10.f)});
+  rootLayer->addChild(blurLayer);
+
+  auto surface = Surface::Make(context, static_cast<int>(pageW), static_cast<int>(pageH));
+  auto surfaceCanvas = surface->getCanvas();
+  rootLayer->draw(surfaceCanvas);
+
+  auto canvas = document->beginPage(pageW, pageH);
+  ASSERT_TRUE(canvas != nullptr);
+  rootLayer->draw(canvas);
+  document->endPage();
+
+  document->close();
+  PDFStream->flush();
+
+  EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/BackgroundBlurLayer_pdf"));
+  EXPECT_TRUE(Baseline::Compare(surface, "PDFTest/BackgroundBlurLayer"));
 }
 
 }  // namespace tgfx

--- a/test/src/PDFExportTest.cpp
+++ b/test/src/PDFExportTest.cpp
@@ -33,8 +33,6 @@
 #include "tgfx/layers/DisplayList.h"
 #include "tgfx/layers/ShapeLayer.h"
 #include "tgfx/layers/ShapeStyle.h"
-#include "tgfx/layers/SolidLayer.h"
-#include "tgfx/layers/layerstyles/BackgroundBlurStyle.h"
 #include "tgfx/layers/layerstyles/DropShadowStyle.h"
 #include "tgfx/pdf/PDFDocument.h"
 #include "tgfx/pdf/PDFMetadata.h"
@@ -901,8 +899,17 @@ TGFX_TEST(PDFExportTest, NonRegularBlendMode) {
   EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/NonRegularBlendMode"));
 }
 
-namespace {
-void DrawSrcBlendOverlap(Canvas* canvas) {
+TGFX_TEST(PDFExportTest, SrcBlendOverlap) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+
+  auto PDFStream = MemoryWriteStream::Make();
+  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
+  ASSERT_TRUE(document != nullptr);
+  auto canvas = document->beginPage(300.f, 300.f);
+  ASSERT_TRUE(canvas != nullptr);
+
   // Bottom rectangle: blue, drawn with default SrcOver blend mode.
   Paint basePaint;
   basePaint.setColor(Color::Blue());
@@ -915,83 +922,11 @@ void DrawSrcBlendOverlap(Canvas* canvas) {
   srcPaint.setColor(Color::FromRGBA(255, 0, 0, 128));
   srcPaint.setBlendMode(BlendMode::Src);
   canvas->drawRect(Rect::MakeXYWH(100, 100, 150, 150), srcPaint);
-}
-}  // namespace
 
-TGFX_TEST(PDFExportTest, SrcBlendOverlap) {
-  ContextScope scope;
-  auto context = scope.getContext();
-  EXPECT_TRUE(context != nullptr);
-
-  float width = 300.f;
-  float height = 300.f;
-
-  auto PDFStream = MemoryWriteStream::Make();
-  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
-  ASSERT_TRUE(document != nullptr);
-  auto canvas = document->beginPage(width, height);
-  ASSERT_TRUE(canvas != nullptr);
-  DrawSrcBlendOverlap(canvas);
   document->endPage();
   document->close();
   PDFStream->flush();
   EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/SrcBlendOverlap"));
-
-  auto surface = Surface::Make(context, static_cast<int>(width), static_cast<int>(height));
-  auto surfaceCanvas = surface->getCanvas();
-  DrawSrcBlendOverlap(surfaceCanvas);
-  EXPECT_TRUE(Baseline::Compare(surface, "PDFTest/SrcBlendOverlap"));
-}
-
-TGFX_TEST(PDFExportTest, BackgroundBlurLayer) {
-  ContextScope scope;
-  auto context = scope.getContext();
-  EXPECT_TRUE(context != nullptr);
-
-  auto PDFStream = MemoryWriteStream::Make();
-  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
-  ASSERT_TRUE(document != nullptr);
-
-  float pageW = 822.f;
-  float pageH = 1663.f;
-
-  auto rootLayer = Layer::Make();
-
-  auto background = SolidLayer::Make();
-  background->setColor(Color::White());
-  background->setWidth(static_cast<int>(pageW));
-  background->setHeight(static_cast<int>(pageH));
-  rootLayer->addChild(background);
-
-  auto redLayer = SolidLayer::Make();
-  redLayer->setColor(Color::Red());
-  redLayer->setWidth(624);
-  redLayer->setHeight(48);
-  redLayer->setPosition(Point{99.f, 381.f});
-  rootLayer->addChild(redLayer);
-
-  auto blurLayer = SolidLayer::Make();
-  blurLayer->setColor(Color::FromRGBA(139, 239, 200));
-  blurLayer->setWidth(822);
-  blurLayer->setHeight(300);
-  blurLayer->setPosition(Point{0.f, 469.f});
-  blurLayer->setLayerStyles({BackgroundBlurStyle::Make(10.f, 10.f)});
-  rootLayer->addChild(blurLayer);
-
-  auto surface = Surface::Make(context, static_cast<int>(pageW), static_cast<int>(pageH));
-  auto surfaceCanvas = surface->getCanvas();
-  rootLayer->draw(surfaceCanvas);
-
-  auto canvas = document->beginPage(pageW, pageH);
-  ASSERT_TRUE(canvas != nullptr);
-  rootLayer->draw(canvas);
-  document->endPage();
-
-  document->close();
-  PDFStream->flush();
-
-  EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/BackgroundBlurLayer_pdf"));
-  EXPECT_TRUE(Baseline::Compare(surface, "PDFTest/BackgroundBlurLayer"));
 }
 
 }  // namespace tgfx


### PR DESCRIPTION
修复 PDF 导出中Src混合模式的bug：

原理上是将src的内容创建为一个mask，然后之前的背景被这个mask。然后再直接绘制上去src内容。

存在几个问题：
创建mask的xobject，写入到了错误的对象，mask的内容并没有实际创建出来。
未实现反向mask，导出背景被完全剔除看不到。
图形状态栈不平衡，类似于src混合导致了确实restore，从而位置错误。

**1. Form XObject Do 命令写入错误流（`PDFExportContext::drawFormXObject`）**
- `Do` 操作符硬编码写入 `content` 而非传入的 `stream` 参数，存在同样的流错位问题。

**2. SMask 反转未实现（`PDFGraphicState::GetSMaskGraphicState`）**
- `invert` 参数被注释掉完全未使用。通过生成 PDF Type 4 Transfer Function（`{ 1 exch sub }`）实现 alpha 通道反转。

**3. 图形状态栈不平衡（`PDFExportContext::setUpContentEntry`）**
- 通过 `makeFormXObjectFromDevice` 打包已有内容时，未先 drain `activeStackState`，导致 content 被 reset 后仍有残留的 `Q` 操作符写入，产生 q/Q 栈下溢。不同 PDF 渲染器（Chrome vs macOS Preview）对此行为不一致，导致元素位置偏差。

src混合模式，渲染和PDF导出效果
<img width="256" height="274" alt="Clipboard_Screenshot_1776327679" src="https://github.com/user-attachments/assets/9de10a32-4a02-4de8-82f9-b28cd0e7afe6" />
<img width="372" height="365" alt="Clipboard_Screenshot_1776327713" src="https://github.com/user-attachments/assets/fbbc99aa-f2d2-4482-abc8-c93a8683d5ef" />

