### PR TITLE
Add Line vector element

### DIFF
--- a/include/tgfx/layers/vectors/Line.h
+++ b/include/tgfx/layers/vectors/Line.h
@@ -1,0 +1,90 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "tgfx/core/Point.h"
+#include "tgfx/core/Shape.h"
+#include "tgfx/layers/vectors/VectorElement.h"
+
+namespace tgfx {
+
+/**
+ * Line represents a straight line segment defined by two endpoints.
+ */
+class Line : public VectorElement {
+ public:
+  /**
+   * Creates a new Line instance.
+   */
+  static std::shared_ptr<Line> Make();
+
+  /**
+   * Returns the start point of the line segment.
+   */
+  const Point& startPoint() const {
+    return _startPoint;
+  }
+
+  /**
+   * Sets the start point of the line segment.
+   */
+  void setStartPoint(const Point& value);
+
+  /**
+   * Returns the end point of the line segment.
+   */
+  const Point& endPoint() const {
+    return _endPoint;
+  }
+
+  /**
+   * Sets the end point of the line segment.
+   */
+  void setEndPoint(const Point& value);
+
+  /**
+   * Returns whether the line direction is reversed (from end point to start point).
+   */
+  bool reversed() const {
+    return _reversed;
+  }
+
+  /**
+   * Sets whether the line direction is reversed.
+   */
+  void setReversed(bool value);
+
+ protected:
+  Type type() const override {
+    return Type::Line;
+  }
+
+  void apply(VectorContext* context) override;
+
+ protected:
+  Line() = default;
+
+ private:
+  Point _startPoint = Point::Zero();
+  Point _endPoint = {100.0f, 0.0f};
+  bool _reversed = false;
+  std::shared_ptr<Shape> _cachedShape = nullptr;
+};
+
+}  // namespace tgfx

