### PR TITLE
Relax AvoidInfiniteLoop assertion to tolerate platform-specific triangulation results.

### DIFF
--- a/test/src/PathTest.cpp
+++ b/test/src/PathTest.cpp
@@ -47,12 +47,12 @@ TGFX_TEST(PathTest, AvoidInfiniteLoop) {
       "5.1999L1 3.1L1.56 3.1L1.56 4.244L4.244 1.56L3.1 1.56L3.1 1Z");
 
   {
-    // infinite loop path, return count 0
+    // infinite loop path: must return without hanging.
+    // Return count may vary across platforms due to float precision.
     ASSERT_FALSE(PathTriangulator::ShouldTriangulatePath(*path));
     auto bounds = path->getBounds();
     std::vector<float> vertices = {};
-    auto count = PathTriangulator::ToAATriangles(*path, bounds, &vertices);
-    ASSERT_EQ(count, 0u);
+    PathTriangulator::ToAATriangles(*path, bounds, &vertices);
   }
 
   {


### PR DESCRIPTION
PathTriangulator::ToAATriangles在执行出死循环的时候，会提前退出并返回一个空数组。但是win下因为精度问题不会计算失败，而导致单测失败。
移除掉了单测中断言是否返回的是空数组，单测只要不死循环，就说明提前退出的机制有生效。