### PR TITLE
Add ExposureColorFilter with tone-mapped brightness adjustment

### DIFF
--- a/include/tgfx/core/ColorFilter.h
+++ b/include/tgfx/core/ColorFilter.h
@@ -86,6 +86,14 @@ class ColorFilter {
    */
   static std::shared_ptr<ColorFilter> Luma();
 
+  /**
+   * Creates a new ColorFilter that adjusts the exposure of the input color using a non-linear
+   * tone-mapped curve. Positive values brighten the image with highlight protection, and negative
+   * values darken it with shadow preservation.
+   * @param exposure The exposure adjustment value in the range of -1.0 to 1.0.
+   */
+  static std::shared_ptr<ColorFilter> Exposure(float exposure);
+
   virtual ~ColorFilter() = default;
 
   /**
@@ -105,7 +113,7 @@ class ColorFilter {
   }
 
  protected:
-  enum class Type { Blend, Matrix, AlphaThreshold, Compose, Luma };
+  enum class Type { Blend, Matrix, AlphaThreshold, Compose, Luma, Exposure };
 
   /**
    * Returns true if this color filter transforms transparent black into a non-transparent color.

--- a/resources/apitest/color_test.png
+++ b/resources/apitest/color_test.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1266c710793904f1f7e3c145807d08a0649b8b51c9a185be6f3d61175ae5e2a0
+size 1198

--- a/src/core/filters/ExposureColorFilter.cpp
+++ b/src/core/filters/ExposureColorFilter.cpp
@@ -1,0 +1,43 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ExposureColorFilter.h"
+#include "core/utils/Types.h"
+#include "gpu/processors/ExposureFragmentProcessor.h"
+
+namespace tgfx {
+
+std::shared_ptr<ColorFilter> ColorFilter::Exposure(float exposure) {
+  return std::make_shared<ExposureColorFilter>(exposure);
+}
+
+bool ExposureColorFilter::isEqual(const ColorFilter* colorFilter) const {
+  auto type = Types::Get(colorFilter);
+  if (type != Types::ColorFilterType::Exposure) {
+    return false;
+  }
+  auto other = static_cast<const ExposureColorFilter*>(colorFilter);
+  return exposure == other->exposure;
+}
+
+PlacementPtr<FragmentProcessor> ExposureColorFilter::asFragmentProcessor(
+    Context* context, const std::shared_ptr<ColorSpace>&) const {
+  return ExposureFragmentProcessor::Make(context->drawingAllocator(), exposure);
+}
+
+}  // namespace tgfx

--- a/src/core/filters/ExposureColorFilter.h
+++ b/src/core/filters/ExposureColorFilter.h
@@ -1,0 +1,46 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "tgfx/core/ColorFilter.h"
+
+namespace tgfx {
+class ExposureColorFilter : public ColorFilter {
+ public:
+  explicit ExposureColorFilter(float exposure) : exposure(exposure) {
+  }
+
+  bool isAlphaUnchanged() const override {
+    return true;
+  }
+
+  float exposure = 0.0f;
+
+ protected:
+  Type type() const override {
+    return Type::Exposure;
+  }
+
+  bool isEqual(const ColorFilter* colorFilter) const override;
+
+ private:
+  PlacementPtr<FragmentProcessor> asFragmentProcessor(
+      Context* context, const std::shared_ptr<ColorSpace>& dstColorSpace) const override;
+};
+}  // namespace tgfx

--- a/src/gpu/glsl/processors/GLSLExposureFragmentProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLExposureFragmentProcessor.cpp
@@ -1,0 +1,88 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "GLSLExposureFragmentProcessor.h"
+
+namespace tgfx {
+PlacementPtr<ExposureFragmentProcessor> ExposureFragmentProcessor::Make(BlockAllocator* allocator,
+                                                                        float exposure) {
+  return allocator->make<GLSLExposureFragmentProcessor>(exposure);
+}
+
+void GLSLExposureFragmentProcessor::emitCode(EmitArgs& args) const {
+  auto uniformHandler = args.uniformHandler;
+  auto exposureUniform =
+      uniformHandler->addUniform("Exposure", UniformFormat::Float, ShaderStage::Fragment);
+
+  auto fragBuilder = args.fragBuilder;
+  // Unpremultiply alpha to get straight RGB.
+  fragBuilder->codeAppendf("float alpha = %s.a;", args.inputColor.c_str());
+  fragBuilder->codeAppend("vec3 color = vec3(0.0);");
+  fragBuilder->codeAppend("if (alpha > 0.0) {");
+  fragBuilder->codeAppendf("  color = %s.rgb / alpha;", args.inputColor.c_str());
+  fragBuilder->codeAppend("}");
+
+  fragBuilder->codeAppendf("float e = %s;", exposureUniform.c_str());
+
+  // Convert sRGB to linear using gamma 2.2.
+  fragBuilder->codeAppend("vec3 c = pow(max(color, vec3(0.0001)), vec3(2.2));");
+
+  // Compute the tone-mapping multiplier using a power-of-10 curve.
+  fragBuilder->codeAppend("float k = pow(10.0, 2.0 * e) - 1.0;");
+
+  // Desaturate by 75% toward BT.709 luminance before tone mapping, then restore afterward. This
+  // prevents oversaturation in highlights and preserves color relationships across channels.
+  fragBuilder->codeAppend("const float DESAT = 0.75;");
+  fragBuilder->codeAppend("float satRestore = 1.0 / (1.0 - DESAT) - 1.0;");
+  fragBuilder->codeAppend("const vec3 LUMA_W = vec3(0.2126, 0.7152, 0.0722);");
+  fragBuilder->codeAppend("float luma = dot(c, LUMA_W);");
+
+  // For negative exposure, reduce the saturation restoration proportionally to luminance to avoid
+  // color shifts in dark regions.
+  fragBuilder->codeAppend("satRestore *= 1.0 + luma * luma * min(0.0, e) / (0.2 - min(0.0, e));");
+
+  // Desaturate: blend each channel toward luminance.
+  fragBuilder->codeAppend("c += (luma - c) * DESAT;");
+
+  // For negative exposure, apply additional darkening.
+  fragBuilder->codeAppend("if (e < 0.0) {");
+  fragBuilder->codeAppend("  c *= 1.0 + e / 16.0;");
+  fragBuilder->codeAppend("  luma *= 1.0 + e / 16.0;");
+  fragBuilder->codeAppend("}");
+
+  // Apply Reinhard tone mapping to both color and luminance.
+  fragBuilder->codeAppend("c *= (k + 1.0) / (c * k + 1.0);");
+  fragBuilder->codeAppend("luma *= (k + 1.0) / (luma * k + 1.0);");
+
+  // Restore saturation.
+  fragBuilder->codeAppend("c += (c - luma) * satRestore;");
+  fragBuilder->codeAppend("c = clamp(c, 0.0, 1.0);");
+
+  // Convert linear back to sRGB.
+  fragBuilder->codeAppend("vec3 result = pow(c, vec3(1.0 / 2.2));");
+
+  // Re-premultiply alpha.
+  fragBuilder->codeAppendf("%s = vec4(result * alpha, alpha);", args.outputColor.c_str());
+}
+
+void GLSLExposureFragmentProcessor::onSetData(UniformData* /*vertexUniformData*/,
+                                              UniformData* fragmentUniformData) const {
+  fragmentUniformData->setData("Exposure", exposure);
+}
+
+}  // namespace tgfx