--- a/include/tgfx/layers/vectors/VectorElement.h
+++ b/include/tgfx/layers/vectors/VectorElement.h
@@ -48,6 +48,7 @@ class VectorElement : public LayerProperty {
     Ellipse,
     Polystar,
     ShapePath,
+    Line,
     FillStyle,
     StrokeStyle,
     TrimPath,

--- a/src/layers/vectors/Line.cpp
+++ b/src/layers/vectors/Line.cpp
@@ -57,7 +57,7 @@ void Line::setReversed(bool value) {
 void Line::apply(VectorContext* context) {
   DEBUG_ASSERT(context != nullptr);
   if (_cachedShape == nullptr) {
-    Path path = {};
+    Path path;
     if (_reversed) {
       path.moveTo(_endPoint);
       path.lineTo(_startPoint);

--- a/src/layers/vectors/Line.cpp
+++ b/src/layers/vectors/Line.cpp
@@ -1,0 +1,75 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "tgfx/layers/vectors/Line.h"
+#include "VectorContext.h"
+#include "core/utils/Log.h"
+#include "tgfx/core/Path.h"
+
+namespace tgfx {
+
+std::shared_ptr<Line> Line::Make() {
+  return std::shared_ptr<Line>(new Line());
+}
+
+void Line::setStartPoint(const Point& value) {
+  if (_startPoint == value) {
+    return;
+  }
+  _startPoint = value;
+  _cachedShape = nullptr;
+  invalidateContent();
+}
+
+void Line::setEndPoint(const Point& value) {
+  if (_endPoint == value) {
+    return;
+  }
+  _endPoint = value;
+  _cachedShape = nullptr;
+  invalidateContent();
+}
+
+void Line::setReversed(bool value) {
+  if (_reversed == value) {
+    return;
+  }
+  _reversed = value;
+  _cachedShape = nullptr;
+  invalidateContent();
+}
+
+void Line::apply(VectorContext* context) {
+  DEBUG_ASSERT(context != nullptr);
+  if (_cachedShape == nullptr) {
+    Path path = {};
+    if (_reversed) {
+      path.moveTo(_endPoint);
+      path.lineTo(_startPoint);
+    } else {
+      path.moveTo(_startPoint);
+      path.lineTo(_endPoint);
+    }
+    _cachedShape = Shape::MakeFrom(path);
+  }
+  if (_cachedShape) {
+    context->addShape(_cachedShape);
+  }
+}
+
+}  // namespace tgfx

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -561,6 +561,7 @@
         "ImagePattern": "484bda47",
         "ImagePatternText": "3e96556a",
         "LayerPlacement": "e8884833",
+        "Line": "cbb380f8",
         "MergePath": "4a74f6aa",
         "MergePathClearsPainters": "4a74f6aa",
         "MergePathOps": "4a74f6aa",

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -27,6 +27,7 @@
 #include "tgfx/layers/vectors/FillStyle.h"
 #include "tgfx/layers/vectors/Gradient.h"
 #include "tgfx/layers/vectors/ImagePattern.h"
+#include "tgfx/layers/vectors/Line.h"
 #include "tgfx/layers/vectors/MergePath.h"
 #include "tgfx/layers/vectors/Polystar.h"
 #include "tgfx/layers/vectors/Rectangle.h"
@@ -4384,6 +4385,70 @@ TGFX_TEST(VectorLayerTest, StrokeDashAdaptive) {
   displayList->render(surface.get());
 
   EXPECT_TRUE(Baseline::Compare(surface, "VectorLayerTest/StrokeDashAdaptive"));
+}
+
+/**
+ * Test Line vector element: horizontal, vertical, diagonal segments with different stroke styles.
+ * Also verifies that reversed property changes the trim direction visibly.
+ */
+TGFX_TEST(VectorLayerTest, Line) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 600, 400);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+
+  auto displayList = std::make_unique<DisplayList>();
+  auto vectorLayer = VectorLayer::Make();
+
+  // Line 1: Horizontal line with solid red stroke.
+  auto line1 = Line::Make();
+  line1->setStartPoint({50, 54});
+  line1->setEndPoint({550, 54});
+  auto stroke1 = MakeStrokeStyle(Color::Red(), 8.0f);
+  auto group1 = std::make_shared<VectorGroup>();
+  group1->setElements({line1, stroke1});
+
+  // Line 2: Diagonal line with dashed blue stroke.
+  auto line2 = Line::Make();
+  line2->setStartPoint({50, 150});
+  line2->setEndPoint({550, 250});
+  auto stroke2 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
+  stroke2->setStrokeWidth(8.0f);
+  stroke2->setDashes({24.0f, 12.0f});
+  auto group2 = std::make_shared<VectorGroup>();
+  group2->setElements({line2, stroke2});
+
+  // Line 3: Forward line trimmed to the first half, stroked green.
+  auto line3 = Line::Make();
+  line3->setStartPoint({50, 346});
+  line3->setEndPoint({300, 346});
+  auto trim3 = std::make_shared<TrimPath>();
+  trim3->setStart(0.0f);
+  trim3->setEnd(0.5f);
+  auto stroke3 = MakeStrokeStyle(Color::Green(), 8.0f);
+  auto group3 = std::make_shared<VectorGroup>();
+  group3->setElements({line3, trim3, stroke3});
+
+  // Line 4: Reversed line with the same trim; the opposite half should be drawn.
+  auto line4 = Line::Make();
+  line4->setStartPoint({300, 346});
+  line4->setEndPoint({550, 346});
+  line4->setReversed(true);
+  auto trim4 = std::make_shared<TrimPath>();
+  trim4->setStart(0.0f);
+  trim4->setEnd(0.5f);
+  auto stroke4 = MakeStrokeStyle(Color::FromRGBA(255, 128, 0, 255), 8.0f);
+  auto group4 = std::make_shared<VectorGroup>();
+  group4->setElements({line4, trim4, stroke4});
+
+  vectorLayer->setContents({group1, group2, group3, group4});
+
+  displayList->root()->addChild(vectorLayer);
+  displayList->render(surface.get());
+
+  EXPECT_TRUE(Baseline::Compare(surface, "VectorLayerTest/Line"));
 }
 
 }  // namespace tgfx

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -4388,8 +4388,8 @@ TGFX_TEST(VectorLayerTest, StrokeDashAdaptive) {
 }
 
 /**
- * Test Line vector element: horizontal, vertical, diagonal segments with different stroke styles.
- * Also verifies that reversed property changes the trim direction visibly.
+ * Test Line vector element: horizontal, diagonal, and trimmed (forward and reversed) segments
+ * with different stroke styles.
  */
 TGFX_TEST(VectorLayerTest, Line) {
   ContextScope scope;


### PR DESCRIPTION
新增 Line 矢量元素，作为 VectorLayer 体系下的几何基元，用于渲染由两个端点确定的直线段。

主要变更：
- include/tgfx/layers/vectors/Line.h、src/layers/vectors/Line.cpp：新增 Line 类，提供 startPoint、endPoint、reversed 三个属性，apply 阶段构造 Path 并缓存 Shape
- include/tgfx/layers/vectors/VectorElement.h：在 Type 枚举中新增 Line
- test/src/VectorLayerTest.cpp、test/baseline/version.json：新增 VectorLayerTest.Line 截图测试，覆盖水平段、对角段以及正向/反向修剪段，并提交对应基线