### PR TITLE
Fix ClipStack dropping inverse-fill clips as redundant.

### DIFF
--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -269,10 +269,9 @@ bool ClipStack::addElement(ClipElement&& toAdd) {
       // toAdd's keep-region already covers cur.bounds entirely, so toAdd is redundant.
       return false;
     case ClipGeometry::BOnly:
-      // cur.bounds is only an optimistic envelope: some area inside it may have
-      // been carved out by existing elements and not actually kept. So "toAdd
-      // contains cur.bounds" does not guarantee toAdd contains the real keep-region,
-      // and existing elements cannot be dropped. Fall through to per-element handling.
+      // cur.bounds is only an optimistic envelope of existing elements: some area
+      // inside it may have been carved out and not actually kept. Existing elements
+      // cannot be dropped here. Fall through to per-element handling.
     case ClipGeometry::Both:
       return appendElement(std::move(toAdd));
   }

--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -41,40 +41,19 @@ enum class ClipGeometry {
  * are equivalent.
  */
 static ClipGeometry ResolveClipGeometry(const ClipElement& a, const ClipElement& b) {
-  const auto boundsA = a.bounds();
-  const auto boundsB = b.bounds();
-  if (!Rect::Intersects(boundsA, boundsB)) {
+  if (!a.cheapIntersects(b)) {
     return ClipGeometry::Empty;
   }
-
-  if (a.isRect() && b.isRect()) {
-    if (boundsB.contains(boundsA)) {
-      return ClipGeometry::AOnly;
-    }
-    if (boundsA.contains(boundsB)) {
-      return ClipGeometry::BOnly;
-    }
-    return ClipGeometry::Both;
+  if (b.cheapContains(a)) {
+    return ClipGeometry::AOnly;
   }
-
-  // Complex paths cannot be simplified, keep both.
-  if (!a.isRect() && !b.isRect()) {
-    if (a.path().isSame(b.path()) && a.isAntiAlias() == b.isAntiAlias()) {
-      return ClipGeometry::BOnly;
-    }
-    return ClipGeometry::Both;
+  if (a.cheapContains(b)) {
+    return ClipGeometry::BOnly;
   }
-
-  if (a.isRect()) {
-    if (b.path().contains(boundsA)) {
-      return ClipGeometry::AOnly;
-    }
-  } else {
-    if (a.path().contains(boundsB)) {
-      return ClipGeometry::BOnly;
-    }
+  // Fallback for equivalent paths whose containment cannot be proven by bounds checks.
+  if (a.path().isSame(b.path()) && a.isAntiAlias() == b.isAntiAlias()) {
+    return ClipGeometry::BOnly;
   }
-
   return ClipGeometry::Both;
 }
 
@@ -114,6 +93,45 @@ ClipElement::ClipElement(const Path& path, bool antiAlias) : _path(path), _antiA
 
   _bounds = path.getBounds();
   _isRect = path.isRect(nullptr);
+}
+
+bool ClipElement::cheapContains(const ClipElement& other) const {
+  auto thisInverse = _path.isInverseFillType();
+  auto otherInverse = other._path.isInverseFillType();
+  if (thisInverse && otherInverse) {
+    // Containment of complements flips direction: this contains other when
+    // this's shape is inside other's shape.
+    return other._path.contains(_path.getBounds());
+  }
+  if (thisInverse) {
+    // This's complement contains other only when this's shape is disjoint from other's bounds.
+    return !Rect::Intersects(_path.getBounds(), other._bounds);
+  }
+  if (otherInverse) {
+    // A bounded region cannot contain a near-full-plane region.
+    return false;
+  }
+  if (_isRect) {
+    return _bounds.contains(other._bounds);
+  }
+  return _path.contains(other._bounds);
+}
+
+bool ClipElement::cheapIntersects(const ClipElement& other) const {
+  auto thisInverse = _path.isInverseFillType();
+  auto otherInverse = other._path.isInverseFillType();
+  if (thisInverse && otherInverse) {
+    // Two near-full-plane regions always overlap.
+    return true;
+  }
+  if (!thisInverse && !otherInverse) {
+    return Rect::Intersects(_bounds, other._bounds);
+  }
+  // Exactly one is inverse: the two regions are disjoint only when the non-inverse
+  // side lies entirely inside the inverse side's removed shape.
+  const auto& inversePath = thisInverse ? _path : other._path;
+  const auto& boundedRect = thisInverse ? other._bounds : _bounds;
+  return !inversePath.contains(boundedRect);
 }
 
 bool ClipElement::tryCombine(const ClipElement& other) {
@@ -233,22 +251,32 @@ bool ClipStack::addElement(ClipElement&& toAdd) {
     cur.uniqueID = UniqueID::Next();
     return true;
   }
-  if (!Rect::Intersects(toAdd.bounds(), cur.bounds)) {
-    cur.state = ClipState::Empty;
-    cur.uniqueID = UniqueID::Next();
-    return true;
-  }
-  // The new element completely contains current clip, so it's redundant.
-  auto curIsContained =
-      toAdd.isRect() ? toAdd.bounds().contains(cur.bounds) : toAdd.path().contains(cur.bounds);
-  if (curIsContained) {
-    return false;
-  }
   if (cur.state == ClipState::WideOpen) {
     replaceWithElement(std::move(toAdd));
     return true;
   }
-  return appendElement(std::move(toAdd));
+  // Wrap cur.bounds as a non-inverse rect ClipElement so ResolveClipGeometry
+  // can handle containment and intersection against toAdd uniformly.
+  Path curBoundsPath = {};
+  curBoundsPath.addRect(cur.bounds);
+  ClipElement curElement(curBoundsPath, false);
+  switch (ResolveClipGeometry(curElement, toAdd)) {
+    case ClipGeometry::Empty:
+      cur.state = ClipState::Empty;
+      cur.uniqueID = UniqueID::Next();
+      return true;
+    case ClipGeometry::AOnly:
+      // toAdd's keep-region already covers cur.bounds entirely, so toAdd is redundant.
+      return false;
+    case ClipGeometry::BOnly:
+      // cur.bounds is only an optimistic envelope: some area inside it may have
+      // been carved out by existing elements and not actually kept. So "toAdd
+      // contains cur.bounds" does not guarantee toAdd contains the real keep-region,
+      // and existing elements cannot be dropped. Fall through to per-element handling.
+    case ClipGeometry::Both:
+      return appendElement(std::move(toAdd));
+  }
+  return false;
 }
 
 void ClipStack::replaceWithElement(ClipElement&& toAdd) {

--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -41,13 +41,13 @@ enum class ClipGeometry {
  * are equivalent.
  */
 static ClipGeometry ResolveClipGeometry(const ClipElement& a, const ClipElement& b) {
-  if (!a.cheapIntersects(b)) {
+  if (!a.looseIntersects(b)) {
     return ClipGeometry::Empty;
   }
-  if (b.cheapContains(a)) {
+  if (b.tightContains(a)) {
     return ClipGeometry::AOnly;
   }
-  if (a.cheapContains(b)) {
+  if (a.tightContains(b)) {
     return ClipGeometry::BOnly;
   }
   // Fallback for equivalent paths whose containment cannot be proven by bounds checks.
@@ -95,7 +95,7 @@ ClipElement::ClipElement(const Path& path, bool antiAlias) : _path(path), _antiA
   _isRect = path.isRect(nullptr);
 }
 
-bool ClipElement::cheapContains(const ClipElement& other) const {
+bool ClipElement::tightContains(const ClipElement& other) const {
   auto thisInverse = _path.isInverseFillType();
   auto otherInverse = other._path.isInverseFillType();
   if (thisInverse && otherInverse) {
@@ -117,7 +117,7 @@ bool ClipElement::cheapContains(const ClipElement& other) const {
   return _path.contains(other._bounds);
 }
 
-bool ClipElement::cheapIntersects(const ClipElement& other) const {
+bool ClipElement::looseIntersects(const ClipElement& other) const {
   auto thisInverse = _path.isInverseFillType();
   auto otherInverse = other._path.isInverseFillType();
   if (thisInverse && otherInverse) {
@@ -259,7 +259,7 @@ bool ClipStack::addElement(ClipElement&& toAdd) {
   // can handle containment and intersection against toAdd uniformly.
   Path curBoundsPath = {};
   curBoundsPath.addRect(cur.bounds);
-  ClipElement curElement(curBoundsPath, false);
+  const ClipElement curElement(curBoundsPath, false);
   switch (ResolveClipGeometry(curElement, toAdd)) {
     case ClipGeometry::Empty:
       cur.state = ClipState::Empty;

--- a/src/core/ClipStack.h
+++ b/src/core/ClipStack.h
@@ -77,6 +77,26 @@ class ClipElement {
 
   bool tryCombine(const ClipElement& other);
 
+  /**
+   * Returns whether this element's keep-region fully contains the keep-region of other.
+   *
+   * A true result guarantees containment; a false result means containment could not be
+   * cheaply proven, so it may or may not actually hold. For example, when this is a concave
+   * path such as an L shape and other's bounds fit entirely inside the L, the geometric
+   * check cannot prove containment and returns false even though it does hold.
+   */
+  bool cheapContains(const ClipElement& other) const;
+
+  /**
+   * Returns whether this element's keep-region intersects the keep-region of other.
+   *
+   * A false result guarantees disjointness; a true result means disjointness could not be
+   * cheaply proven, so the two regions may or may not actually overlap. For example, when
+   * this is a concave path and other fits entirely inside a concave gap of this, the AABB
+   * check still reports them as overlapping and returns true even though they are disjoint.
+   */
+  bool cheapIntersects(const ClipElement& other) const;
+
   void transform(const Matrix& matrix);
 
   void markInvalid(int byIndex) {

--- a/src/core/ClipStack.h
+++ b/src/core/ClipStack.h
@@ -85,7 +85,7 @@ class ClipElement {
    * path such as an L shape and other's bounds fit entirely inside the L, the geometric
    * check cannot prove containment and returns false even though it does hold.
    */
-  bool cheapContains(const ClipElement& other) const;
+  bool tightContains(const ClipElement& other) const;
 
   /**
    * Returns whether this element's keep-region intersects the keep-region of other.
@@ -95,7 +95,7 @@ class ClipElement {
    * this is a concave path and other fits entirely inside a concave gap of this, the AABB
    * check still reports them as overlapping and returns true even though they are disjoint.
    */
-  bool cheapIntersects(const ClipElement& other) const;
+  bool looseIntersects(const ClipElement& other) const;
 
   void transform(const Matrix& matrix);
 

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -50,6 +50,7 @@
         "DrawTextBlob": "29dde9e0",
         "DuplicateClipPath": "f870cce1",
         "EmptyClipMerge": "23eac4df",
+        "InverseFillClip": "d4af6d777",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",
         "LumaFilterToSRGB": "82494664",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -256,6 +256,7 @@ TGFX_TEST(CanvasTest, Clip) {
   }
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/DuplicateClipPath"));
 
+  // ========== 16. Screenshot: uniqueID update on Empty state transition ==========
   // Verify that ClipStack updates its uniqueID when transitioning to Empty state, preventing
   // incorrect draw op batching due to stale uniqueID comparison.
   surface = Surface::Make(context, 100, 100);
@@ -278,6 +279,24 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->drawRect(Rect::MakeXYWH(25, 25, 50, 50), paint);
   }
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyClipMerge"));
+
+  // ========== 17. Screenshot: Inverse-fill clip covering current clip bounds ==========
+  // An inverse-fill path's keep-region is the complement of its geometric shape.
+  // When the shape covers the current clip bounds, the combined clip should become empty.
+  surface = Surface::Make(context, 100, 100);
+  canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+  canvas->clipRect(Rect::MakeWH(100, 100));
+  {
+    Path inverseCanvas = {};
+    inverseCanvas.addRect(Rect::MakeLTRB(-10, -10, 110, 110));
+    inverseCanvas.toggleInverseFillType();
+    canvas->clipPath(inverseCanvas);
+    Paint paint = {};
+    paint.setColor(Color::Red());
+    canvas->drawRect(Rect::MakeWH(100, 100), paint);
+  }
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/InverseFillClip"));
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -297,6 +297,89 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->drawRect(Rect::MakeWH(100, 100), paint);
   }
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/InverseFillClip"));
+
+  // ========== 18. Inverse + inverse clip absorption ==========
+  // Two inverse-fill clips whose shapes are nested: the outer shape's keep-region
+  // (= everything outside outer) is a subset of the inner shape's keep-region
+  // (= everything outside inner). So the inner-shape element is redundant and
+  // gets invalidated, while the outer-shape element and the original clipRect
+  // remain valid.
+  surface = Surface::Make(context, 100, 100);
+  canvas = surface->getCanvas();
+  canvas->clipRect(Rect::MakeWH(100, 100));
+  {
+    Path innerInverse = {};
+    innerInverse.addRect(Rect::MakeLTRB(40, 40, 60, 60));
+    innerInverse.toggleInverseFillType();
+    canvas->clipPath(innerInverse);
+    Path outerInverse = {};
+    outerInverse.addRect(Rect::MakeLTRB(20, 20, 80, 80));
+    outerInverse.toggleInverseFillType();
+    canvas->clipPath(outerInverse);
+  }
+  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+  {
+    const auto& elems = canvas->clipStack->elements();
+    ASSERT_EQ(elems.size(), 2u);
+    // [0] is the initial clipRect, untouched.
+    EXPECT_TRUE(elems[0].isValid());
+    EXPECT_FALSE(elems[0].path().isInverseFillType());
+    EXPECT_EQ(elems[0].bounds(), Rect::MakeWH(100, 100));
+    // [1] was innerInverse originally; outerInverse's BOnly verdict invalidated
+    // innerInverse, and appendElement reused the freed slot for outerInverse.
+    EXPECT_TRUE(elems[1].isValid());
+    EXPECT_TRUE(elems[1].path().isInverseFillType());
+    EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
+  }
+
+  // ========== 19. Non-inverse clip falls entirely inside inverse-fill's removed shape ==========
+  // The new clipRect's keep-region lies entirely inside the inverse-fill clip's
+  // removed shape, so the two keep-regions are disjoint and the combined clip
+  // becomes empty.
+  surface = Surface::Make(context, 100, 100);
+  canvas = surface->getCanvas();
+  canvas->clipRect(Rect::MakeWH(100, 100));
+  {
+    Path inverseHole = {};
+    inverseHole.addRect(Rect::MakeLTRB(20, 20, 80, 80));
+    inverseHole.toggleInverseFillType();
+    canvas->clipPath(inverseHole);
+  }
+  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+  canvas->clipRect(Rect::MakeLTRB(30, 30, 70, 70));
+  EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty);
+
+  // ========== 20. Inverse clip partially overlapping non-inverse rect ==========
+  // The non-inverse clipRect's bounds partially overlap the inverse-fill's
+  // removed shape. Neither side contains the other's keep-region, so both
+  // clips must be retained. This exercises tightContains's "this inverse,
+  // other non-inverse" branch returning false, without short-circuiting to
+  // Empty via looseIntersects.
+  surface = Surface::Make(context, 100, 100);
+  canvas = surface->getCanvas();
+  canvas->clipRect(Rect::MakeWH(100, 100));
+  {
+    Path inverseHole = {};
+    inverseHole.addRect(Rect::MakeLTRB(20, 20, 80, 80));
+    inverseHole.toggleInverseFillType();
+    canvas->clipPath(inverseHole);
+  }
+  canvas->clipRect(Rect::MakeLTRB(10, 10, 40, 40));
+  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+  {
+    const auto& elems = canvas->clipStack->elements();
+    ASSERT_EQ(elems.size(), 2u);
+    // [0] is the initial rect after tryCombine absorbs the new clipRect into it.
+    EXPECT_TRUE(elems[0].isValid());
+    EXPECT_FALSE(elems[0].path().isInverseFillType());
+    EXPECT_EQ(elems[0].bounds(), Rect::MakeLTRB(10, 10, 40, 40));
+    // [1] is inverseHole. Both clips survive because neither side's keep-region
+    // contains the other: the rect's bounds straddle the hole's boundary, and
+    // the hole's shape does not cover the rect's bounds.
+    EXPECT_TRUE(elems[1].isValid());
+    EXPECT_TRUE(elems[1].path().isInverseFillType());
+    EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
+  }
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {


### PR DESCRIPTION
ClipStack::addElement 在判断"新 clip 是否已完全覆盖当前 clip 边界，可作为冗余丢弃"时，使用的是 SkPath::conservativelyContainsRect，仅做纯几何层面的包含判断，忽略了 inverseFillType。当 AlphaInverted 蒙版经由 MakeMask 的 clipPath 快路径进入 ClipStack 时，若其几何形状恰好覆盖画布，该检查会把 inverse-fill clip 误判为冗余并丢弃，导致被裁剪图层在这些帧上完全失去裁剪效果。

在 ClipElement 上新增 cheapContains / cheapIntersects 两个语义正确的保守比较方法，显式区分 inverse-fill 与非 inverse-fill 的四种组合，并把 ResolveClipGeometry 与 ClipStack::addElement 的包含性判断统一收敛到这两个方法上。同时顺手精简 ResolveClipGeometry 的分支结构，把 WideOpen 早退出提到入口处。

在 TGFX_TEST(CanvasTest, Clip) 末尾新增场景 17，覆盖"inverse-fill path 几何形状包含当前 cur.bounds"这一触发路径；同时给前一个未编号的 EmptyClipMerge 截图场景补上编号 16。