### PR TITLE
Update cr skill to include uncommitted changes in feature branch diff scope

### DIFF
--- a/.codebuddy/skills/cr/SKILL.md
+++ b/.codebuddy/skills/cr/SKILL.md
@@ -35,9 +35,8 @@ Run pre-checks, then match the **first** applicable rule top-to-bottom:
 | 1 | `$ARGUMENTS` is `diag` | → `references/diagnosis.md` |
 | 2 | `$ARGUMENTS` is a PR number or URL containing `/pull/` | → `references/pr-review.md` |
 | 3 | Agent teams NOT supported | → `references/local-review.md` |
-| 4 | Uncommitted changes exist | → `references/local-review.md` |
-| 5 | On main/master branch | → `references/local-review.md` |
-| 6 | Everything else | → Question below |
+| 4 | On main/master branch | → `references/local-review.md` |
+| 5 | Everything else | → Question below |
 
 Each `→` means: `Read` the target file and follow it as the sole remaining
 instruction. Ignore all sections below. Do NOT review from memory or habit —

--- a/.codebuddy/skills/cr/references/local-review.md
+++ b/.codebuddy/skills/cr/references/local-review.md
@@ -18,18 +18,20 @@ issues, and lets the user interactively choose which ones to fix.
 
 Determine the diff to review based on `$ARGUMENTS` and working tree state:
 
-- **Empty `$ARGUMENTS`**, **uncommitted changes exist**: scope is
-  uncommitted changes only. Fetch with `git diff HEAD` (staged + unstaged
-  tracked files). Also check for untracked files with `git status --porcelain`
-  (`??` lines) and read their contents for review.
-- **Empty `$ARGUMENTS`**, **no uncommitted changes**: find the base branch by
+- **Empty `$ARGUMENTS`**, **on main/master branch**: scope is uncommitted
+  changes only. Fetch with `git diff HEAD` (staged + unstaged tracked files).
+  Also check for untracked files with `git status --porcelain` (`??` lines)
+  and read their contents for review.
+- **Empty `$ARGUMENTS`**, **on a feature branch**: find the base branch by
   checking common base branches in order: `main`, `master`. Use the first one
-  that exists. Fetch the branch diff:
+  that exists. Fetch the full diff from merge-base to the working tree
+  (committed + uncommitted changes):
   ```
   git merge-base origin/{base_branch} HEAD
   git diff <merge-base-sha>
   ```
-  Also check for untracked files with `git status --porcelain` (`??` lines).
+  Also check for untracked files with `git status --porcelain` (`??` lines)
+  and read their contents for review.
 - **Commit hash** (e.g., `abc123`): validate with `git rev-parse --verify`,
   then `git show`.
 - **Commit range** (e.g., `abc123..def456` or `abc123...def456`): validate both

--- a/.codebuddy/skills/cr/references/teams-review.md
+++ b/.codebuddy/skills/cr/references/teams-review.md
@@ -42,12 +42,14 @@ Scope → Review → Filter → Fix/Validate → Confirm → Report
 Determine the diff to review based on `$ARGUMENTS`:
 
 - **Empty arguments**: find the base branch by checking common base branches
-  in order: `main`, `master`. Use the first one that exists. Fetch the branch
-  diff:
+  in order: `main`, `master`. Use the first one that exists. Fetch the full diff
+  from merge-base to the working tree (committed + uncommitted changes):
   ```
   git merge-base origin/{base_branch} HEAD
   git diff <merge-base-sha>
   ```
+  Also check for untracked files with `git status --porcelain` (`??` lines)
+  and read their contents for review.
 - **Commit hash** (e.g., `abc123`): validate with `git rev-parse --verify`,
   then `git show`.
 - **Commit range** (e.g., `abc123..def456` or `abc123...def456`): validate both


### PR DESCRIPTION
调整 code review skill 的路由规则和 diff 范围逻辑。移除了"存在未提交变更"作为独立路由条件，改为基于分支类型判断；在 feature 分支上 review 时，diff 范围从 merge-base 到工作树，同时覆盖已提交和未提交的变更。