### PR TITLE
Clarify coordinate space documentation for ColorSource and ImagePattern.

### DIFF
--- a/include/tgfx/layers/vectors/ColorSource.h
+++ b/include/tgfx/layers/vectors/ColorSource.h
@@ -39,8 +39,8 @@ class ColorSource : public LayerProperty {
   /**
    * Returns true when this ColorSource's parameters are interpreted relative to each geometry's
    * bounding box. When true, FillStyle/StrokeStyle supplies the shader with a per-geometry fit
-   * matrix obtained from getFitMatrix(). When false, the shader is used as-is in the layer's
-   * coordinate space.
+   * matrix obtained from getFitMatrix(). When false, the shader is used as-is in the parent
+   * container's (VectorLayer or VectorGroup) coordinate space.
    */
   virtual bool fitsToGeometry() const = 0;
 

--- a/include/tgfx/layers/vectors/Gradient.h
+++ b/include/tgfx/layers/vectors/Gradient.h
@@ -33,7 +33,8 @@ class DiamondGradient;
 /**
  * The base class for all gradient types that can be drawn on a vector layer. By default, gradient
  * parameters are interpreted in a normalized 0-1 space that maps to each geometry's bounding box.
- * Call setFitsToGeometry(false) to interpret them in the layer's coordinate space instead.
+ * Call setFitsToGeometry(false) to interpret them in the parent container's (VectorLayer or
+ * VectorGroup) coordinate space instead.
  */
 class Gradient : public ColorSource {
  public:
@@ -148,8 +149,8 @@ class Gradient : public ColorSource {
   /**
    * Returns whether the gradient parameters are interpreted relative to each geometry's bounding
    * box. When true (the default), the parameters live in a (0, 0)-(1, 1) coordinate space that
-   * maps to each geometry's bounding box. When false, the parameters are in the layer's
-   * coordinate space.
+   * maps to each geometry's bounding box. When false, the parameters are in the parent
+   * container's (VectorLayer or VectorGroup) coordinate space.
    */
   bool fitsToGeometry() const override {
     return _fitsToGeometry;
@@ -196,8 +197,8 @@ class LinearGradient : public Gradient {
   /**
    * Returns the start point of the gradient. The start point corresponds to the first stop of the
    * gradient. It is interpreted in the coordinate space selected by fitsToGeometry(): a normalized
-   * 0-1 space relative to each geometry's bounding box when true (the default), or the layer's
-   * coordinate space when false.
+   * 0-1 space relative to each geometry's bounding box when true (the default), or the parent
+   * container's (VectorLayer or VectorGroup) coordinate space when false.
    */
   const Point& startPoint() const {
     return _startPoint;
@@ -252,7 +253,7 @@ class RadialGradient : public Gradient {
    * Returns the center of the circle for this gradient. The center point corresponds to the first
    * stop of the gradient. It is interpreted in the coordinate space selected by fitsToGeometry():
    * a normalized 0-1 space relative to each geometry's bounding box when true (the default), or
-   * the layer's coordinate space when false.
+   * the parent container's (VectorLayer or VectorGroup) coordinate space when false.
    */
   const Point& center() const {
     return _center;
@@ -305,7 +306,8 @@ class ConicGradient : public Gradient {
   /**
    * Returns the center of the circle for this gradient. It is interpreted in the coordinate space
    * selected by fitsToGeometry(): a normalized 0-1 space relative to each geometry's bounding box
-   * when true (the default), or the layer's coordinate space when false.
+   * when true (the default), or the parent container's (VectorLayer or VectorGroup) coordinate
+   * space when false.
    */
   const Point& center() const {
     return _center;
@@ -372,7 +374,7 @@ class DiamondGradient : public Gradient {
    * Returns the center of the diamond for this gradient. The center point corresponds to the first
    * stop of the gradient. It is interpreted in the coordinate space selected by fitsToGeometry():
    * a normalized 0-1 space relative to each geometry's bounding box when true (the default), or
-   * the layer's coordinate space when false.
+   * the parent container's (VectorLayer or VectorGroup) coordinate space when false.
    */
   const Point& center() const {
     return _center;

--- a/include/tgfx/layers/vectors/ImagePattern.h
+++ b/include/tgfx/layers/vectors/ImagePattern.h
@@ -29,8 +29,8 @@ namespace tgfx {
  * The transformation matrix set via setMatrix() is applied to the image's local coordinate space
  * first. When scaleMode() is not ScaleMode::None, the transformed image is then fitted into each
  * geometry's bounding box according to the scale mode (ScaleMode::LetterBox by default). When
- * scaleMode() is ScaleMode::None, the transformed image is placed directly in the layer's
- * coordinate space without per-geometry fitting.
+ * scaleMode() is ScaleMode::None, the transformed image is placed in the parent container's
+ * (VectorLayer or VectorGroup) coordinate space without per-geometry fitting.
  */
 class ImagePattern : public ColorSource {
  public:
@@ -79,8 +79,9 @@ class ImagePattern : public ColorSource {
 
   /**
    * Returns the rule used to fit the transformed image into each geometry's bounding box. The
-   * default value is ScaleMode::LetterBox. When set to ScaleMode::None, the image is placed
-   * directly in the layer's coordinate space without per-geometry fitting.
+   * default value is ScaleMode::LetterBox. When set to ScaleMode::None, the image is placed in
+   * the parent container's (VectorLayer or VectorGroup) coordinate space without per-geometry
+   * fitting.
    */
   ScaleMode scaleMode() const {
     return _scaleMode;

--- a/include/tgfx/layers/vectors/ScaleMode.h
+++ b/include/tgfx/layers/vectors/ScaleMode.h
@@ -25,10 +25,10 @@ namespace tgfx {
  */
 enum class ScaleMode {
   /**
-   * The image is not fitted to each geometry's bounding box. It is placed directly in the layer's
-   * coordinate space and tiled according to the pattern's tile modes. Use this mode when multiple
-   * geometries should share a single continuous image layout rather than each one receiving its
-   * own fitted copy.
+   * The image is not fitted to each geometry's bounding box. It is placed in the parent
+   * container's (VectorLayer or VectorGroup) coordinate space and tiled according to the
+   * pattern's tile modes. Use this mode when multiple geometries should share a single
+   * continuous image layout rather than each one receiving its own fitted copy.
    */
   None,
 


### PR DESCRIPTION
更新 ColorSource、Gradient、ImagePattern 和 ScaleMode 头文件中的注释，将 fitsToGeometry 为 false 或 ScaleMode::None 时参数所处的坐标空间由原来的 "layer's coordinate space" 修正为 "parent container's (VectorLayer or VectorGroup) coordinate space"，以更准确地描述实际行为，避免使用者对容器归属产生误解。本次只涉及文档注释调整，不修改任何运行时逻辑。