--- a/src/gpu/glsl/processors/GLSLExposureFragmentProcessor.h
+++ b/src/gpu/glsl/processors/GLSLExposureFragmentProcessor.h
@@ -1,0 +1,33 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "gpu/processors/ExposureFragmentProcessor.h"
+
+namespace tgfx {
+class GLSLExposureFragmentProcessor : public ExposureFragmentProcessor {
+ public:
+  explicit GLSLExposureFragmentProcessor(float exposure) : ExposureFragmentProcessor(exposure) {
+  }
+
+  void emitCode(EmitArgs& args) const override;
+
+  void onSetData(UniformData* vertexUniformData, UniformData* fragmentUniformData) const override;
+};
+}  // namespace tgfx

--- a/src/gpu/processors/ExposureFragmentProcessor.h
+++ b/src/gpu/processors/ExposureFragmentProcessor.h
@@ -1,0 +1,41 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "gpu/processors/FragmentProcessor.h"
+
+namespace tgfx {
+class ExposureFragmentProcessor : public FragmentProcessor {
+ public:
+  static PlacementPtr<ExposureFragmentProcessor> Make(BlockAllocator* allocator, float exposure);
+
+  std::string name() const override {
+    return "ExposureFragmentProcessor";
+  }
+
+ protected:
+  DEFINE_PROCESSOR_CLASS_ID
+
+  explicit ExposureFragmentProcessor(float exposure)
+      : FragmentProcessor(ClassID()), exposure(exposure) {
+  }
+
+  float exposure = 0.0f;
+};
+}  // namespace tgfx

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -112,6 +112,7 @@
         "ComposeImageFilter": "c26ff3d9",
         "ComposeImageFilter2": "b613521e",
         "EmptyShadowTest": "b9a42bf",
+        "ExposureColorFilter": "792903fb",
         "GaussianBlurImageFilterComplex1D": "c26ff3d9",
         "GaussianBlurImageFilterComplex2D": "c26ff3d9",
         "GaussianBlurImageFilterSimple2D": "c26ff3d9",

--- a/test/src/FilterTest.cpp
+++ b/test/src/FilterTest.cpp
@@ -84,6 +84,45 @@ TGFX_TEST(FilterTest, ModeColorFilter) {
   EXPECT_TRUE(Baseline::Compare(surface, "FilterTest/ModeColorFilter"));
 }
 
+TGFX_TEST(FilterTest, ExposureColorFilter) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  float exposures[] = {-1.0f, -0.75f, -0.5f, -0.25f, 0.0f, 0.25f, 0.5f, 0.75f, 1.0f};
+  int count = 9;
+
+  auto image = MakeImage("resources/apitest/mandrill_128.png");
+  ASSERT_TRUE(image != nullptr);
+  auto colorTest = MakeImage("resources/apitest/color_test.png");
+  ASSERT_TRUE(colorTest != nullptr);
+
+  int colWidth = image->width() > colorTest->width() ? image->width() : colorTest->width();
+  auto totalWidth = colWidth * count + 50 * (count + 1);
+  auto totalHeight = image->height() + colorTest->height() + 150;
+  auto surface = Surface::Make(context, totalWidth, totalHeight);
+  auto canvas = surface->getCanvas();
+  Paint paint;
+
+  for (int i = 0; i < count; i++) {
+    canvas->save();
+    canvas->translate(50 + static_cast<float>(colWidth + 50) * i, 50);
+    paint.setColorFilter(ColorFilter::Exposure(exposures[i]));
+    canvas->drawImage(image, &paint);
+    canvas->restore();
+  }
+
+  for (int i = 0; i < count; i++) {
+    canvas->save();
+    canvas->translate(50 + static_cast<float>(colWidth + 50) * i,
+                      100 + static_cast<float>(image->height()));
+    paint.setColorFilter(ColorFilter::Exposure(exposures[i]));
+    canvas->drawImage(colorTest, &paint);
+    canvas->restore();
+  }
+
+  EXPECT_TRUE(Baseline::Compare(surface, "FilterTest/ExposureColorFilter"));
+}
+
 TGFX_TEST(FilterTest, ComposeColorFilter) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
新增 ExposureColorFilter，支持基于 Reinhard 色调映射曲线的曝光度调节。正值提亮并保护高光，负值压暗并保留暗部细节。包含完整的 GPU 着色器实现、公开 API 接口及截图测试。