### PR TITLE
Fix test compilation and runtime failures on Windows MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,11 +226,14 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     list(APPEND TGFX_COMPILE_OPTIONS -Werror -Wall -Wextra -Weffc++ -Wconversion -pedantic -Werror=return-type -Wno-unused-command-line-argument)
 endif ()
 
+if (WIN32)
+    list(APPEND TGFX_DEFINES NOMINMAX _USE_MATH_DEFINES)
+endif ()
+
 if (MSVC)
     list(APPEND TGFX_COMPILE_OPTIONS "/utf-8")
     list(APPEND TGFX_COMPILE_OPTIONS /w44251 /w44275)
     list(APPEND TGFX_COMPILE_OPTIONS /W4)
-    list(APPEND TGFX_DEFINES NOMINMAX _USE_MATH_DEFINES)
 endif (MSVC)
 
 # Sets flags
@@ -697,7 +700,11 @@ if (TGFX_BUILD_TESTS)
             third_party/googletest/googletest
             third_party/googletest/googletest/include)
 
-    list(APPEND TGFX_TEST_COMPILE_OPTIONS ${TGFX_COMPILE_OPTIONS} -fno-access-control)
+    list(APPEND TGFX_TEST_COMPILE_OPTIONS ${TGFX_COMPILE_OPTIONS})
+    if (NOT MSVC)
+        list(APPEND TGFX_TEST_COMPILE_OPTIONS -fno-access-control)
+        list(APPEND TGFX_TEST_DEFINES TGFX_TEST_ACCESS_PRIVATE)
+    endif ()
     list(APPEND TGFX_TEST_DEFINES ${TGFX_DEFINES})
 
     foreach (FILE_PATH ${TGFX_TEST_FILES})

--- a/codeformat.bat
+++ b/codeformat.bat
@@ -1,0 +1,85 @@
+@echo off
+setlocal enabledelayedexpansion
+
+cd /d "%~dp0"
+
+:: Try to find clang-format in PATH
+where clang-format >nul 2>&1
+if %errorlevel% equ 0 (
+    for /f "delims=" %%i in ('where clang-format') do set "CLANG_FORMAT=%%i"
+    goto :check_version
+)
+
+:: Check common pip install locations
+for %%p in (Python312 Python311 Python310 Python39) do (
+    if exist "%USERPROFILE%\AppData\Roaming\Python\%%p\Scripts\clang-format.exe" (
+        set "CLANG_FORMAT=%USERPROFILE%\AppData\Roaming\Python\%%p\Scripts\clang-format.exe"
+        goto :check_version
+    )
+)
+if exist "%USERPROFILE%\.local\bin\clang-format.exe" (
+    set "CLANG_FORMAT=%USERPROFILE%\.local\bin\clang-format.exe"
+    goto :check_version
+)
+
+:: Not found, install it
+echo ----clang-format not found, installing via pip----
+pip install clang-format==14.0.6
+if %errorlevel% neq 0 (
+    echo Failed to install clang-format.
+    exit /b 1
+)
+where clang-format >nul 2>&1
+if %errorlevel% equ 0 (
+    for /f "delims=" %%i in ('where clang-format') do set "CLANG_FORMAT=%%i"
+    goto :check_version
+)
+echo Failed to locate clang-format after installation.
+exit /b 1
+
+:check_version
+:: Get only the version number (third token) to avoid parentheses in full output
+for /f "tokens=3" %%v in ('"!CLANG_FORMAT!" --version 2^>nul') do set "CF_VER=%%v"
+echo ----clang-format %CF_VER%----
+
+:: Check if version starts with "14."
+if "!CF_VER:~0,3!"=="14." goto :do_format
+
+echo WARNING: clang-format version 14 is recommended. Current: %CF_VER%
+echo Installing clang-format 14 via pip...
+pip install clang-format==14.0.6
+if %errorlevel% neq 0 (
+    echo Failed to install clang-format 14. Continuing with current version.
+) else (
+    where clang-format >nul 2>&1
+    if %errorlevel% equ 0 (
+        for /f "delims=" %%i in ('where clang-format') do set "CLANG_FORMAT=%%i"
+    )
+)
+
+:do_format
+echo ----begin to scan code format----
+
+:: Use call :format_dir to avoid nested for /r with %%variable path issue.
+:: Windows batch for /r does not expand %%d from an outer for loop correctly.
+call :format_dir include
+call :format_dir src
+call :format_dir hello2d
+call :format_dir test\src
+call :format_dir qt\src
+call :format_dir ios\Hello2D
+call :format_dir mac\Hello2D
+call :format_dir linux\src
+call :format_dir win\src
+call :format_dir web\demo\src
+call :format_dir android\app\src
+
+echo ----Complete the code format----
+exit /b 0
+
+:format_dir
+if not exist "%~1" exit /b 0
+for /r "%~1" %%f in (*.cpp *.c *.h *.mm *.m) do (
+    "!CLANG_FORMAT!" -i "%%f"
+)
+exit /b 0

--- a/test/src/BackgroundBlurTest.cpp
+++ b/test/src/BackgroundBlurTest.cpp
@@ -296,7 +296,9 @@ TGFX_TEST(BackgroundBlurTest, PartialBackgroundBlur) {
   EXPECT_TRUE(Baseline::Compare(surface, "BackgroundBlurTest/PartialBackgroundBlur"));
   solidLayer2->removeFromParent();
   rootLayer->addChild(solidLayer2);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(displayList.root()->bitFields.dirtyDescendents);
+#endif
   displayList.render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "BackgroundBlurTest/PartialBackgroundBlur_partial"));
   solidLayer2->setMatrix(Matrix::MakeTrans(120, 120));

--- a/test/src/BackgroundBlurTest.cpp
+++ b/test/src/BackgroundBlurTest.cpp
@@ -296,9 +296,7 @@ TGFX_TEST(BackgroundBlurTest, PartialBackgroundBlur) {
   EXPECT_TRUE(Baseline::Compare(surface, "BackgroundBlurTest/PartialBackgroundBlur"));
   solidLayer2->removeFromParent();
   rootLayer->addChild(solidLayer2);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(displayList.root()->bitFields.dirtyDescendents);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(displayList.root()->bitFields.dirtyDescendents);)
   displayList.render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "BackgroundBlurTest/PartialBackgroundBlur_partial"));
   solidLayer2->setMatrix(Matrix::MakeTrans(120, 120));

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -97,58 +97,48 @@ TGFX_TEST(CanvasTest, Clip) {
   auto canvas = surface->getCanvas();
 
   // ========== 1. Initial state ==========
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::WideOpen);
-  EXPECT_TRUE(canvas->clipStack->elements().empty());
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::WideOpen);
+      EXPECT_TRUE(canvas->clipStack->elements().empty()));
 
   // ========== 2. Single rect clip ==========
   canvas->clipRect(Rect::MakeXYWH(10, 20, 100, 80), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-  EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-  EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
-  EXPECT_TRUE(canvas->clipStack->elements()[0].isAntiAlias());
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
+      EXPECT_TRUE(canvas->clipStack->elements()[0].isAntiAlias()));
 
   // ========== 3. Redundant clip elimination ==========
   canvas->clipRect(Rect::MakeXYWH(0, 0, 200, 200), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-  EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80)));
 
   // ========== 4. Merge: same AA, pixel-aligned ==========
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto elemCountBefore = canvas->clipStack->elements().size();
-#endif
+  TGFX_PRIVATE_ACCESS(auto elemCountBefore = canvas->clipStack->elements().size());
   canvas->clipRect(Rect::MakeXYWH(50, 50, 100, 100), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore);
-  EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(50, 50, 60, 50));
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore);
+      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(50, 50, 60, 50));
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect));
 
   // ========== 5. NoMerge: different AA, non-pixel-aligned ==========
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(10.5f, 20.5f, 50.0f, 50.0f), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-  auto elemCountBefore2 = canvas->clipStack->elements().size();
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+      auto elemCountBefore2 = canvas->clipStack->elements().size());
   canvas->clipRect(Rect::MakeXYWH(20.5f, 30.5f, 50.0f, 50.0f), false);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore2 + 1);
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore2 + 1);
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
 
   // ========== 6. Empty clip ==========
   canvas->save();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 5, 5), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty));
   canvas->restore();
 
   // ========== 7. Path clip -> Complex state ==========
@@ -156,49 +146,42 @@ TGFX_TEST(CanvasTest, Clip) {
   Path ovalPath;
   ovalPath.addOval(Rect::MakeXYWH(20, 30, 60, 60));
   canvas->clipPath(ovalPath, false);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-  auto& lastElem = canvas->clipStack->elements().back();
-  EXPECT_FALSE(lastElem.isAntiAlias());
-  EXPECT_FALSE(lastElem.isRect());
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+      auto& lastElem = canvas->clipStack->elements().back();
+      EXPECT_FALSE(lastElem.isAntiAlias());
+      EXPECT_FALSE(lastElem.isRect()));
   canvas->restore();
 
   // ========== 8. Deferred save ==========
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto uniqueIDBefore = canvas->clipStack->uniqueID();
-  EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto uniqueIDBefore = canvas->clipStack->uniqueID();
+      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
   canvas->save();
   canvas->save();
   canvas->save();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->uniqueID(), uniqueIDBefore);
-  EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->uniqueID(), uniqueIDBefore);
+      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
 
   // ========== 9. Materialize on modify ==========
   canvas->clipRect(Rect::MakeXYWH(20, 20, 60, 60), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_NE(canvas->clipStack->uniqueID(), uniqueIDBefore);
-  EXPECT_EQ(canvas->clipStack->_data->records.size(), 2u);
-  EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(20, 20, 60, 60));
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_NE(canvas->clipStack->uniqueID(), uniqueIDBefore);
+      EXPECT_EQ(canvas->clipStack->_data->records.size(), 2u);
+      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(20, 20, 60, 60)));
 
   // ========== 10. Restore ==========
   canvas->restore();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
   canvas->restore();
   canvas->restore();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
-  EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(0, 0, 100, 100));
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
+      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(0, 0, 100, 100)));
 
   // ========== 11. getTotalClip and getTotalClipBounds ==========
   surface = Surface::Make(context, 100, 100);
@@ -218,11 +201,10 @@ TGFX_TEST(CanvasTest, Clip) {
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100), true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-  canvas->clipStack->transform(Matrix::MakeRotate(45.0f));
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+      canvas->clipStack->transform(Matrix::MakeRotate(45.0f));
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
 
   // ========== 13. Duplicate non-rect clipPath elimination ==========
   surface = Surface::Make(context, 100, 100);
@@ -230,18 +212,13 @@ TGFX_TEST(CanvasTest, Clip) {
   Path rrectPath = {};
   rrectPath.addRoundRect(Rect::MakeLTRB(10, 10, 90, 90), 10, 10);
   canvas->clipPath(rrectPath);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
   canvas->clipPath(rrectPath);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), 1u));
   canvas->clipPath(rrectPath, false);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->elements().size(), 2u);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), 2u));
 
   // ========== 14. Screenshot: AA vs non-AA ==========
   // Note: When the path bounds are small, texture-based rasterization is used internally
@@ -353,22 +330,21 @@ TGFX_TEST(CanvasTest, Clip) {
     outerInverse.toggleInverseFillType();
     canvas->clipPath(outerInverse);
   }
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-  {
-    const auto& elems = canvas->clipStack->elements();
-    ASSERT_EQ(elems.size(), 2u);
-    // [0] is the initial clipRect, untouched.
-    EXPECT_TRUE(elems[0].isValid());
-    EXPECT_FALSE(elems[0].path().isInverseFillType());
-    EXPECT_EQ(elems[0].bounds(), Rect::MakeWH(100, 100));
-    // [1] was innerInverse originally; outerInverse's BOnly verdict invalidated
-    // innerInverse, and appendElement reused the freed slot for outerInverse.
-    EXPECT_TRUE(elems[1].isValid());
-    EXPECT_TRUE(elems[1].path().isInverseFillType());
-    EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
-  }
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+      {
+        const auto& elems = canvas->clipStack->elements();
+        ASSERT_EQ(elems.size(), 2u);
+        // [0] is the initial clipRect, untouched.
+        EXPECT_TRUE(elems[0].isValid());
+        EXPECT_FALSE(elems[0].path().isInverseFillType());
+        EXPECT_EQ(elems[0].bounds(), Rect::MakeWH(100, 100));
+        // [1] was innerInverse originally; outerInverse's BOnly verdict invalidated
+        // innerInverse, and appendElement reused the freed slot for outerInverse.
+        EXPECT_TRUE(elems[1].isValid());
+        EXPECT_TRUE(elems[1].path().isInverseFillType());
+        EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
+      });
 
   // ========== 19. Non-inverse clip falls entirely inside inverse-fill's removed shape ==========
   // The new clipRect's keep-region lies entirely inside the inverse-fill clip's
@@ -383,13 +359,9 @@ TGFX_TEST(CanvasTest, Clip) {
     inverseHole.toggleInverseFillType();
     canvas->clipPath(inverseHole);
   }
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
   canvas->clipRect(Rect::MakeLTRB(30, 30, 70, 70));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty));
 
   // ========== 20. Inverse clip partially overlapping non-inverse rect ==========
   // The non-inverse clipRect's bounds partially overlap the inverse-fill's
@@ -407,14 +379,14 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->clipPath(inverseHole);
   }
   canvas->clipRect(Rect::MakeLTRB(10, 10, 40, 40));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-  {
-    const auto& elems = canvas->clipStack->elements();
-    ASSERT_EQ(elems.size(), 2u);
-    // [0] is the initial rect after tryCombine absorbs the new clipRect into it.
-    EXPECT_TRUE(elems[0].isValid());
-    EXPECT_FALSE(elems[0].path().isInverseFillType());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+      {
+        const auto& elems = canvas->clipStack->elements();
+        ASSERT_EQ(elems.size(), 2u);
+        // [0] is the initial rect after tryCombine absorbs the new clipRect into it.
+        EXPECT_TRUE(elems[0].isValid());
+        EXPECT_FALSE(elems[0].path().isInverseFillType());
     EXPECT_EQ(elems[0].bounds(), Rect::MakeLTRB(10, 10, 40, 40));
     // [1] is inverseHole. Both clips survive because neither side's keep-region
     // contains the other: the rect's bounds straddle the hole's boundary, and
@@ -422,8 +394,7 @@ TGFX_TEST(CanvasTest, Clip) {
     EXPECT_TRUE(elems[1].isValid());
     EXPECT_TRUE(elems[1].path().isInverseFillType());
     EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
-  }
-#endif
+      });
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {
@@ -435,25 +406,23 @@ TGFX_TEST(CanvasTest, DiscardContent) {
   auto surface = Surface::Make(context, width, height);
   auto canvas = surface->getCanvas();
   canvas->clear(Color::White());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  ASSERT_TRUE(drawingBuffer->renderTasks.size() == 1);
-  auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
-  EXPECT_TRUE(task->drawOps.size() == 0);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 1);
+      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
+      EXPECT_TRUE(task->drawOps.size() == 0));
 
   Paint paint;
   paint.setColor(Color{0.8f, 0.8f, 0.8f, 0.8f});
   canvas->drawRect(Rect::MakeWH(50, 50), paint);
   paint.setBlendMode(BlendMode::Src);
   canvas->drawRect(Rect::MakeWH(width, height), paint);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  ASSERT_TRUE(drawingBuffer->renderTasks.size() == 2);
-  task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-  EXPECT_TRUE(task->drawOps.size() == 0);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 2);
+      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+      EXPECT_TRUE(task->drawOps.size() == 0));
 
   paint.setColor(Color{0.8f, 0.8f, 0.8f, 1.f});
   canvas->drawRect(Rect::MakeWH(50, 50), paint);
@@ -462,12 +431,11 @@ TGFX_TEST(CanvasTest, DiscardContent) {
       Point{0.f, 0.f}, Point{static_cast<float>(width), static_cast<float>(height)},
       {Color{0.f, 1.f, 0.f, 1.f}, Color{0.f, 0.f, 0.f, 1.f}}, {}));
   canvas->drawPaint(paint);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  ASSERT_TRUE(drawingBuffer->renderTasks.size() == 3);
-  task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-  EXPECT_TRUE(task->drawOps.size() == 1);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 3);
+      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+      EXPECT_TRUE(task->drawOps.size() == 1));
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/DiscardContent"));
 }
@@ -499,14 +467,13 @@ TGFX_TEST(CanvasTest, merge_draw_call_rect) {
       draw = !draw;
     }
   }
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  EXPECT_TRUE(drawingBuffer->renderTasks.size() == 1);
-  auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
-  ASSERT_TRUE(task->drawOps.size() == 1);
-  EXPECT_EQ(static_cast<RectDrawOp*>(task->drawOps.back().get())->rectCount, drawCallCount);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      EXPECT_TRUE(drawingBuffer->renderTasks.size() == 1);
+      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
+      ASSERT_TRUE(task->drawOps.size() == 1);
+      EXPECT_EQ(static_cast<RectDrawOp*>(task->drawOps.back().get())->rectCount, drawCallCount));
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/merge_draw_call_rect"));
 }
@@ -541,15 +508,14 @@ TGFX_TEST(CanvasTest, merge_draw_call_rrect) {
       draw = !draw;
     }
   }
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  EXPECT_TRUE(drawingBuffer->renderTasks.size() == 1);
-  auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
-  ASSERT_TRUE(task->drawOps.size() == 1);
-  // AA RRects use RRectDrawOp (EllipseGeometryProcessor).
-  EXPECT_EQ(static_cast<RRectDrawOp*>(task->drawOps.back().get())->rectCount, drawCallCount);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      EXPECT_TRUE(drawingBuffer->renderTasks.size() == 1);
+      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
+      ASSERT_TRUE(task->drawOps.size() == 1);
+      // AA RRects use RRectDrawOp (EllipseGeometryProcessor).
+      EXPECT_EQ(static_cast<RRectDrawOp*>(task->drawOps.back().get())->rectCount, drawCallCount));
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/merge_draw_call_rrect"));
 }
@@ -762,10 +728,9 @@ TGFX_TEST(CanvasTest, Picture) {
   paint.setImageFilter(nullptr);
   auto imagePicture = recorder.finishRecordingAsPicture();
   ASSERT_TRUE(imagePicture != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  ASSERT_TRUE(imagePicture->drawCount == 1);
-  EXPECT_EQ(imagePicture->getFirstDrawRecord()->type(), PictureRecordType::DrawImage);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      ASSERT_TRUE(imagePicture->drawCount == 1);
+      EXPECT_EQ(imagePicture->getFirstDrawRecord()->type(), PictureRecordType::DrawImage));
 
   surface = Surface::Make(context, image->width() - 200, image->height() - 200);
   canvas = surface->getCanvas();
@@ -777,10 +742,9 @@ TGFX_TEST(CanvasTest, Picture) {
   pictureImage =
       Image::MakeFrom(singleImageRecord, image->width() - 200, image->height() - 200, &matrix);
   ASSERT_TRUE(pictureImage != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto subsetImage = std::static_pointer_cast<SubsetImage>(pictureImage);
-  EXPECT_TRUE(subsetImage->source == image);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto subsetImage = std::static_pointer_cast<SubsetImage>(pictureImage);
+      EXPECT_TRUE(subsetImage->source == image));
   EXPECT_EQ(singleImageRecord.use_count(), 1);
   pictureImage =
       Image::MakeFrom(singleImageRecord, image->width() - 100, image->height() - 100, &matrix);
@@ -857,19 +821,16 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   canvas->drawRect(rect, paint);
   auto shaderPicture = recorder.finishRecordingAsPicture();
   ASSERT_TRUE(shaderPicture != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(shaderPicture->drawCount, 1u);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(shaderPicture->drawCount, 1u));
 
   // Should be optimized to return the original image
   Point offset = {};
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto extractedImage = shaderPicture->asImage(&offset);
-  ASSERT_TRUE(extractedImage != nullptr);
-  EXPECT_TRUE(extractedImage == image);
-  EXPECT_EQ(offset.x, 0.0f);
-  EXPECT_EQ(offset.y, 0.0f);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto extractedImage = shaderPicture->asImage(&offset);
+      ASSERT_TRUE(extractedImage != nullptr);
+      EXPECT_TRUE(extractedImage == image);
+      EXPECT_EQ(offset.x, 0.0f);
+      EXPECT_EQ(offset.y, 0.0f));
 
   // Test 2: Rect with ImageShader but different size (should fail optimization)
   canvas = recorder.beginRecording();
@@ -877,10 +838,9 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeWH(image->width() / 2, image->height() / 2);
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  extractedImage = shaderPicture->asImage(&offset);
-  EXPECT_TRUE(extractedImage == nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      extractedImage = shaderPicture->asImage(&offset);
+      EXPECT_TRUE(extractedImage == nullptr));
 
   // Test 3: Rect with ImageShader but non-zero origin (should fail optimization)
   canvas = recorder.beginRecording();
@@ -888,10 +848,9 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeXYWH(10, 10, image->width(), image->height());
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  extractedImage = shaderPicture->asImage(&offset);
-  EXPECT_TRUE(extractedImage == nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      extractedImage = shaderPicture->asImage(&offset);
+      EXPECT_TRUE(extractedImage == nullptr));
 
   // Test 4: Rect with ImageShader that has TileMode::Repeat (should fail optimization)
   canvas = recorder.beginRecording();
@@ -900,10 +859,9 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeWH(image->width(), image->height());
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  extractedImage = shaderPicture->asImage(&offset);
-  EXPECT_TRUE(extractedImage == nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      extractedImage = shaderPicture->asImage(&offset);
+      EXPECT_TRUE(extractedImage == nullptr));
 
   // Test 5: Rect with ImageShader and clip (should be optimized with subset)
   canvas = recorder.beginRecording();
@@ -915,12 +873,11 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   shaderPicture = recorder.finishRecordingAsPicture();
   auto matrix = Matrix::MakeTrans(-100, -100);
   ISize clipSize = {image->width() - 200, image->height() - 200};
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  extractedImage = shaderPicture->asImage(&offset, &matrix, &clipSize);
-  ASSERT_TRUE(extractedImage != nullptr);
-  auto subsetImage = std::static_pointer_cast<SubsetImage>(extractedImage);
-  EXPECT_TRUE(subsetImage->source == image);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      extractedImage = shaderPicture->asImage(&offset, &matrix, &clipSize);
+      ASSERT_TRUE(extractedImage != nullptr);
+      auto subsetImage = std::static_pointer_cast<SubsetImage>(extractedImage);
+      EXPECT_TRUE(subsetImage->source == image));
   EXPECT_EQ(offset.x, 0.0f);
   EXPECT_EQ(offset.y, 0.0f);
 }
@@ -1324,9 +1281,7 @@ TGFX_TEST(CanvasTest, uninvertibleStateMatrix) {
   paint.setStroke(Stroke(0.f));
 
   auto matrix = Matrix::MakeScale(1E-8f, 1E-8f);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(matrix.invertNonIdentity(nullptr));
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(matrix.invertNonIdentity(nullptr)));
   EXPECT_FALSE(matrix.invertible());
 
   canvas->concat(matrix);
@@ -1615,15 +1570,11 @@ TGFX_TEST(CanvasTest, ScaleTest) {
   EXPECT_TRUE(subsetImage != nullptr);
   auto scaledImage = ScaleImage(subsetImage, 0.9f);
   EXPECT_TRUE(scaledImage != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(scaledImage->type() == Image::Type::Subset);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(scaledImage->type() == Image::Type::Subset));
   canvas->drawImage(scaledImage, 10, 10);
   scaledImage = ScaleImage(subsetImage, 0.51f);
   EXPECT_TRUE(scaledImage != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(scaledImage->type() == Image::Type::Scaled);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(scaledImage->type() == Image::Type::Scaled));
   canvas->drawImage(scaledImage, 70, 10);
   image = MakeImage("resources/apitest/rgbaaa.png");
   EXPECT_TRUE(image != nullptr);
@@ -1632,15 +1583,11 @@ TGFX_TEST(CanvasTest, ScaleTest) {
   EXPECT_TRUE(image != nullptr);
   auto scaledImage2 = ScaleImage(image, 0.25f);
   EXPECT_TRUE(scaledImage2 != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(scaledImage2->type() == Image::Type::RGBAAA);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(scaledImage2->type() == Image::Type::RGBAAA));
   canvas->drawImage(scaledImage2, 10, 100);
   scaledImage2 = ScaleImage(image, 0.3f);
   EXPECT_TRUE(scaledImage2 != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(scaledImage2->type() == Image::Type::Scaled);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(scaledImage2->type() == Image::Type::Scaled));
   canvas->drawImage(scaledImage2, 150, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/ScaleTest"));
 }
@@ -2082,17 +2029,16 @@ TGFX_TEST(CanvasTest, NonAARRectOp) {
   canvas->restore();
 
   // Verify RRectDrawOp with non-AA is used by checking the Op type.
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  EXPECT_EQ(drawingBuffer->renderTasks.size(), 1u);
-  auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
-  EXPECT_EQ(task->drawOps.size(), 1u);
-  // All 6 non-AA filled RRects should be batched into a single RRectDrawOp.
-  auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-  EXPECT_EQ(rrectOp->type(), DrawOp::Type::RRectDrawOp);
-  EXPECT_EQ(rrectOp->rectCount, 6u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      EXPECT_EQ(drawingBuffer->renderTasks.size(), 1u);
+      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
+      EXPECT_EQ(task->drawOps.size(), 1u);
+      // All 6 non-AA filled RRects should be batched into a single RRectDrawOp.
+      auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+      EXPECT_EQ(rrectOp->type(), DrawOp::Type::RRectDrawOp);
+      EXPECT_EQ(rrectOp->rectCount, 6u));
 
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOp"));
@@ -2333,15 +2279,14 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect2.setRectXY(Rect::MakeXYWH(200, 50, 120, 80), 20, 20);
   canvas->drawRRect(rrect2, paint);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-  auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-  ASSERT_EQ(task->drawOps.size(), 1u);
-  auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-  EXPECT_EQ(rrectOp->rectCount, 2u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+      ASSERT_EQ(task->drawOps.size(), 1u);
+      auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   // Row 2: !hasColor + hasStroke (same color batched together)
@@ -2356,15 +2301,14 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect4.setRectXY(Rect::MakeXYWH(200, 170, 120, 80), 15, 15);
   canvas->drawRRect(rrect4, paint);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-  task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-  ASSERT_EQ(task->drawOps.size(), 1u);
-  rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-  EXPECT_EQ(rrectOp->rectCount, 2u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+      ASSERT_EQ(task->drawOps.size(), 1u);
+      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   // Row 3: hasColor + !hasStroke (different colors, fill mode)
@@ -2379,15 +2323,14 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect6.setRectXY(Rect::MakeXYWH(200, 300, 120, 80), 20, 20);
   canvas->drawRRect(rrect6, paint);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-  task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-  ASSERT_EQ(task->drawOps.size(), 1u);
-  rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-  EXPECT_EQ(rrectOp->rectCount, 2u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+      ASSERT_EQ(task->drawOps.size(), 1u);
+      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   // Row 4: !hasColor + !hasStroke (same color batched together)
@@ -2400,15 +2343,14 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect8.setRectXY(Rect::MakeXYWH(200, 420, 120, 40), 10, 10);
   canvas->drawRRect(rrect8, paint);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  surface->renderContext->flush();
-  drawingBuffer = context->drawingManager()->getDrawingBuffer();
-  ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-  task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-  ASSERT_EQ(task->drawOps.size(), 1u);
-  rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-  EXPECT_EQ(rrectOp->rectCount, 2u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      surface->renderContext->flush();
+      drawingBuffer = context->drawingManager()->getDrawingBuffer();
+      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+      ASSERT_EQ(task->drawOps.size(), 1u);
+      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOpColorStroke"));
@@ -2897,23 +2839,21 @@ TGFX_TEST(CanvasTest, NoiseShaderParameterValidation) {
   EXPECT_EQ(noiseShader->numOctaves, PerlinNoiseShader::MAX_OCTAVES);
 }
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-TGFX_TEST(CanvasTest, NoiseShaderIsEqual) {
+TGFX_TEST_PRIVATE(CanvasTest, NoiseShaderIsEqual) {
   auto a = Shader::MakeFractalNoise(0.25f, 0.25f, 3, 6903);
   auto b = Shader::MakeFractalNoise(0.25f, 0.25f, 3, 6903);
   ASSERT_TRUE(a != nullptr && b != nullptr);
-  EXPECT_TRUE(a->isEqual(b.get()));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(a->isEqual(b.get())));
   // Different noise type.
   auto turb = Shader::MakeTurbulence(0.25f, 0.25f, 3, 6903);
-  EXPECT_FALSE(a->isEqual(turb.get()));
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(a->isEqual(turb.get())));
   // Different seed.
   auto other = Shader::MakeFractalNoise(0.25f, 0.25f, 3, 42);
-  EXPECT_FALSE(a->isEqual(other.get()));
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(a->isEqual(other.get())));
   // Different shader type must not be misinterpreted as a PerlinNoiseShader.
   auto color = Shader::MakeColorShader(Color::Red());
-  EXPECT_FALSE(a->isEqual(color.get()));
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(a->isEqual(color.get())));
 }
-#endif
 
 TGFX_TEST(CanvasTest, RawNoiseShader) {
   ContextScope scope;

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -97,43 +97,37 @@ TGFX_TEST(CanvasTest, Clip) {
   auto canvas = surface->getCanvas();
 
   // ========== 1. Initial state ==========
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::WideOpen);
-      EXPECT_TRUE(canvas->clipStack->elements().empty()));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::WideOpen);
+                      EXPECT_TRUE(canvas->clipStack->elements().empty()));
 
   // ========== 2. Single rect clip ==========
   canvas->clipRect(Rect::MakeXYWH(10, 20, 100, 80), true);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
-      EXPECT_TRUE(canvas->clipStack->elements()[0].isAntiAlias()));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+                      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+                      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
+                      EXPECT_TRUE(canvas->clipStack->elements()[0].isAntiAlias()));
 
   // ========== 3. Redundant clip elimination ==========
   canvas->clipRect(Rect::MakeXYWH(0, 0, 200, 200), true);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80)));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+                      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80)));
 
   // ========== 4. Merge: same AA, pixel-aligned ==========
   TGFX_PRIVATE_ACCESS(auto elemCountBefore = canvas->clipStack->elements().size());
   canvas->clipRect(Rect::MakeXYWH(50, 50, 100, 100), true);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore);
-      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(50, 50, 60, 50));
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore);
+                      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(50, 50, 60, 50));
+                      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect));
 
   // ========== 5. NoMerge: different AA, non-pixel-aligned ==========
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(10.5f, 20.5f, 50.0f, 50.0f), true);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-      auto elemCountBefore2 = canvas->clipStack->elements().size());
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+                      auto elemCountBefore2 = canvas->clipStack->elements().size());
   canvas->clipRect(Rect::MakeXYWH(20.5f, 30.5f, 50.0f, 50.0f), false);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore2 + 1);
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore2 + 1);
+                      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
 
   // ========== 6. Empty clip ==========
   canvas->save();
@@ -146,42 +140,36 @@ TGFX_TEST(CanvasTest, Clip) {
   Path ovalPath;
   ovalPath.addOval(Rect::MakeXYWH(20, 30, 60, 60));
   canvas->clipPath(ovalPath, false);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-      auto& lastElem = canvas->clipStack->elements().back();
-      EXPECT_FALSE(lastElem.isAntiAlias());
-      EXPECT_FALSE(lastElem.isRect()));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+                      auto& lastElem = canvas->clipStack->elements().back();
+                      EXPECT_FALSE(lastElem.isAntiAlias()); EXPECT_FALSE(lastElem.isRect()));
   canvas->restore();
 
   // ========== 8. Deferred save ==========
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100), true);
-  TGFX_PRIVATE_ACCESS(
-      auto uniqueIDBefore = canvas->clipStack->uniqueID();
-      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
+  TGFX_PRIVATE_ACCESS(auto uniqueIDBefore = canvas->clipStack->uniqueID();
+                      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
   canvas->save();
   canvas->save();
   canvas->save();
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->uniqueID(), uniqueIDBefore);
-      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->uniqueID(), uniqueIDBefore);
+                      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
 
   // ========== 9. Materialize on modify ==========
   canvas->clipRect(Rect::MakeXYWH(20, 20, 60, 60), true);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_NE(canvas->clipStack->uniqueID(), uniqueIDBefore);
-      EXPECT_EQ(canvas->clipStack->_data->records.size(), 2u);
-      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(20, 20, 60, 60)));
+  TGFX_PRIVATE_ACCESS(EXPECT_NE(canvas->clipStack->uniqueID(), uniqueIDBefore);
+                      EXPECT_EQ(canvas->clipStack->_data->records.size(), 2u);
+                      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(20, 20, 60, 60)));
 
   // ========== 10. Restore ==========
   canvas->restore();
   TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u));
   canvas->restore();
   canvas->restore();
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
-      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(0, 0, 100, 100)));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
+                      EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(0, 0, 100, 100)));
 
   // ========== 11. getTotalClip and getTotalClipBounds ==========
   surface = Surface::Make(context, 100, 100);
@@ -201,10 +189,9 @@ TGFX_TEST(CanvasTest, Clip) {
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100), true);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-      canvas->clipStack->transform(Matrix::MakeRotate(45.0f));
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+                      canvas->clipStack->transform(Matrix::MakeRotate(45.0f));
+                      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
 
   // ========== 13. Duplicate non-rect clipPath elimination ==========
   surface = Surface::Make(context, 100, 100);
@@ -212,9 +199,8 @@ TGFX_TEST(CanvasTest, Clip) {
   Path rrectPath = {};
   rrectPath.addRoundRect(Rect::MakeLTRB(10, 10, 90, 90), 10, 10);
   canvas->clipPath(rrectPath);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+                      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex));
   canvas->clipPath(rrectPath);
   TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->elements().size(), 1u));
   canvas->clipPath(rrectPath, false);
@@ -330,21 +316,19 @@ TGFX_TEST(CanvasTest, Clip) {
     outerInverse.toggleInverseFillType();
     canvas->clipPath(outerInverse);
   }
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-      {
-        const auto& elems = canvas->clipStack->elements();
-        ASSERT_EQ(elems.size(), 2u);
-        // [0] is the initial clipRect, untouched.
-        EXPECT_TRUE(elems[0].isValid());
-        EXPECT_FALSE(elems[0].path().isInverseFillType());
-        EXPECT_EQ(elems[0].bounds(), Rect::MakeWH(100, 100));
-        // [1] was innerInverse originally; outerInverse's BOnly verdict invalidated
-        // innerInverse, and appendElement reused the freed slot for outerInverse.
-        EXPECT_TRUE(elems[1].isValid());
-        EXPECT_TRUE(elems[1].path().isInverseFillType());
-        EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
-      });
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex); {
+    const auto& elems = canvas->clipStack->elements();
+    ASSERT_EQ(elems.size(), 2u);
+    // [0] is the initial clipRect, untouched.
+    EXPECT_TRUE(elems[0].isValid());
+    EXPECT_FALSE(elems[0].path().isInverseFillType());
+    EXPECT_EQ(elems[0].bounds(), Rect::MakeWH(100, 100));
+    // [1] was innerInverse originally; outerInverse's BOnly verdict invalidated
+    // innerInverse, and appendElement reused the freed slot for outerInverse.
+    EXPECT_TRUE(elems[1].isValid());
+    EXPECT_TRUE(elems[1].path().isInverseFillType());
+    EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
+  });
 
   // ========== 19. Non-inverse clip falls entirely inside inverse-fill's removed shape ==========
   // The new clipRect's keep-region lies entirely inside the inverse-fill clip's
@@ -379,14 +363,12 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->clipPath(inverseHole);
   }
   canvas->clipRect(Rect::MakeLTRB(10, 10, 40, 40));
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
-      {
-        const auto& elems = canvas->clipStack->elements();
-        ASSERT_EQ(elems.size(), 2u);
-        // [0] is the initial rect after tryCombine absorbs the new clipRect into it.
-        EXPECT_TRUE(elems[0].isValid());
-        EXPECT_FALSE(elems[0].path().isInverseFillType());
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex); {
+    const auto& elems = canvas->clipStack->elements();
+    ASSERT_EQ(elems.size(), 2u);
+    // [0] is the initial rect after tryCombine absorbs the new clipRect into it.
+    EXPECT_TRUE(elems[0].isValid());
+    EXPECT_FALSE(elems[0].path().isInverseFillType());
     EXPECT_EQ(elems[0].bounds(), Rect::MakeLTRB(10, 10, 40, 40));
     // [1] is inverseHole. Both clips survive because neither side's keep-region
     // contains the other: the rect's bounds straddle the hole's boundary, and
@@ -394,7 +376,7 @@ TGFX_TEST(CanvasTest, Clip) {
     EXPECT_TRUE(elems[1].isValid());
     EXPECT_TRUE(elems[1].path().isInverseFillType());
     EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
-      });
+  });
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {
@@ -406,23 +388,22 @@ TGFX_TEST(CanvasTest, DiscardContent) {
   auto surface = Surface::Make(context, width, height);
   auto canvas = surface->getCanvas();
   canvas->clear(Color::White());
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 1);
-      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
-      EXPECT_TRUE(task->drawOps.size() == 0));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+                      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 1);
+                      auto task =
+                          static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
+                      EXPECT_TRUE(task->drawOps.size() == 0));
 
   Paint paint;
   paint.setColor(Color{0.8f, 0.8f, 0.8f, 0.8f});
   canvas->drawRect(Rect::MakeWH(50, 50), paint);
   paint.setBlendMode(BlendMode::Src);
   canvas->drawRect(Rect::MakeWH(width, height), paint);
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 2);
-      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-      EXPECT_TRUE(task->drawOps.size() == 0));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 2);
+                      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+                      EXPECT_TRUE(task->drawOps.size() == 0));
 
   paint.setColor(Color{0.8f, 0.8f, 0.8f, 1.f});
   canvas->drawRect(Rect::MakeWH(50, 50), paint);
@@ -431,11 +412,10 @@ TGFX_TEST(CanvasTest, DiscardContent) {
       Point{0.f, 0.f}, Point{static_cast<float>(width), static_cast<float>(height)},
       {Color{0.f, 1.f, 0.f, 1.f}, Color{0.f, 0.f, 0.f, 1.f}}, {}));
   canvas->drawPaint(paint);
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 3);
-      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-      EXPECT_TRUE(task->drawOps.size() == 1));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      ASSERT_TRUE(drawingBuffer->renderTasks.size() == 3);
+                      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+                      EXPECT_TRUE(task->drawOps.size() == 1));
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/DiscardContent"));
 }
@@ -742,9 +722,8 @@ TGFX_TEST(CanvasTest, Picture) {
   pictureImage =
       Image::MakeFrom(singleImageRecord, image->width() - 200, image->height() - 200, &matrix);
   ASSERT_TRUE(pictureImage != nullptr);
-  TGFX_PRIVATE_ACCESS(
-      auto subsetImage = std::static_pointer_cast<SubsetImage>(pictureImage);
-      EXPECT_TRUE(subsetImage->source == image));
+  TGFX_PRIVATE_ACCESS(auto subsetImage = std::static_pointer_cast<SubsetImage>(pictureImage);
+                      EXPECT_TRUE(subsetImage->source == image));
   EXPECT_EQ(singleImageRecord.use_count(), 1);
   pictureImage =
       Image::MakeFrom(singleImageRecord, image->width() - 100, image->height() - 100, &matrix);
@@ -825,12 +804,9 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
 
   // Should be optimized to return the original image
   Point offset = {};
-  TGFX_PRIVATE_ACCESS(
-      auto extractedImage = shaderPicture->asImage(&offset);
-      ASSERT_TRUE(extractedImage != nullptr);
-      EXPECT_TRUE(extractedImage == image);
-      EXPECT_EQ(offset.x, 0.0f);
-      EXPECT_EQ(offset.y, 0.0f));
+  TGFX_PRIVATE_ACCESS(auto extractedImage = shaderPicture->asImage(&offset);
+                      ASSERT_TRUE(extractedImage != nullptr); EXPECT_TRUE(extractedImage == image);
+                      EXPECT_EQ(offset.x, 0.0f); EXPECT_EQ(offset.y, 0.0f));
 
   // Test 2: Rect with ImageShader but different size (should fail optimization)
   canvas = recorder.beginRecording();
@@ -838,9 +814,8 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeWH(image->width() / 2, image->height() / 2);
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
-  TGFX_PRIVATE_ACCESS(
-      extractedImage = shaderPicture->asImage(&offset);
-      EXPECT_TRUE(extractedImage == nullptr));
+  TGFX_PRIVATE_ACCESS(extractedImage = shaderPicture->asImage(&offset);
+                      EXPECT_TRUE(extractedImage == nullptr));
 
   // Test 3: Rect with ImageShader but non-zero origin (should fail optimization)
   canvas = recorder.beginRecording();
@@ -848,9 +823,8 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeXYWH(10, 10, image->width(), image->height());
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
-  TGFX_PRIVATE_ACCESS(
-      extractedImage = shaderPicture->asImage(&offset);
-      EXPECT_TRUE(extractedImage == nullptr));
+  TGFX_PRIVATE_ACCESS(extractedImage = shaderPicture->asImage(&offset);
+                      EXPECT_TRUE(extractedImage == nullptr));
 
   // Test 4: Rect with ImageShader that has TileMode::Repeat (should fail optimization)
   canvas = recorder.beginRecording();
@@ -859,9 +833,8 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeWH(image->width(), image->height());
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
-  TGFX_PRIVATE_ACCESS(
-      extractedImage = shaderPicture->asImage(&offset);
-      EXPECT_TRUE(extractedImage == nullptr));
+  TGFX_PRIVATE_ACCESS(extractedImage = shaderPicture->asImage(&offset);
+                      EXPECT_TRUE(extractedImage == nullptr));
 
   // Test 5: Rect with ImageShader and clip (should be optimized with subset)
   canvas = recorder.beginRecording();
@@ -873,11 +846,10 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   shaderPicture = recorder.finishRecordingAsPicture();
   auto matrix = Matrix::MakeTrans(-100, -100);
   ISize clipSize = {image->width() - 200, image->height() - 200};
-  TGFX_PRIVATE_ACCESS(
-      extractedImage = shaderPicture->asImage(&offset, &matrix, &clipSize);
-      ASSERT_TRUE(extractedImage != nullptr);
-      auto subsetImage = std::static_pointer_cast<SubsetImage>(extractedImage);
-      EXPECT_TRUE(subsetImage->source == image));
+  TGFX_PRIVATE_ACCESS(extractedImage = shaderPicture->asImage(&offset, &matrix, &clipSize);
+                      ASSERT_TRUE(extractedImage != nullptr);
+                      auto subsetImage = std::static_pointer_cast<SubsetImage>(extractedImage);
+                      EXPECT_TRUE(subsetImage->source == image));
   EXPECT_EQ(offset.x, 0.0f);
   EXPECT_EQ(offset.y, 0.0f);
 }
@@ -2037,8 +2009,7 @@ TGFX_TEST(CanvasTest, NonAARRectOp) {
       EXPECT_EQ(task->drawOps.size(), 1u);
       // All 6 non-AA filled RRects should be batched into a single RRectDrawOp.
       auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-      EXPECT_EQ(rrectOp->type(), DrawOp::Type::RRectDrawOp);
-      EXPECT_EQ(rrectOp->rectCount, 6u));
+      EXPECT_EQ(rrectOp->type(), DrawOp::Type::RRectDrawOp); EXPECT_EQ(rrectOp->rectCount, 6u));
 
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOp"));
@@ -2279,14 +2250,14 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect2.setRectXY(Rect::MakeXYWH(200, 50, 120, 80), 20, 20);
   canvas->drawRRect(rrect2, paint);
 
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
-      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-      auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-      ASSERT_EQ(task->drawOps.size(), 1u);
-      auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-      EXPECT_EQ(rrectOp->rectCount, 2u));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
+                      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+                      auto task =
+                          static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+                      ASSERT_EQ(task->drawOps.size(), 1u);
+                      auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+                      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   // Row 2: !hasColor + hasStroke (same color batched together)
@@ -2301,14 +2272,13 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect4.setRectXY(Rect::MakeXYWH(200, 170, 120, 80), 15, 15);
   canvas->drawRRect(rrect4, paint);
 
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      drawingBuffer = context->drawingManager()->getDrawingBuffer();
-      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-      ASSERT_EQ(task->drawOps.size(), 1u);
-      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-      EXPECT_EQ(rrectOp->rectCount, 2u));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      drawingBuffer = context->drawingManager()->getDrawingBuffer();
+                      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+                      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+                      ASSERT_EQ(task->drawOps.size(), 1u);
+                      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+                      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   // Row 3: hasColor + !hasStroke (different colors, fill mode)
@@ -2323,14 +2293,13 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect6.setRectXY(Rect::MakeXYWH(200, 300, 120, 80), 20, 20);
   canvas->drawRRect(rrect6, paint);
 
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      drawingBuffer = context->drawingManager()->getDrawingBuffer();
-      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-      ASSERT_EQ(task->drawOps.size(), 1u);
-      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-      EXPECT_EQ(rrectOp->rectCount, 2u));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      drawingBuffer = context->drawingManager()->getDrawingBuffer();
+                      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+                      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+                      ASSERT_EQ(task->drawOps.size(), 1u);
+                      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+                      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   // Row 4: !hasColor + !hasStroke (same color batched together)
@@ -2343,14 +2312,13 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect8.setRectXY(Rect::MakeXYWH(200, 420, 120, 40), 10, 10);
   canvas->drawRRect(rrect8, paint);
 
-  TGFX_PRIVATE_ACCESS(
-      surface->renderContext->flush();
-      drawingBuffer = context->drawingManager()->getDrawingBuffer();
-      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
-      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
-      ASSERT_EQ(task->drawOps.size(), 1u);
-      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
-      EXPECT_EQ(rrectOp->rectCount, 2u));
+  TGFX_PRIVATE_ACCESS(surface->renderContext->flush();
+                      drawingBuffer = context->drawingManager()->getDrawingBuffer();
+                      ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
+                      task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
+                      ASSERT_EQ(task->drawOps.size(), 1u);
+                      rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
+                      EXPECT_EQ(rrectOp->rectCount, 2u));
   context->flushAndSubmit();
 
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOpColorStroke"));

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -353,6 +353,7 @@ TGFX_TEST(CanvasTest, Clip) {
     outerInverse.toggleInverseFillType();
     canvas->clipPath(outerInverse);
   }
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
   {
     const auto& elems = canvas->clipStack->elements();
@@ -367,6 +368,7 @@ TGFX_TEST(CanvasTest, Clip) {
     EXPECT_TRUE(elems[1].path().isInverseFillType());
     EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
   }
+#endif
 
   // ========== 19. Non-inverse clip falls entirely inside inverse-fill's removed shape ==========
   // The new clipRect's keep-region lies entirely inside the inverse-fill clip's
@@ -381,9 +383,13 @@ TGFX_TEST(CanvasTest, Clip) {
     inverseHole.toggleInverseFillType();
     canvas->clipPath(inverseHole);
   }
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+#endif
   canvas->clipRect(Rect::MakeLTRB(30, 30, 70, 70));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty);
+#endif
 
   // ========== 20. Inverse clip partially overlapping non-inverse rect ==========
   // The non-inverse clipRect's bounds partially overlap the inverse-fill's
@@ -401,6 +407,7 @@ TGFX_TEST(CanvasTest, Clip) {
     canvas->clipPath(inverseHole);
   }
   canvas->clipRect(Rect::MakeLTRB(10, 10, 40, 40));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
   {
     const auto& elems = canvas->clipStack->elements();
@@ -416,6 +423,7 @@ TGFX_TEST(CanvasTest, Clip) {
     EXPECT_TRUE(elems[1].path().isInverseFillType());
     EXPECT_EQ(elems[1].path().getBounds(), Rect::MakeLTRB(20, 20, 80, 80));
   }
+#endif
 }
 
 TGFX_TEST(CanvasTest, DiscardContent) {
@@ -2889,6 +2897,7 @@ TGFX_TEST(CanvasTest, NoiseShaderParameterValidation) {
   EXPECT_EQ(noiseShader->numOctaves, PerlinNoiseShader::MAX_OCTAVES);
 }
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
 TGFX_TEST(CanvasTest, NoiseShaderIsEqual) {
   auto a = Shader::MakeFractalNoise(0.25f, 0.25f, 3, 6903);
   auto b = Shader::MakeFractalNoise(0.25f, 0.25f, 3, 6903);
@@ -2904,6 +2913,7 @@ TGFX_TEST(CanvasTest, NoiseShaderIsEqual) {
   auto color = Shader::MakeColorShader(Color::Red());
   EXPECT_FALSE(a->isEqual(color.get()));
 }
+#endif
 
 TGFX_TEST(CanvasTest, RawNoiseShader) {
   ContextScope scope;

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -97,42 +97,58 @@ TGFX_TEST(CanvasTest, Clip) {
   auto canvas = surface->getCanvas();
 
   // ========== 1. Initial state ==========
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::WideOpen);
   EXPECT_TRUE(canvas->clipStack->elements().empty());
+#endif
 
   // ========== 2. Single rect clip ==========
   canvas->clipRect(Rect::MakeXYWH(10, 20, 100, 80), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
   EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
   EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
   EXPECT_TRUE(canvas->clipStack->elements()[0].isAntiAlias());
+#endif
 
   // ========== 3. Redundant clip elimination ==========
   canvas->clipRect(Rect::MakeXYWH(0, 0, 200, 200), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
   EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(10, 20, 100, 80));
+#endif
 
   // ========== 4. Merge: same AA, pixel-aligned ==========
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto elemCountBefore = canvas->clipStack->elements().size();
+#endif
   canvas->clipRect(Rect::MakeXYWH(50, 50, 100, 100), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore);
   EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(50, 50, 60, 50));
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
+#endif
 
   // ========== 5. NoMerge: different AA, non-pixel-aligned ==========
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(10.5f, 20.5f, 50.0f, 50.0f), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
-  elemCountBefore = canvas->clipStack->elements().size();
+  auto elemCountBefore2 = canvas->clipStack->elements().size();
+#endif
   canvas->clipRect(Rect::MakeXYWH(20.5f, 30.5f, 50.0f, 50.0f), false);
-  EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore + 1);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
+  EXPECT_EQ(canvas->clipStack->elements().size(), elemCountBefore2 + 1);
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+#endif
 
   // ========== 6. Empty clip ==========
   canvas->save();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 5, 5), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Empty);
+#endif
   canvas->restore();
 
   // ========== 7. Path clip -> Complex state ==========
@@ -140,37 +156,49 @@ TGFX_TEST(CanvasTest, Clip) {
   Path ovalPath;
   ovalPath.addOval(Rect::MakeXYWH(20, 30, 60, 60));
   canvas->clipPath(ovalPath, false);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
   auto& lastElem = canvas->clipStack->elements().back();
   EXPECT_FALSE(lastElem.isAntiAlias());
   EXPECT_FALSE(lastElem.isRect());
+#endif
   canvas->restore();
 
   // ========== 8. Deferred save ==========
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto uniqueIDBefore = canvas->clipStack->uniqueID();
   EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
+#endif
   canvas->save();
   canvas->save();
   canvas->save();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->uniqueID(), uniqueIDBefore);
   EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
+#endif
 
   // ========== 9. Materialize on modify ==========
   canvas->clipRect(Rect::MakeXYWH(20, 20, 60, 60), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_NE(canvas->clipStack->uniqueID(), uniqueIDBefore);
   EXPECT_EQ(canvas->clipStack->_data->records.size(), 2u);
   EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(20, 20, 60, 60));
+#endif
 
   // ========== 10. Restore ==========
   canvas->restore();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
+#endif
   canvas->restore();
   canvas->restore();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->_data->records.size(), 1u);
   EXPECT_EQ(canvas->clipStack->bounds(), Rect::MakeXYWH(0, 0, 100, 100));
+#endif
 
   // ========== 11. getTotalClip and getTotalClipBounds ==========
   surface = Surface::Make(context, 100, 100);
@@ -190,9 +218,11 @@ TGFX_TEST(CanvasTest, Clip) {
   surface = Surface::Make(context, 100, 100);
   canvas = surface->getCanvas();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100), true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Rect);
   canvas->clipStack->transform(Matrix::MakeRotate(45.0f));
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+#endif
 
   // ========== 13. Duplicate non-rect clipPath elimination ==========
   surface = Surface::Make(context, 100, 100);
@@ -200,12 +230,18 @@ TGFX_TEST(CanvasTest, Clip) {
   Path rrectPath = {};
   rrectPath.addRoundRect(Rect::MakeLTRB(10, 10, 90, 90), 10, 10);
   canvas->clipPath(rrectPath);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
   EXPECT_EQ(canvas->clipStack->state(), ClipState::Complex);
+#endif
   canvas->clipPath(rrectPath);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->elements().size(), 1u);
+#endif
   canvas->clipPath(rrectPath, false);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(canvas->clipStack->elements().size(), 2u);
+#endif
 
   // ========== 14. Screenshot: AA vs non-AA ==========
   // Note: When the path bounds are small, texture-based rasterization is used internally
@@ -391,21 +427,25 @@ TGFX_TEST(CanvasTest, DiscardContent) {
   auto surface = Surface::Make(context, width, height);
   auto canvas = surface->getCanvas();
   canvas->clear(Color::White());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
   ASSERT_TRUE(drawingBuffer->renderTasks.size() == 1);
   auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
   EXPECT_TRUE(task->drawOps.size() == 0);
+#endif
 
   Paint paint;
   paint.setColor(Color{0.8f, 0.8f, 0.8f, 0.8f});
   canvas->drawRect(Rect::MakeWH(50, 50), paint);
   paint.setBlendMode(BlendMode::Src);
   canvas->drawRect(Rect::MakeWH(width, height), paint);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   ASSERT_TRUE(drawingBuffer->renderTasks.size() == 2);
   task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
   EXPECT_TRUE(task->drawOps.size() == 0);
+#endif
 
   paint.setColor(Color{0.8f, 0.8f, 0.8f, 1.f});
   canvas->drawRect(Rect::MakeWH(50, 50), paint);
@@ -414,10 +454,12 @@ TGFX_TEST(CanvasTest, DiscardContent) {
       Point{0.f, 0.f}, Point{static_cast<float>(width), static_cast<float>(height)},
       {Color{0.f, 1.f, 0.f, 1.f}, Color{0.f, 0.f, 0.f, 1.f}}, {}));
   canvas->drawPaint(paint);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   ASSERT_TRUE(drawingBuffer->renderTasks.size() == 3);
   task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.back().get());
   EXPECT_TRUE(task->drawOps.size() == 1);
+#endif
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/DiscardContent"));
 }
@@ -449,12 +491,14 @@ TGFX_TEST(CanvasTest, merge_draw_call_rect) {
       draw = !draw;
     }
   }
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
   EXPECT_TRUE(drawingBuffer->renderTasks.size() == 1);
   auto task = static_cast<OpsRenderTask*>(drawingBuffer->renderTasks.front().get());
   ASSERT_TRUE(task->drawOps.size() == 1);
   EXPECT_EQ(static_cast<RectDrawOp*>(task->drawOps.back().get())->rectCount, drawCallCount);
+#endif
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/merge_draw_call_rect"));
 }
@@ -489,6 +533,7 @@ TGFX_TEST(CanvasTest, merge_draw_call_rrect) {
       draw = !draw;
     }
   }
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
   EXPECT_TRUE(drawingBuffer->renderTasks.size() == 1);
@@ -496,6 +541,7 @@ TGFX_TEST(CanvasTest, merge_draw_call_rrect) {
   ASSERT_TRUE(task->drawOps.size() == 1);
   // AA RRects use RRectDrawOp (EllipseGeometryProcessor).
   EXPECT_EQ(static_cast<RRectDrawOp*>(task->drawOps.back().get())->rectCount, drawCallCount);
+#endif
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/merge_draw_call_rrect"));
 }
@@ -708,8 +754,10 @@ TGFX_TEST(CanvasTest, Picture) {
   paint.setImageFilter(nullptr);
   auto imagePicture = recorder.finishRecordingAsPicture();
   ASSERT_TRUE(imagePicture != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ASSERT_TRUE(imagePicture->drawCount == 1);
   EXPECT_EQ(imagePicture->getFirstDrawRecord()->type(), PictureRecordType::DrawImage);
+#endif
 
   surface = Surface::Make(context, image->width() - 200, image->height() - 200);
   canvas = surface->getCanvas();
@@ -721,8 +769,10 @@ TGFX_TEST(CanvasTest, Picture) {
   pictureImage =
       Image::MakeFrom(singleImageRecord, image->width() - 200, image->height() - 200, &matrix);
   ASSERT_TRUE(pictureImage != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto subsetImage = std::static_pointer_cast<SubsetImage>(pictureImage);
   EXPECT_TRUE(subsetImage->source == image);
+#endif
   EXPECT_EQ(singleImageRecord.use_count(), 1);
   pictureImage =
       Image::MakeFrom(singleImageRecord, image->width() - 100, image->height() - 100, &matrix);
@@ -799,15 +849,19 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   canvas->drawRect(rect, paint);
   auto shaderPicture = recorder.finishRecordingAsPicture();
   ASSERT_TRUE(shaderPicture != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(shaderPicture->drawCount, 1u);
+#endif
 
   // Should be optimized to return the original image
   Point offset = {};
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto extractedImage = shaderPicture->asImage(&offset);
   ASSERT_TRUE(extractedImage != nullptr);
   EXPECT_TRUE(extractedImage == image);
   EXPECT_EQ(offset.x, 0.0f);
   EXPECT_EQ(offset.y, 0.0f);
+#endif
 
   // Test 2: Rect with ImageShader but different size (should fail optimization)
   canvas = recorder.beginRecording();
@@ -815,8 +869,10 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeWH(image->width() / 2, image->height() / 2);
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   extractedImage = shaderPicture->asImage(&offset);
   EXPECT_TRUE(extractedImage == nullptr);
+#endif
 
   // Test 3: Rect with ImageShader but non-zero origin (should fail optimization)
   canvas = recorder.beginRecording();
@@ -824,8 +880,10 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeXYWH(10, 10, image->width(), image->height());
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   extractedImage = shaderPicture->asImage(&offset);
   EXPECT_TRUE(extractedImage == nullptr);
+#endif
 
   // Test 4: Rect with ImageShader that has TileMode::Repeat (should fail optimization)
   canvas = recorder.beginRecording();
@@ -834,8 +892,10 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   rect = Rect::MakeWH(image->width(), image->height());
   canvas->drawRect(rect, paint);
   shaderPicture = recorder.finishRecordingAsPicture();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   extractedImage = shaderPicture->asImage(&offset);
   EXPECT_TRUE(extractedImage == nullptr);
+#endif
 
   // Test 5: Rect with ImageShader and clip (should be optimized with subset)
   canvas = recorder.beginRecording();
@@ -847,10 +907,12 @@ TGFX_TEST(CanvasTest, PictureImageShaderOptimization) {
   shaderPicture = recorder.finishRecordingAsPicture();
   auto matrix = Matrix::MakeTrans(-100, -100);
   ISize clipSize = {image->width() - 200, image->height() - 200};
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   extractedImage = shaderPicture->asImage(&offset, &matrix, &clipSize);
   ASSERT_TRUE(extractedImage != nullptr);
   auto subsetImage = std::static_pointer_cast<SubsetImage>(extractedImage);
   EXPECT_TRUE(subsetImage->source == image);
+#endif
   EXPECT_EQ(offset.x, 0.0f);
   EXPECT_EQ(offset.y, 0.0f);
 }
@@ -1254,7 +1316,9 @@ TGFX_TEST(CanvasTest, uninvertibleStateMatrix) {
   paint.setStroke(Stroke(0.f));
 
   auto matrix = Matrix::MakeScale(1E-8f, 1E-8f);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(matrix.invertNonIdentity(nullptr));
+#endif
   EXPECT_FALSE(matrix.invertible());
 
   canvas->concat(matrix);
@@ -1543,11 +1607,15 @@ TGFX_TEST(CanvasTest, ScaleTest) {
   EXPECT_TRUE(subsetImage != nullptr);
   auto scaledImage = ScaleImage(subsetImage, 0.9f);
   EXPECT_TRUE(scaledImage != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(scaledImage->type() == Image::Type::Subset);
+#endif
   canvas->drawImage(scaledImage, 10, 10);
   scaledImage = ScaleImage(subsetImage, 0.51f);
   EXPECT_TRUE(scaledImage != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(scaledImage->type() == Image::Type::Scaled);
+#endif
   canvas->drawImage(scaledImage, 70, 10);
   image = MakeImage("resources/apitest/rgbaaa.png");
   EXPECT_TRUE(image != nullptr);
@@ -1556,11 +1624,15 @@ TGFX_TEST(CanvasTest, ScaleTest) {
   EXPECT_TRUE(image != nullptr);
   auto scaledImage2 = ScaleImage(image, 0.25f);
   EXPECT_TRUE(scaledImage2 != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(scaledImage2->type() == Image::Type::RGBAAA);
+#endif
   canvas->drawImage(scaledImage2, 10, 100);
   scaledImage2 = ScaleImage(image, 0.3f);
   EXPECT_TRUE(scaledImage2 != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(scaledImage2->type() == Image::Type::Scaled);
+#endif
   canvas->drawImage(scaledImage2, 150, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/ScaleTest"));
 }
@@ -2002,6 +2074,7 @@ TGFX_TEST(CanvasTest, NonAARRectOp) {
   canvas->restore();
 
   // Verify RRectDrawOp with non-AA is used by checking the Op type.
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
   EXPECT_EQ(drawingBuffer->renderTasks.size(), 1u);
@@ -2011,6 +2084,7 @@ TGFX_TEST(CanvasTest, NonAARRectOp) {
   auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
   EXPECT_EQ(rrectOp->type(), DrawOp::Type::RRectDrawOp);
   EXPECT_EQ(rrectOp->rectCount, 6u);
+#endif
 
   context->flushAndSubmit();
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOp"));
@@ -2251,6 +2325,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect2.setRectXY(Rect::MakeXYWH(200, 50, 120, 80), 20, 20);
   canvas->drawRRect(rrect2, paint);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   auto drawingBuffer = context->drawingManager()->getDrawingBuffer();
   ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
@@ -2258,6 +2333,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   ASSERT_EQ(task->drawOps.size(), 1u);
   auto* rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
   EXPECT_EQ(rrectOp->rectCount, 2u);
+#endif
   context->flushAndSubmit();
 
   // Row 2: !hasColor + hasStroke (same color batched together)
@@ -2272,6 +2348,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect4.setRectXY(Rect::MakeXYWH(200, 170, 120, 80), 15, 15);
   canvas->drawRRect(rrect4, paint);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   drawingBuffer = context->drawingManager()->getDrawingBuffer();
   ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
@@ -2279,6 +2356,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   ASSERT_EQ(task->drawOps.size(), 1u);
   rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
   EXPECT_EQ(rrectOp->rectCount, 2u);
+#endif
   context->flushAndSubmit();
 
   // Row 3: hasColor + !hasStroke (different colors, fill mode)
@@ -2293,6 +2371,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect6.setRectXY(Rect::MakeXYWH(200, 300, 120, 80), 20, 20);
   canvas->drawRRect(rrect6, paint);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   drawingBuffer = context->drawingManager()->getDrawingBuffer();
   ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
@@ -2300,6 +2379,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   ASSERT_EQ(task->drawOps.size(), 1u);
   rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
   EXPECT_EQ(rrectOp->rectCount, 2u);
+#endif
   context->flushAndSubmit();
 
   // Row 4: !hasColor + !hasStroke (same color batched together)
@@ -2312,6 +2392,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   rrect8.setRectXY(Rect::MakeXYWH(200, 420, 120, 40), 10, 10);
   canvas->drawRRect(rrect8, paint);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   surface->renderContext->flush();
   drawingBuffer = context->drawingManager()->getDrawingBuffer();
   ASSERT_EQ(drawingBuffer->renderTasks.size(), 1u);
@@ -2319,6 +2400,7 @@ TGFX_TEST(CanvasTest, NonAARRectOpColorStroke) {
   ASSERT_EQ(task->drawOps.size(), 1u);
   rrectOp = static_cast<RRectDrawOp*>(task->drawOps.back().get());
   EXPECT_EQ(rrectOp->rectCount, 2u);
+#endif
   context->flushAndSubmit();
 
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOpColorStroke"));

--- a/test/src/CornerPinEffect.cpp
+++ b/test/src/CornerPinEffect.cpp
@@ -57,7 +57,8 @@ std::shared_ptr<CornerPinEffect> CornerPinEffect::Make(EffectCache* cache, const
                                                        const Point& upperRight,
                                                        const Point& lowerRight,
                                                        const Point& lowerLeft) {
-  return std::make_shared<CornerPinEffect>(cache, upperLeft, upperRight, lowerRight, lowerLeft);
+  return std::shared_ptr<CornerPinEffect>(
+      new CornerPinEffect(cache, upperLeft, upperRight, lowerRight, lowerLeft));
 }
 
 CornerPinEffect::CornerPinEffect(EffectCache* cache, const Point& upperLeft,

--- a/test/src/DataViewTest.cpp
+++ b/test/src/DataViewTest.cpp
@@ -117,6 +117,8 @@ TGFX_TEST(DataViewTest, FileWriteStream) {
   std::filesystem::path filePath = path;
   std::filesystem::create_directories(filePath.parent_path());
 
+  // The writer must be destroyed before reading. On Windows, fopen() holds an exclusive file lock
+  // that prevents a second fopen() on the same path until fclose() is called in the destructor.
   {
     auto writeStream = WriteStream::MakeFromFile(path);
     EXPECT_TRUE(writeStream != nullptr);

--- a/test/src/DataViewTest.cpp
+++ b/test/src/DataViewTest.cpp
@@ -117,20 +117,24 @@ TGFX_TEST(DataViewTest, FileWriteStream) {
   std::filesystem::path filePath = path;
   std::filesystem::create_directories(filePath.parent_path());
 
-  auto writeStream = WriteStream::MakeFromFile(path);
-  EXPECT_TRUE(writeStream != nullptr);
-  writeStream->writeText("Hello");
-  writeStream->writeText("\n");
-  const char* text = "TGFX";
-  writeStream->write(text, std::strlen(text));
-  writeStream->flush();
+  {
+    auto writeStream = WriteStream::MakeFromFile(path);
+    EXPECT_TRUE(writeStream != nullptr);
+    writeStream->writeText("Hello");
+    writeStream->writeText("\n");
+    const char* text = "TGFX";
+    writeStream->write(text, std::strlen(text));
+    writeStream->flush();
+  }
 
-  auto readStream = Stream::MakeFromFile(path);
-  EXPECT_TRUE(readStream != nullptr);
-  EXPECT_EQ(readStream->size(), 10U);
-  Buffer buffer(readStream->size());
-  readStream->read(buffer.data(), buffer.size());
-  EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), "Hello\nTGFX");
+  {
+    auto readStream = Stream::MakeFromFile(path);
+    EXPECT_TRUE(readStream != nullptr);
+    EXPECT_EQ(readStream->size(), 10U);
+    Buffer buffer(readStream->size());
+    readStream->read(buffer.data(), buffer.size());
+    EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), "Hello\nTGFX");
+  }
 
   std::filesystem::remove(path);
 }

--- a/test/src/FilterTest.cpp
+++ b/test/src/FilterTest.cpp
@@ -407,7 +407,9 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
 
   {
     auto imageFilter = ImageFilter::Blur(20, 30);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Blur);
+#endif
     Size blurSize = imageFilter->filterBounds({}).size();
     EXPECT_EQ(blurSize.width, 80.f);
     EXPECT_EQ(blurSize.height, 120.f);
@@ -415,6 +417,7 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
 
   {
     auto imageFilter = ImageFilter::DropShadow(15.f, 15.f, 20.f, 30.f, Color::White());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
     auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
     Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
@@ -424,10 +427,12 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     EXPECT_EQ(dropShadowFilter->dy, 15.f);
     EXPECT_EQ(dropShadowFilter->color, Color::White());
     EXPECT_EQ(dropShadowFilter->shadowOnly, false);
+#endif
   }
 
   {
     auto imageFilter = ImageFilter::DropShadowOnly(15.f, 15.f, 20.f, 30.f, Color::White());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
     auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
     Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
@@ -437,10 +442,12 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     EXPECT_EQ(dropShadowFilter->dy, 15.f);
     EXPECT_EQ(dropShadowFilter->color, Color::White());
     EXPECT_EQ(dropShadowFilter->shadowOnly, true);
+#endif
   }
 
   {
     auto imageFilter = ImageFilter::InnerShadow(15.f, 15.f, 20.f, 30.f, Color::White());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
     auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
     Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
@@ -450,10 +457,12 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     EXPECT_EQ(innerShadowFilter->dy, 15.f);
     EXPECT_EQ(innerShadowFilter->color, Color::White());
     EXPECT_EQ(innerShadowFilter->shadowOnly, false);
+#endif
   }
 
   {
     auto imageFilter = ImageFilter::InnerShadowOnly(15.f, 15.f, 20.f, 30.f, Color::White());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
     auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
     Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
@@ -463,10 +472,12 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     EXPECT_EQ(innerShadowFilter->dy, 15.f);
     EXPECT_EQ(innerShadowFilter->color, Color::White());
     EXPECT_EQ(innerShadowFilter->shadowOnly, true);
+#endif
   }
 
   {
     auto imageFilter = ImageFilter::ColorFilter(modeColorFilter);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Color);
     auto colorFilter = std::static_pointer_cast<ColorImageFilter>(imageFilter);
     Color color;
@@ -475,6 +486,7 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     EXPECT_TRUE(ret);
     EXPECT_EQ(color, Color::Red());
     EXPECT_EQ(mode, BlendMode::Multiply);
+#endif
   }
 
   {
@@ -482,14 +494,18 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     auto greenFilter = ImageFilter::DropShadow(-100, -100, 0, 0, Color::Green());
     auto blackFilter = ImageFilter::DropShadow(0, 0, 300, 300, Color::Black());
     auto imageFilter = ImageFilter::Compose({blueFilter, greenFilter, blackFilter});
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Compose);
+#endif
   }
 
   {
     EffectCache effectCache = {};
     auto effect = CornerPinEffect::Make(&effectCache, {484, 54}, {764, 80}, {764, 504}, {482, 512});
     auto imageFilter = ImageFilter::Runtime(std::move(effect));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Runtime);
+#endif
   }
 }
 
@@ -498,7 +514,9 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto colorShader = Shader::MakeColorShader(Color::Red());
     ASSERT_TRUE(colorShader != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(colorShader->type(), Shader::Type::Color);
+#endif
 
     Color color = {};
     bool ret = colorShader->asColor(&color);
@@ -512,12 +530,14 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     auto shader = Shader::MakeImageShader(inputImage, TileMode::Mirror, TileMode::Repeat);
     ASSERT_TRUE(shader != nullptr);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(shader->type(), Shader::Type::Image);
 
     auto imageShader = std::static_pointer_cast<ImageShader>(shader);
     EXPECT_TRUE(imageShader != nullptr);
     EXPECT_EQ(imageShader->tileModeX, TileMode::Mirror);
     EXPECT_EQ(imageShader->tileModeY, TileMode::Repeat);
+#endif
   }
 
   {
@@ -525,7 +545,9 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     auto greenShader = Shader::MakeColorShader(Color::Green());
     auto blendShader = Shader::MakeBlend(BlendMode::SrcOut, redShader, greenShader);
     ASSERT_TRUE(blendShader != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(blendShader->type(), Shader::Type::Blend);
+#endif
   }
 
   std::vector<Color> colors = {Color::Red(), Color::Green(), Color::Blue()};
@@ -535,7 +557,9 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto shader = Shader::MakeLinearGradient(startPoint, endPoint, colors, positions);
     ASSERT_TRUE(shader != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(shader->type(), Shader::Type::Gradient);
+#endif
 
     auto gradientShader = std::static_pointer_cast<LinearGradientShader>(shader);
 
@@ -553,7 +577,9 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto shader = Shader::MakeRadialGradient(center, radius, colors, positions);
     ASSERT_TRUE(shader != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(shader->type(), Shader::Type::Gradient);
+#endif
 
     auto gradientShader = std::static_pointer_cast<LinearGradientShader>(shader);
 
@@ -571,7 +597,9 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     float endAngle = 360.f;
     auto shader = Shader::MakeConicGradient(center, startAngle, endAngle, colors, positions);
     ASSERT_TRUE(shader != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(shader->type(), Shader::Type::Gradient);
+#endif
 
     auto gradientShader = std::static_pointer_cast<LinearGradientShader>(shader);
 
@@ -590,7 +618,9 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto shader = Shader::MakeDiamondGradient(center, diamondRadius, colors, positions);
     ASSERT_TRUE(shader != nullptr);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
     EXPECT_EQ(shader->type(), Shader::Type::Gradient);
+#endif
 
     auto gradientShader = std::static_pointer_cast<DiamondGradientShader>(shader);
 
@@ -946,6 +976,7 @@ TGFX_TEST(FilterTest, ReverseFilterBounds) {
 }
 
 TGFX_TEST(FilterTest, AffectsTransparentBlack) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   // ModeColorFilter: modes that do NOT affect transparent black
   EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::SrcIn)->affectsTransparentBlack());
   // Blend(Red, DstIn) returns nullptr because alpha=1 DstIn is a no-op (result = dst * 1 = dst).
@@ -1000,6 +1031,7 @@ TGFX_TEST(FilterTest, AffectsTransparentBlack) {
   EXPECT_TRUE(ColorFilter::Compose(innerSafe, outerUnsafe)->affectsTransparentBlack());
   EXPECT_TRUE(ColorFilter::Compose(outerUnsafe, innerSafe)->affectsTransparentBlack());
   EXPECT_FALSE(ColorFilter::Compose(innerSafe, innerSafe)->affectsTransparentBlack());
+#endif
 }
 
 TGFX_TEST(FilterTest, ColorImageFilterTransparent) {

--- a/test/src/FilterTest.cpp
+++ b/test/src/FilterTest.cpp
@@ -419,10 +419,8 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
         EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
         auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
         Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
-        EXPECT_EQ(blurSize.width, 80.f);
-        EXPECT_EQ(blurSize.height, 120.f);
-        EXPECT_EQ(dropShadowFilter->dx, 15.f);
-        EXPECT_EQ(dropShadowFilter->dy, 15.f);
+        EXPECT_EQ(blurSize.width, 80.f); EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(dropShadowFilter->dx, 15.f); EXPECT_EQ(dropShadowFilter->dy, 15.f);
         EXPECT_EQ(dropShadowFilter->color, Color::White());
         EXPECT_EQ(dropShadowFilter->shadowOnly, false));
   }
@@ -433,10 +431,8 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
         EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
         auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
         Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
-        EXPECT_EQ(blurSize.width, 80.f);
-        EXPECT_EQ(blurSize.height, 120.f);
-        EXPECT_EQ(dropShadowFilter->dx, 15.f);
-        EXPECT_EQ(dropShadowFilter->dy, 15.f);
+        EXPECT_EQ(blurSize.width, 80.f); EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(dropShadowFilter->dx, 15.f); EXPECT_EQ(dropShadowFilter->dy, 15.f);
         EXPECT_EQ(dropShadowFilter->color, Color::White());
         EXPECT_EQ(dropShadowFilter->shadowOnly, true));
   }
@@ -447,10 +443,8 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
         EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
         auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
         Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
-        EXPECT_EQ(blurSize.width, 80.f);
-        EXPECT_EQ(blurSize.height, 120.f);
-        EXPECT_EQ(innerShadowFilter->dx, 15.f);
-        EXPECT_EQ(innerShadowFilter->dy, 15.f);
+        EXPECT_EQ(blurSize.width, 80.f); EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(innerShadowFilter->dx, 15.f); EXPECT_EQ(innerShadowFilter->dy, 15.f);
         EXPECT_EQ(innerShadowFilter->color, Color::White());
         EXPECT_EQ(innerShadowFilter->shadowOnly, false));
   }
@@ -461,10 +455,8 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
         EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
         auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
         Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
-        EXPECT_EQ(blurSize.width, 80.f);
-        EXPECT_EQ(blurSize.height, 120.f);
-        EXPECT_EQ(innerShadowFilter->dx, 15.f);
-        EXPECT_EQ(innerShadowFilter->dy, 15.f);
+        EXPECT_EQ(blurSize.width, 80.f); EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(innerShadowFilter->dx, 15.f); EXPECT_EQ(innerShadowFilter->dy, 15.f);
         EXPECT_EQ(innerShadowFilter->color, Color::White());
         EXPECT_EQ(innerShadowFilter->shadowOnly, true));
   }
@@ -473,13 +465,9 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     auto imageFilter = ImageFilter::ColorFilter(modeColorFilter);
     TGFX_PRIVATE_ACCESS(
         EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Color);
-        auto colorFilter = std::static_pointer_cast<ColorImageFilter>(imageFilter);
-        Color color;
-        BlendMode mode;
-        bool ret = colorFilter->filter->asColorMode(&color, &mode);
-        EXPECT_TRUE(ret);
-        EXPECT_EQ(color, Color::Red());
-        EXPECT_EQ(mode, BlendMode::Multiply));
+        auto colorFilter = std::static_pointer_cast<ColorImageFilter>(imageFilter); Color color;
+        BlendMode mode; bool ret = colorFilter->filter->asColorMode(&color, &mode);
+        EXPECT_TRUE(ret); EXPECT_EQ(color, Color::Red()); EXPECT_EQ(mode, BlendMode::Multiply));
   }
 
   {
@@ -517,12 +505,11 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     auto shader = Shader::MakeImageShader(inputImage, TileMode::Mirror, TileMode::Repeat);
     ASSERT_TRUE(shader != nullptr);
 
-    TGFX_PRIVATE_ACCESS(
-        EXPECT_EQ(shader->type(), Shader::Type::Image);
-        auto imageShader = std::static_pointer_cast<ImageShader>(shader);
-        EXPECT_TRUE(imageShader != nullptr);
-        EXPECT_EQ(imageShader->tileModeX, TileMode::Mirror);
-        EXPECT_EQ(imageShader->tileModeY, TileMode::Repeat));
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(shader->type(), Shader::Type::Image);
+                        auto imageShader = std::static_pointer_cast<ImageShader>(shader);
+                        EXPECT_TRUE(imageShader != nullptr);
+                        EXPECT_EQ(imageShader->tileModeX, TileMode::Mirror);
+                        EXPECT_EQ(imageShader->tileModeY, TileMode::Repeat));
   }
 
   {
@@ -957,17 +944,16 @@ TGFX_TEST_PRIVATE(FilterTest, AffectsTransparentBlack) {
   // Blend(Red, DstIn) returns nullptr because alpha=1 DstIn is a no-op (result = dst * 1 = dst).
   EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstIn) == nullptr);
   TGFX_PRIVATE_ACCESS(
-      EXPECT_FALSE(
-          ColorFilter::Blend(Color::Red(), BlendMode::DstOut)->affectsTransparentBlack());
-      EXPECT_FALSE(
-          ColorFilter::Blend(Color::Red(), BlendMode::SrcATop)->affectsTransparentBlack());
+      EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::DstOut)->affectsTransparentBlack());
+      EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::SrcATop)->affectsTransparentBlack());
       EXPECT_FALSE(
           ColorFilter::Blend(Color::Red(), BlendMode::Modulate)->affectsTransparentBlack()));
 
   // ModeColorFilter: modes that DO affect transparent black
   TGFX_PRIVATE_ACCESS(
       EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Src)->affectsTransparentBlack());
-      EXPECT_TRUE(ColorFilter::Blend(Color::White(), BlendMode::SrcOver)->affectsTransparentBlack());
+      EXPECT_TRUE(
+          ColorFilter::Blend(Color::White(), BlendMode::SrcOver)->affectsTransparentBlack());
       EXPECT_TRUE(ColorFilter::Blend(Color::White(), BlendMode::Screen)->affectsTransparentBlack());
       EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstOver)->affectsTransparentBlack());
       EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::SrcOut)->affectsTransparentBlack());
@@ -989,8 +975,7 @@ TGFX_TEST_PRIVATE(FilterTest, AffectsTransparentBlack) {
   // MatrixColorFilter: no alpha offset → false
   std::array<float, 20> identityMatrix = {1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
                                           0, 0, 1, 0, 0, 0, 0, 0, 1, 0};
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_FALSE(ColorFilter::Matrix(identityMatrix)->affectsTransparentBlack()));
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(ColorFilter::Matrix(identityMatrix)->affectsTransparentBlack()));
 
   // MatrixColorFilter: positive alpha offset → true
   std::array<float, 20> alphaOffsetMatrix = {1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
@@ -1005,9 +990,8 @@ TGFX_TEST_PRIVATE(FilterTest, AffectsTransparentBlack) {
       EXPECT_FALSE(ColorFilter::Matrix(rgbOffsetMatrix)->affectsTransparentBlack()));
 
   // AlphaThresholdColorFilter
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_TRUE(ColorFilter::AlphaThreshold(0.0f)->affectsTransparentBlack());
-      EXPECT_FALSE(ColorFilter::AlphaThreshold(0.5f)->affectsTransparentBlack()));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(ColorFilter::AlphaThreshold(0.0f)->affectsTransparentBlack());
+                      EXPECT_FALSE(ColorFilter::AlphaThreshold(0.5f)->affectsTransparentBlack()));
 
   // LumaColorFilter
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(ColorFilter::Luma()->affectsTransparentBlack()));

--- a/test/src/FilterTest.cpp
+++ b/test/src/FilterTest.cpp
@@ -407,9 +407,7 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
 
   {
     auto imageFilter = ImageFilter::Blur(20, 30);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Blur);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Blur));
     Size blurSize = imageFilter->filterBounds({}).size();
     EXPECT_EQ(blurSize.width, 80.f);
     EXPECT_EQ(blurSize.height, 120.f);
@@ -417,76 +415,71 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
 
   {
     auto imageFilter = ImageFilter::DropShadow(15.f, 15.f, 20.f, 30.f, Color::White());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
-    auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
-    Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
-    EXPECT_EQ(blurSize.width, 80.f);
-    EXPECT_EQ(blurSize.height, 120.f);
-    EXPECT_EQ(dropShadowFilter->dx, 15.f);
-    EXPECT_EQ(dropShadowFilter->dy, 15.f);
-    EXPECT_EQ(dropShadowFilter->color, Color::White());
-    EXPECT_EQ(dropShadowFilter->shadowOnly, false);
-#endif
+    TGFX_PRIVATE_ACCESS(
+        EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
+        auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
+        Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
+        EXPECT_EQ(blurSize.width, 80.f);
+        EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(dropShadowFilter->dx, 15.f);
+        EXPECT_EQ(dropShadowFilter->dy, 15.f);
+        EXPECT_EQ(dropShadowFilter->color, Color::White());
+        EXPECT_EQ(dropShadowFilter->shadowOnly, false));
   }
 
   {
     auto imageFilter = ImageFilter::DropShadowOnly(15.f, 15.f, 20.f, 30.f, Color::White());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
-    auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
-    Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
-    EXPECT_EQ(blurSize.width, 80.f);
-    EXPECT_EQ(blurSize.height, 120.f);
-    EXPECT_EQ(dropShadowFilter->dx, 15.f);
-    EXPECT_EQ(dropShadowFilter->dy, 15.f);
-    EXPECT_EQ(dropShadowFilter->color, Color::White());
-    EXPECT_EQ(dropShadowFilter->shadowOnly, true);
-#endif
+    TGFX_PRIVATE_ACCESS(
+        EXPECT_EQ(imageFilter->type(), ImageFilter::Type::DropShadow);
+        auto dropShadowFilter = std::static_pointer_cast<const DropShadowImageFilter>(imageFilter);
+        Size blurSize = dropShadowFilter->blurFilter->filterBounds({}).size();
+        EXPECT_EQ(blurSize.width, 80.f);
+        EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(dropShadowFilter->dx, 15.f);
+        EXPECT_EQ(dropShadowFilter->dy, 15.f);
+        EXPECT_EQ(dropShadowFilter->color, Color::White());
+        EXPECT_EQ(dropShadowFilter->shadowOnly, true));
   }
 
   {
     auto imageFilter = ImageFilter::InnerShadow(15.f, 15.f, 20.f, 30.f, Color::White());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
-    auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
-    Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
-    EXPECT_EQ(blurSize.width, 80.f);
-    EXPECT_EQ(blurSize.height, 120.f);
-    EXPECT_EQ(innerShadowFilter->dx, 15.f);
-    EXPECT_EQ(innerShadowFilter->dy, 15.f);
-    EXPECT_EQ(innerShadowFilter->color, Color::White());
-    EXPECT_EQ(innerShadowFilter->shadowOnly, false);
-#endif
+    TGFX_PRIVATE_ACCESS(
+        EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
+        auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
+        Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
+        EXPECT_EQ(blurSize.width, 80.f);
+        EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(innerShadowFilter->dx, 15.f);
+        EXPECT_EQ(innerShadowFilter->dy, 15.f);
+        EXPECT_EQ(innerShadowFilter->color, Color::White());
+        EXPECT_EQ(innerShadowFilter->shadowOnly, false));
   }
 
   {
     auto imageFilter = ImageFilter::InnerShadowOnly(15.f, 15.f, 20.f, 30.f, Color::White());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
-    auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
-    Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
-    EXPECT_EQ(blurSize.width, 80.f);
-    EXPECT_EQ(blurSize.height, 120.f);
-    EXPECT_EQ(innerShadowFilter->dx, 15.f);
-    EXPECT_EQ(innerShadowFilter->dy, 15.f);
-    EXPECT_EQ(innerShadowFilter->color, Color::White());
-    EXPECT_EQ(innerShadowFilter->shadowOnly, true);
-#endif
+    TGFX_PRIVATE_ACCESS(
+        EXPECT_EQ(imageFilter->type(), ImageFilter::Type::InnerShadow);
+        auto innerShadowFilter = std::static_pointer_cast<InnerShadowImageFilter>(imageFilter);
+        Size blurSize = innerShadowFilter->blurFilter->filterBounds({}).size();
+        EXPECT_EQ(blurSize.width, 80.f);
+        EXPECT_EQ(blurSize.height, 120.f);
+        EXPECT_EQ(innerShadowFilter->dx, 15.f);
+        EXPECT_EQ(innerShadowFilter->dy, 15.f);
+        EXPECT_EQ(innerShadowFilter->color, Color::White());
+        EXPECT_EQ(innerShadowFilter->shadowOnly, true));
   }
 
   {
     auto imageFilter = ImageFilter::ColorFilter(modeColorFilter);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Color);
-    auto colorFilter = std::static_pointer_cast<ColorImageFilter>(imageFilter);
-    Color color;
-    BlendMode mode;
-    bool ret = colorFilter->filter->asColorMode(&color, &mode);
-    EXPECT_TRUE(ret);
-    EXPECT_EQ(color, Color::Red());
-    EXPECT_EQ(mode, BlendMode::Multiply);
-#endif
+    TGFX_PRIVATE_ACCESS(
+        EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Color);
+        auto colorFilter = std::static_pointer_cast<ColorImageFilter>(imageFilter);
+        Color color;
+        BlendMode mode;
+        bool ret = colorFilter->filter->asColorMode(&color, &mode);
+        EXPECT_TRUE(ret);
+        EXPECT_EQ(color, Color::Red());
+        EXPECT_EQ(mode, BlendMode::Multiply));
   }
 
   {
@@ -494,18 +487,14 @@ TGFX_TEST(FilterTest, GetFilterProperties) {
     auto greenFilter = ImageFilter::DropShadow(-100, -100, 0, 0, Color::Green());
     auto blackFilter = ImageFilter::DropShadow(0, 0, 300, 300, Color::Black());
     auto imageFilter = ImageFilter::Compose({blueFilter, greenFilter, blackFilter});
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Compose);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Compose));
   }
 
   {
     EffectCache effectCache = {};
     auto effect = CornerPinEffect::Make(&effectCache, {484, 54}, {764, 80}, {764, 504}, {482, 512});
     auto imageFilter = ImageFilter::Runtime(std::move(effect));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Runtime);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(imageFilter->type(), ImageFilter::Type::Runtime));
   }
 }
 
@@ -514,9 +503,7 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto colorShader = Shader::MakeColorShader(Color::Red());
     ASSERT_TRUE(colorShader != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(colorShader->type(), Shader::Type::Color);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(colorShader->type(), Shader::Type::Color));
 
     Color color = {};
     bool ret = colorShader->asColor(&color);
@@ -530,14 +517,12 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     auto shader = Shader::MakeImageShader(inputImage, TileMode::Mirror, TileMode::Repeat);
     ASSERT_TRUE(shader != nullptr);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(shader->type(), Shader::Type::Image);
-
-    auto imageShader = std::static_pointer_cast<ImageShader>(shader);
-    EXPECT_TRUE(imageShader != nullptr);
-    EXPECT_EQ(imageShader->tileModeX, TileMode::Mirror);
-    EXPECT_EQ(imageShader->tileModeY, TileMode::Repeat);
-#endif
+    TGFX_PRIVATE_ACCESS(
+        EXPECT_EQ(shader->type(), Shader::Type::Image);
+        auto imageShader = std::static_pointer_cast<ImageShader>(shader);
+        EXPECT_TRUE(imageShader != nullptr);
+        EXPECT_EQ(imageShader->tileModeX, TileMode::Mirror);
+        EXPECT_EQ(imageShader->tileModeY, TileMode::Repeat));
   }
 
   {
@@ -545,9 +530,7 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     auto greenShader = Shader::MakeColorShader(Color::Green());
     auto blendShader = Shader::MakeBlend(BlendMode::SrcOut, redShader, greenShader);
     ASSERT_TRUE(blendShader != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(blendShader->type(), Shader::Type::Blend);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(blendShader->type(), Shader::Type::Blend));
   }
 
   std::vector<Color> colors = {Color::Red(), Color::Green(), Color::Blue()};
@@ -557,9 +540,7 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto shader = Shader::MakeLinearGradient(startPoint, endPoint, colors, positions);
     ASSERT_TRUE(shader != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(shader->type(), Shader::Type::Gradient);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(shader->type(), Shader::Type::Gradient));
 
     auto gradientShader = std::static_pointer_cast<LinearGradientShader>(shader);
 
@@ -577,9 +558,7 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto shader = Shader::MakeRadialGradient(center, radius, colors, positions);
     ASSERT_TRUE(shader != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(shader->type(), Shader::Type::Gradient);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(shader->type(), Shader::Type::Gradient));
 
     auto gradientShader = std::static_pointer_cast<LinearGradientShader>(shader);
 
@@ -597,9 +576,7 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
     float endAngle = 360.f;
     auto shader = Shader::MakeConicGradient(center, startAngle, endAngle, colors, positions);
     ASSERT_TRUE(shader != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(shader->type(), Shader::Type::Gradient);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(shader->type(), Shader::Type::Gradient));
 
     auto gradientShader = std::static_pointer_cast<LinearGradientShader>(shader);
 
@@ -618,9 +595,7 @@ TGFX_TEST(FilterTest, GetShaderProperties) {
   {
     auto shader = Shader::MakeDiamondGradient(center, diamondRadius, colors, positions);
     ASSERT_TRUE(shader != nullptr);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-    EXPECT_EQ(shader->type(), Shader::Type::Gradient);
-#endif
+    TGFX_PRIVATE_ACCESS(EXPECT_EQ(shader->type(), Shader::Type::Gradient));
 
     auto gradientShader = std::static_pointer_cast<DiamondGradientShader>(shader);
 
@@ -975,63 +950,75 @@ TGFX_TEST(FilterTest, ReverseFilterBounds) {
   EXPECT_TRUE(Baseline::Compare(surface, "FilterTest/ReverseFilterBounds_dropShadow"));
 }
 
-TGFX_TEST(FilterTest, AffectsTransparentBlack) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(FilterTest, AffectsTransparentBlack) {
   // ModeColorFilter: modes that do NOT affect transparent black
-  EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::SrcIn)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::SrcIn)->affectsTransparentBlack()));
   // Blend(Red, DstIn) returns nullptr because alpha=1 DstIn is a no-op (result = dst * 1 = dst).
   EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstIn) == nullptr);
-  EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::DstOut)->affectsTransparentBlack());
-  EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::SrcATop)->affectsTransparentBlack());
-  EXPECT_FALSE(ColorFilter::Blend(Color::Red(), BlendMode::Modulate)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_FALSE(
+          ColorFilter::Blend(Color::Red(), BlendMode::DstOut)->affectsTransparentBlack());
+      EXPECT_FALSE(
+          ColorFilter::Blend(Color::Red(), BlendMode::SrcATop)->affectsTransparentBlack());
+      EXPECT_FALSE(
+          ColorFilter::Blend(Color::Red(), BlendMode::Modulate)->affectsTransparentBlack()));
 
   // ModeColorFilter: modes that DO affect transparent black
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Src)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::White(), BlendMode::SrcOver)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::White(), BlendMode::Screen)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstOver)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::SrcOut)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstATop)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Xor)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::PlusLighter)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Overlay)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Multiply)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Src)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::White(), BlendMode::SrcOver)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::White(), BlendMode::Screen)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstOver)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::SrcOut)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::DstATop)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Xor)->affectsTransparentBlack());
+      EXPECT_TRUE(
+          ColorFilter::Blend(Color::Red(), BlendMode::PlusLighter)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Blend(Color::Red(), BlendMode::Overlay)->affectsTransparentBlack());
+      EXPECT_TRUE(
+          ColorFilter::Blend(Color::Red(), BlendMode::Multiply)->affectsTransparentBlack()));
 
   // ModeColorFilter: transparent color never affects transparent black
   auto transparentFilter = ColorFilter::Blend(Color::Transparent(), BlendMode::Screen);
   // Blend() with alpha=0 and SrcOver converts to Dst, which is a no-op and returns nullptr.
   // Screen with transparent color: src=(0,0,0,0), dst=(0,0,0,0) → 0, not affected.
-  EXPECT_TRUE(transparentFilter == nullptr || !transparentFilter->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(transparentFilter == nullptr || !transparentFilter->affectsTransparentBlack()));
 
   // MatrixColorFilter: no alpha offset → false
   std::array<float, 20> identityMatrix = {1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
                                           0, 0, 1, 0, 0, 0, 0, 0, 1, 0};
-  EXPECT_FALSE(ColorFilter::Matrix(identityMatrix)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_FALSE(ColorFilter::Matrix(identityMatrix)->affectsTransparentBlack()));
 
   // MatrixColorFilter: positive alpha offset → true
   std::array<float, 20> alphaOffsetMatrix = {1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
                                              0, 0, 1, 0, 0, 0, 0, 0, 1, 0.5f};
-  EXPECT_TRUE(ColorFilter::Matrix(alphaOffsetMatrix)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(ColorFilter::Matrix(alphaOffsetMatrix)->affectsTransparentBlack()));
 
   // MatrixColorFilter: RGB offset only (no alpha offset) → false (premultiply makes rgb 0)
   std::array<float, 20> rgbOffsetMatrix = {1, 0, 0, 0, 0.5f, 0, 1, 0, 0, 0,
                                            0, 0, 1, 0, 0,    0, 0, 0, 1, 0};
-  EXPECT_FALSE(ColorFilter::Matrix(rgbOffsetMatrix)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_FALSE(ColorFilter::Matrix(rgbOffsetMatrix)->affectsTransparentBlack()));
 
   // AlphaThresholdColorFilter
-  EXPECT_TRUE(ColorFilter::AlphaThreshold(0.0f)->affectsTransparentBlack());
-  EXPECT_FALSE(ColorFilter::AlphaThreshold(0.5f)->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(ColorFilter::AlphaThreshold(0.0f)->affectsTransparentBlack());
+      EXPECT_FALSE(ColorFilter::AlphaThreshold(0.5f)->affectsTransparentBlack()));
 
   // LumaColorFilter
-  EXPECT_FALSE(ColorFilter::Luma()->affectsTransparentBlack());
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(ColorFilter::Luma()->affectsTransparentBlack()));
 
   // ComposeColorFilter
   auto innerSafe = ColorFilter::Blend(Color::Red(), BlendMode::SrcIn);
   auto outerUnsafe = ColorFilter::Blend(Color::White(), BlendMode::Screen);
-  EXPECT_TRUE(ColorFilter::Compose(innerSafe, outerUnsafe)->affectsTransparentBlack());
-  EXPECT_TRUE(ColorFilter::Compose(outerUnsafe, innerSafe)->affectsTransparentBlack());
-  EXPECT_FALSE(ColorFilter::Compose(innerSafe, innerSafe)->affectsTransparentBlack());
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(ColorFilter::Compose(innerSafe, outerUnsafe)->affectsTransparentBlack());
+      EXPECT_TRUE(ColorFilter::Compose(outerUnsafe, innerSafe)->affectsTransparentBlack());
+      EXPECT_FALSE(ColorFilter::Compose(innerSafe, innerSafe)->affectsTransparentBlack()));
 }
 
 TGFX_TEST(FilterTest, ColorImageFilterTransparent) {

--- a/test/src/ImageRenderTest.cpp
+++ b/test/src/ImageRenderTest.cpp
@@ -110,19 +110,18 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   auto canvas = surface->getCanvas();
   canvas->drawImage(rasterImage, 100, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "ImageRenderTest/rasterized"));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto rasterImageUniqueKey =
-      std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
-  auto textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
-  ASSERT_TRUE(textureView != nullptr);
-  EXPECT_TRUE(textureView != nullptr);
-  EXPECT_EQ(textureView->width(), 454);
-  EXPECT_EQ(textureView->height(), 605);
-  auto source = std::static_pointer_cast<TransformImage>(image)->source;
-  auto imageUniqueKey = std::static_pointer_cast<RasterizedImage>(source)->getTextureKey();
-  textureView = Resource::Find<TextureView>(context, imageUniqueKey);
-  EXPECT_TRUE(textureView == nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto rasterImageUniqueKey =
+          std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
+      auto textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
+      ASSERT_TRUE(textureView != nullptr);
+      EXPECT_TRUE(textureView != nullptr);
+      EXPECT_EQ(textureView->width(), 454);
+      EXPECT_EQ(textureView->height(), 605);
+      auto source = std::static_pointer_cast<TransformImage>(image)->source;
+      auto imageUniqueKey = std::static_pointer_cast<RasterizedImage>(source)->getTextureKey();
+      textureView = Resource::Find<TextureView>(context, imageUniqueKey);
+      EXPECT_TRUE(textureView == nullptr));
   canvas->clear();
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
@@ -132,13 +131,12 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   EXPECT_TRUE(rasterImage->hasMipmaps());
   canvas->drawImage(rasterImage, 100, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "ImageRenderTest/rasterized_mipmap"));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
-  EXPECT_TRUE(textureView == nullptr);
-  rasterImageUniqueKey = std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
-  textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
-  EXPECT_TRUE(textureView != nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
+      EXPECT_TRUE(textureView == nullptr);
+      rasterImageUniqueKey = std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
+      textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
+      EXPECT_TRUE(textureView != nullptr));
   canvas->clear();
   scaledImage = scaledImage->makeMipmapped(false);
   EXPECT_FALSE(scaledImage->hasMipmaps());
@@ -531,50 +529,43 @@ TGFX_TEST(ImageRenderTest, RasterizedMipmapImage) {
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
   auto image = MakeImage("resources/apitest/imageReplacement.png");
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto originKey = std::static_pointer_cast<RasterizedImage>(image)->getTextureKey();
-  auto textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
-  EXPECT_TRUE(textureProxy == nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto originKey = std::static_pointer_cast<RasterizedImage>(image)->getTextureKey();
+      auto textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
+      EXPECT_TRUE(textureProxy == nullptr));
   auto surface = Surface::Make(context, 300, 300);
   auto canvas = surface->getCanvas();
   canvas->drawImage(image);
   context->flushAndSubmit();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
-  EXPECT_TRUE(textureProxy != nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
+      EXPECT_TRUE(textureProxy != nullptr));
 
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto mipmapKey = std::static_pointer_cast<RasterizedImage>(image)->getTextureKey();
-  EXPECT_TRUE(mipmapKey != originKey);
-  auto mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
-  EXPECT_TRUE(mipmapTexture == nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto mipmapKey = std::static_pointer_cast<RasterizedImage>(image)->getTextureKey();
+      EXPECT_TRUE(mipmapKey != originKey);
+      auto mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
+      EXPECT_TRUE(mipmapTexture == nullptr));
   canvas->drawImage(image);
   context->flushAndSubmit();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
-  EXPECT_TRUE(mipmapTexture != nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
+      EXPECT_TRUE(mipmapTexture != nullptr));
 
   image = image->makeMipmapped(false);
   EXPECT_FALSE(image->hasMipmaps());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(originKey == std::static_pointer_cast<RasterizedImage>(image)->getTextureKey());
-
-  textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
-  EXPECT_TRUE(textureProxy != nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(originKey == std::static_pointer_cast<RasterizedImage>(image)->getTextureKey());
+      textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
+      EXPECT_TRUE(textureProxy != nullptr));
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(mipmapKey == std::static_pointer_cast<RasterizedImage>(image)->getTextureKey());
-  mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
-  EXPECT_TRUE(mipmapTexture != nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(mipmapKey == std::static_pointer_cast<RasterizedImage>(image)->getTextureKey());
+      mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
+      EXPECT_TRUE(mipmapTexture != nullptr));
 }
 
 TGFX_TEST(ImageRenderTest, drawScaleImage) {

--- a/test/src/ImageRenderTest.cpp
+++ b/test/src/ImageRenderTest.cpp
@@ -110,6 +110,7 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   auto canvas = surface->getCanvas();
   canvas->drawImage(rasterImage, 100, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "ImageRenderTest/rasterized"));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto rasterImageUniqueKey =
       std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
   auto textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
@@ -121,6 +122,7 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   auto imageUniqueKey = std::static_pointer_cast<RasterizedImage>(source)->getTextureKey();
   textureView = Resource::Find<TextureView>(context, imageUniqueKey);
   EXPECT_TRUE(textureView == nullptr);
+#endif
   canvas->clear();
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
@@ -130,11 +132,13 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   EXPECT_TRUE(rasterImage->hasMipmaps());
   canvas->drawImage(rasterImage, 100, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "ImageRenderTest/rasterized_mipmap"));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
   EXPECT_TRUE(textureView == nullptr);
   rasterImageUniqueKey = std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
   textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
   EXPECT_TRUE(textureView != nullptr);
+#endif
   canvas->clear();
   scaledImage = scaledImage->makeMipmapped(false);
   EXPECT_FALSE(scaledImage->hasMipmaps());
@@ -527,38 +531,50 @@ TGFX_TEST(ImageRenderTest, RasterizedMipmapImage) {
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
   auto image = MakeImage("resources/apitest/imageReplacement.png");
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto originKey = std::static_pointer_cast<RasterizedImage>(image)->getTextureKey();
   auto textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
   EXPECT_TRUE(textureProxy == nullptr);
+#endif
   auto surface = Surface::Make(context, 300, 300);
   auto canvas = surface->getCanvas();
   canvas->drawImage(image);
   context->flushAndSubmit();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
   EXPECT_TRUE(textureProxy != nullptr);
+#endif
 
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto mipmapKey = std::static_pointer_cast<RasterizedImage>(image)->getTextureKey();
   EXPECT_TRUE(mipmapKey != originKey);
   auto mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
   EXPECT_TRUE(mipmapTexture == nullptr);
+#endif
   canvas->drawImage(image);
   context->flushAndSubmit();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
   EXPECT_TRUE(mipmapTexture != nullptr);
+#endif
 
   image = image->makeMipmapped(false);
   EXPECT_FALSE(image->hasMipmaps());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(originKey == std::static_pointer_cast<RasterizedImage>(image)->getTextureKey());
 
   textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
   EXPECT_TRUE(textureProxy != nullptr);
+#endif
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(mipmapKey == std::static_pointer_cast<RasterizedImage>(image)->getTextureKey());
   mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
   EXPECT_TRUE(mipmapTexture != nullptr);
+#endif
 }
 
 TGFX_TEST(ImageRenderTest, drawScaleImage) {

--- a/test/src/ImageRenderTest.cpp
+++ b/test/src/ImageRenderTest.cpp
@@ -110,18 +110,16 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   auto canvas = surface->getCanvas();
   canvas->drawImage(rasterImage, 100, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "ImageRenderTest/rasterized"));
-  TGFX_PRIVATE_ACCESS(
-      auto rasterImageUniqueKey =
-          std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
-      auto textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
-      ASSERT_TRUE(textureView != nullptr);
-      EXPECT_TRUE(textureView != nullptr);
-      EXPECT_EQ(textureView->width(), 454);
-      EXPECT_EQ(textureView->height(), 605);
-      auto source = std::static_pointer_cast<TransformImage>(image)->source;
-      auto imageUniqueKey = std::static_pointer_cast<RasterizedImage>(source)->getTextureKey();
-      textureView = Resource::Find<TextureView>(context, imageUniqueKey);
-      EXPECT_TRUE(textureView == nullptr));
+  TGFX_PRIVATE_ACCESS(auto rasterImageUniqueKey =
+                          std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
+                      auto textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
+                      ASSERT_TRUE(textureView != nullptr); EXPECT_TRUE(textureView != nullptr);
+                      EXPECT_EQ(textureView->width(), 454); EXPECT_EQ(textureView->height(), 605);
+                      auto source = std::static_pointer_cast<TransformImage>(image)->source;
+                      auto imageUniqueKey =
+                          std::static_pointer_cast<RasterizedImage>(source)->getTextureKey();
+                      textureView = Resource::Find<TextureView>(context, imageUniqueKey);
+                      EXPECT_TRUE(textureView == nullptr));
   canvas->clear();
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
@@ -131,12 +129,12 @@ TGFX_TEST(ImageRenderTest, rasterizedImage) {
   EXPECT_TRUE(rasterImage->hasMipmaps());
   canvas->drawImage(rasterImage, 100, 100);
   EXPECT_TRUE(Baseline::Compare(surface, "ImageRenderTest/rasterized_mipmap"));
-  TGFX_PRIVATE_ACCESS(
-      textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
-      EXPECT_TRUE(textureView == nullptr);
-      rasterImageUniqueKey = std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
-      textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
-      EXPECT_TRUE(textureView != nullptr));
+  TGFX_PRIVATE_ACCESS(textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
+                      EXPECT_TRUE(textureView == nullptr);
+                      rasterImageUniqueKey =
+                          std::static_pointer_cast<RasterizedImage>(rasterImage)->getTextureKey();
+                      textureView = Resource::Find<TextureView>(context, rasterImageUniqueKey);
+                      EXPECT_TRUE(textureView != nullptr));
   canvas->clear();
   scaledImage = scaledImage->makeMipmapped(false);
   EXPECT_FALSE(scaledImage->hasMipmaps());
@@ -537,9 +535,8 @@ TGFX_TEST(ImageRenderTest, RasterizedMipmapImage) {
   auto canvas = surface->getCanvas();
   canvas->drawImage(image);
   context->flushAndSubmit();
-  TGFX_PRIVATE_ACCESS(
-      textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
-      EXPECT_TRUE(textureProxy != nullptr));
+  TGFX_PRIVATE_ACCESS(textureProxy = context->proxyProvider()->findOrWrapTextureProxy(originKey);
+                      EXPECT_TRUE(textureProxy != nullptr));
 
   image = image->makeMipmapped(true);
   EXPECT_TRUE(image->hasMipmaps());
@@ -550,9 +547,8 @@ TGFX_TEST(ImageRenderTest, RasterizedMipmapImage) {
       EXPECT_TRUE(mipmapTexture == nullptr));
   canvas->drawImage(image);
   context->flushAndSubmit();
-  TGFX_PRIVATE_ACCESS(
-      mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
-      EXPECT_TRUE(mipmapTexture != nullptr));
+  TGFX_PRIVATE_ACCESS(mipmapTexture = context->proxyProvider()->findOrWrapTextureProxy(mipmapKey);
+                      EXPECT_TRUE(mipmapTexture != nullptr));
 
   image = image->makeMipmapped(false);
   EXPECT_FALSE(image->hasMipmaps());

--- a/test/src/InstancedGridRenderPass.cpp
+++ b/test/src/InstancedGridRenderPass.cpp
@@ -76,7 +76,7 @@ static std::string GetFinalShaderCode(const char* codeSnippet, bool isDesktop) {
 
 std::shared_ptr<InstancedGridRenderPass> InstancedGridRenderPass::Make(uint32_t rows,
                                                                        uint32_t columns) {
-  return std::make_shared<InstancedGridRenderPass>(rows, columns);
+  return std::shared_ptr<InstancedGridRenderPass>(new InstancedGridRenderPass(rows, columns));
 }
 
 InstancedGridRenderPass::InstancedGridRenderPass(uint32_t rows, uint32_t columns)

--- a/test/src/LayerCacheTest.cpp
+++ b/test/src/LayerCacheTest.cpp
@@ -314,7 +314,7 @@ TGFX_TEST_PRIVATE(LayerCacheTest, LayerCacheContentScale) {
   // At zoom 0.1, longEdge < minLongEdge, cache should be 50
   int expectedLongEdge0_1 = 50;
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->cacheEntries.size() == 3);
-                       EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge0_1)));
+                      EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge0_1)));
 }
 
 TGFX_TEST_PRIVATE(LayerCacheTest, StaticSubtree) {
@@ -334,44 +334,44 @@ TGFX_TEST_PRIVATE(LayerCacheTest, StaticSubtree) {
 
   displayList->root()->addChild(rootLayer);
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_FALSE(childLayer->bitFields.staticSubtree));
+                      EXPECT_FALSE(childLayer->bitFields.staticSubtree));
 
   // After first render, staticSubtree should be true
   displayList->render(surface.get());
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
+                      EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After adding filter, both should be false
   auto filter = BlurFilter::Make(10.f, 10.f);
   childLayer->setFilters({filter});
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_FALSE(childLayer->bitFields.staticSubtree));
+                      EXPECT_FALSE(childLayer->bitFields.staticSubtree));
 
   // After render, both should be true again
   displayList->render(surface.get());
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
+                      EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After adding layer style, both should be false
   auto style = DropShadowStyle::Make(5, 5, 0, 0, Color::Black(), false);
   childLayer->setLayerStyles({style});
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_FALSE(childLayer->bitFields.staticSubtree));
+                      EXPECT_FALSE(childLayer->bitFields.staticSubtree));
 
   // After render, both should be true again
   displayList->render(surface.get());
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
+                      EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After invalidating descendents, both should be false
   TGFX_PRIVATE_ACCESS(rootLayer->invalidateDescendents());
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
+                      EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After render, both should be true again
   displayList->render(surface.get());
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
+                      EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 }
 
 /**
@@ -787,11 +787,10 @@ TGFX_TEST_PRIVATE(LayerCacheTest, TileClearWhenAllLayersRemoved) {
   rootLayer->addChild(blueRect);
   displayList->render(surface.get());
 
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_EQ(displayList->tileCaches.size(), 1u);
-      auto result = displayList->tileCaches.find(1000);
-      EXPECT_TRUE(result != displayList->tileCaches.end());
-      EXPECT_EQ(result->second->tileMap.size(), 4u));
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(displayList->tileCaches.size(), 1u);
+                      auto result = displayList->tileCaches.find(1000);
+                      EXPECT_TRUE(result != displayList->tileCaches.end());
+                      EXPECT_EQ(result->second->tileMap.size(), 4u));
 
   blueRect->removeFromParent();
   displayList->render(surface.get());
@@ -859,12 +858,12 @@ TGFX_TEST_PRIVATE(LayerCacheTest, ContentBlendModeDisablesCache) {
   // First render
   displayList->render(surface.get());
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(blendLayer->subtreeCache == nullptr);
-                       EXPECT_TRUE(blendLayer->bitFields.hasBlendMode));
+                      EXPECT_TRUE(blendLayer->bitFields.hasBlendMode));
 
   // Second render - should still not create cache due to content blend mode
   displayList->render(surface.get());
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(blendLayer->subtreeCache == nullptr);
-                       EXPECT_TRUE(blendLayer->bitFields.hasBlendMode));
+                      EXPECT_TRUE(blendLayer->bitFields.hasBlendMode));
 
   // Compare the rendering result to ensure blend mode works correctly
   EXPECT_TRUE(Baseline::Compare(surface, "LayerCacheTest/ContentBlendModeDisablesCache"));
@@ -913,7 +912,7 @@ TGFX_TEST_PRIVATE(LayerCacheTest, OverlappingDirtyRegions) {
   TGFX_PRIVATE_ACCESS(EXPECT_EQ(displayList->tileCaches.size(), 0lu));
 
   TGFX_PRIVATE_ACCESS(auto emptyTilesAfter = displayList->emptyTiles.size();
-                       EXPECT_EQ(9lu, emptyTilesAfter));
+                      EXPECT_EQ(9lu, emptyTilesAfter));
 }
 
 }  // namespace tgfx

--- a/test/src/LayerCacheTest.cpp
+++ b/test/src/LayerCacheTest.cpp
@@ -29,9 +29,7 @@
 
 namespace tgfx {
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-
-TGFX_TEST(LayerCacheTest, LayerCache) {
+TGFX_TEST_PRIVATE(LayerCacheTest, LayerCache) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -72,16 +70,16 @@ TGFX_TEST(LayerCacheTest, LayerCache) {
   // First render - staticSubtree flag is not set yet
   displayList->render(surface.get());
   auto root = displayList->root();
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - creates subtreeCache
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
   int expectedLongEdge = 64;
-  EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge)));
 }
 
-TGFX_TEST(LayerCacheTest, LayerCacheInvalidation) {
+TGFX_TEST_PRIVATE(LayerCacheTest, LayerCacheInvalidation) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -107,11 +105,11 @@ TGFX_TEST(LayerCacheTest, LayerCacheInvalidation) {
 
   // First render - staticSubtree flag is not set yet
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - creates subtreeCache
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // Adding a new child - should invalidate root's cache
   auto newChild = ShapeLayer::Make();
@@ -123,27 +121,27 @@ TGFX_TEST(LayerCacheTest, LayerCacheInvalidation) {
   parent->addChild(newChild);
 
   // Cache should be invalidated after adding child
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // First render after modification - staticSubtree flag is not set yet
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - creates subtreeCache again
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // Modifying child transform - should invalidate cache
   child->setMatrix(Matrix::MakeTrans(10, 10));
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Render twice to recreate cache
   displayList->render(surface.get());
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 }
 
-TGFX_TEST(LayerCacheTest, LayerCacheWithEffects) {
+TGFX_TEST_PRIVATE(LayerCacheTest, LayerCacheWithEffects) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -187,16 +185,16 @@ TGFX_TEST(LayerCacheTest, LayerCacheWithEffects) {
 
   // First render - staticSubtree flag is not set yet
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - creates subtreeCache
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   EXPECT_TRUE(Baseline::Compare(surface, "LayerCacheTest/LayerCacheWithEffects"));
 }
 
-TGFX_TEST(LayerCacheTest, LayerCacheWithTransform) {
+TGFX_TEST_PRIVATE(LayerCacheTest, LayerCacheWithTransform) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -222,31 +220,31 @@ TGFX_TEST(LayerCacheTest, LayerCacheWithTransform) {
 
   // First render - staticSubtree flag is not set yet
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - creates subtreeCache
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // Change zoomScale - cache should still be valid (just uses different mipmap level)
   displayList->setZoomScale(1.5f);
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // Change parent's transform - should invalidate root's cache
   parent->setMatrix(Matrix::MakeTrans(10, 10));
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // First render after modification - staticSubtree flag is not set yet
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - recreate cache
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 }
 
-TGFX_TEST(LayerCacheTest, LayerCacheContentScale) {
+TGFX_TEST_PRIVATE(LayerCacheTest, LayerCacheContentScale) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -272,54 +270,54 @@ TGFX_TEST(LayerCacheTest, LayerCacheContentScale) {
 
   // First render - staticSubtree flag is not set yet
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache == nullptr));
 
   // Second render - creates subtreeCache
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // At zoom 1.0, longEdge should be 100
   int expectedLongEdge1_0 = 100;
-  EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge1_0));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge1_0)));
 
   // Render at zoom 0.5 - cache should still exist
   displayList->setZoomScale(0.5f);
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // At zoom 0.5, longEdge should be 50
   int expectedLongEdge0_5 = 50;
-  EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge0_5));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge0_5)));
 
   // Render at zoom 2.0
   displayList->setZoomScale(2.0f);
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // At zoom 2.0, longEdge should be 200
   int expectedLongEdge2_0 = 200;
-  EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge2_0));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge2_0)));
 
   // Render at zoom 1.0 again
   displayList->setZoomScale(1.0f);
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // At zoom 1.0 again, cache should still be valid for longEdge 100
-  EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge1_0));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge1_0)));
 
   // Render at extreme zoom out
   displayList->setZoomScale(0.1f);
   displayList->render(surface.get());
-  EXPECT_TRUE(root->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache != nullptr));
 
   // At zoom 0.1, longEdge < minLongEdge, cache should be 50
   int expectedLongEdge0_1 = 50;
-  EXPECT_TRUE(root->subtreeCache->cacheEntries.size() == 3);
-  EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge0_1));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(root->subtreeCache->cacheEntries.size() == 3);
+                       EXPECT_TRUE(root->subtreeCache->hasCache(context, expectedLongEdge0_1)));
 }
 
-TGFX_TEST(LayerCacheTest, StaticSubtree) {
+TGFX_TEST_PRIVATE(LayerCacheTest, StaticSubtree) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -335,51 +333,51 @@ TGFX_TEST(LayerCacheTest, StaticSubtree) {
   rootLayer->addChild(childLayer);
 
   displayList->root()->addChild(rootLayer);
-  EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-  EXPECT_FALSE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_FALSE(childLayer->bitFields.staticSubtree));
 
   // After first render, staticSubtree should be true
   displayList->render(surface.get());
-  EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-  EXPECT_TRUE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After adding filter, both should be false
   auto filter = BlurFilter::Make(10.f, 10.f);
   childLayer->setFilters({filter});
-  EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-  EXPECT_FALSE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_FALSE(childLayer->bitFields.staticSubtree));
 
   // After render, both should be true again
   displayList->render(surface.get());
-  EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-  EXPECT_TRUE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After adding layer style, both should be false
   auto style = DropShadowStyle::Make(5, 5, 0, 0, Color::Black(), false);
   childLayer->setLayerStyles({style});
-  EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-  EXPECT_FALSE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_FALSE(childLayer->bitFields.staticSubtree));
 
   // After render, both should be true again
   displayList->render(surface.get());
-  EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-  EXPECT_TRUE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After invalidating descendents, both should be false
-  rootLayer->invalidateDescendents();
-  EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
-  EXPECT_TRUE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(rootLayer->invalidateDescendents());
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 
   // After render, both should be true again
   displayList->render(surface.get());
-  EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
-  EXPECT_TRUE(childLayer->bitFields.staticSubtree);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rootLayer->bitFields.staticSubtree);
+                       EXPECT_TRUE(childLayer->bitFields.staticSubtree));
 }
 
 /**
  * Test that simple Rect/RRect leaf nodes skip subtree caching.
  */
-TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
+TGFX_TEST_PRIVATE(LayerCacheTest, SimpleShapeSkipsCache) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -404,7 +402,7 @@ TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
   displayList->render(surface.get());
 
   // Simple Rect layer should not have subtree cache
-  EXPECT_TRUE(rectLayer->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rectLayer->subtreeCache == nullptr));
 
   // Test 2: Simple SolidLayer (RRect) - should NOT create subtree cache
   auto rrectLayer = SolidLayer::Make();
@@ -420,7 +418,7 @@ TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
   displayList->render(surface.get());
 
   // Simple RRect layer should not have subtree cache
-  EXPECT_TRUE(rrectLayer->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rrectLayer->subtreeCache == nullptr));
 
   // Test 3: ShapeLayer with Path (not Rect/RRect) - SHOULD create subtree cache
   auto pathLayer = ShapeLayer::Make();
@@ -435,7 +433,7 @@ TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
   displayList->render(surface.get());
 
   // Path layer (not Rect/RRect) should have subtree cache
-  EXPECT_TRUE(pathLayer->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(pathLayer->subtreeCache != nullptr));
 
   // Test 4: SolidLayer with filter - SHOULD create subtree cache
   auto rectWithFilter = SolidLayer::Make();
@@ -450,7 +448,7 @@ TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
   displayList->render(surface.get());
 
   // Rect with filter should have subtree cache
-  EXPECT_TRUE(rectWithFilter->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rectWithFilter->subtreeCache != nullptr));
 
   // Test 5: SolidLayer with layer style - SHOULD create subtree cache
   auto rectWithStyle = SolidLayer::Make();
@@ -465,7 +463,7 @@ TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
   displayList->render(surface.get());
 
   // Rect with layer style should have subtree cache
-  EXPECT_TRUE(rectWithStyle->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(rectWithStyle->subtreeCache != nullptr));
 
   // Test 6: Layer with Rect child - SHOULD create subtree cache (not a leaf node)
   auto parentLayer = Layer::Make();
@@ -481,12 +479,12 @@ TGFX_TEST(LayerCacheTest, SimpleShapeSkipsCache) {
   displayList->render(surface.get());
 
   // Parent layer with children should have subtree cache
-  EXPECT_TRUE(parentLayer->subtreeCache != nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(parentLayer->subtreeCache != nullptr));
   // Child rect should not have subtree cache (simple leaf)
-  EXPECT_TRUE(childRect->subtreeCache == nullptr);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(childRect->subtreeCache == nullptr));
 }
 
-TGFX_TEST(LayerCacheTest, DirtyFlag) {
+TGFX_TEST_PRIVATE(LayerCacheTest, DirtyFlag) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -510,31 +508,35 @@ TGFX_TEST(LayerCacheTest, DirtyFlag) {
   displayList->render(surface.get());
 
   auto root = displayList->root();
-  EXPECT_TRUE(grandChild->bitFields.dirtyDescendents);
-  EXPECT_TRUE(grandChild->layerContent == nullptr && grandChild->bitFields.dirtyContent);
-  EXPECT_TRUE(!child->bitFields.dirtyDescendents && !child->bitFields.dirtyContent);
-  EXPECT_TRUE(!root->bitFields.dirtyDescendents && !root->bitFields.dirtyContent);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(grandChild->bitFields.dirtyDescendents);
+      EXPECT_TRUE(grandChild->layerContent == nullptr && grandChild->bitFields.dirtyContent);
+      EXPECT_TRUE(!child->bitFields.dirtyDescendents && !child->bitFields.dirtyContent);
+      EXPECT_TRUE(!root->bitFields.dirtyDescendents && !root->bitFields.dirtyContent));
 
   grandChild->setVisible(true);
-  EXPECT_TRUE(grandChild->bitFields.dirtyDescendents);
-  EXPECT_TRUE(grandChild->layerContent == nullptr && grandChild->bitFields.dirtyContent);
-  EXPECT_TRUE(child->bitFields.dirtyDescendents);
-  EXPECT_TRUE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(grandChild->bitFields.dirtyDescendents);
+      EXPECT_TRUE(grandChild->layerContent == nullptr && grandChild->bitFields.dirtyContent);
+      EXPECT_TRUE(child->bitFields.dirtyDescendents);
+      EXPECT_TRUE(root->bitFields.dirtyDescendents));
   displayList->render(surface.get());
 
-  EXPECT_TRUE(!grandChild->bitFields.dirtyDescendents && !grandChild->bitFields.dirtyContent);
-  EXPECT_TRUE(grandChild->layerContent != nullptr);
-  EXPECT_TRUE(!child->bitFields.dirtyDescendents && !child->bitFields.dirtyContent);
-  EXPECT_TRUE(!root->bitFields.dirtyDescendents && !root->bitFields.dirtyContent);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(!grandChild->bitFields.dirtyDescendents && !grandChild->bitFields.dirtyContent);
+      EXPECT_TRUE(grandChild->layerContent != nullptr);
+      EXPECT_TRUE(!child->bitFields.dirtyDescendents && !child->bitFields.dirtyContent);
+      EXPECT_TRUE(!root->bitFields.dirtyDescendents && !root->bitFields.dirtyContent));
 
   child->setVisible(false);
-  EXPECT_TRUE(!grandChild->bitFields.dirtyDescendents && !grandChild->bitFields.dirtyContent);
-  EXPECT_TRUE(grandChild->layerContent != nullptr);
-  EXPECT_TRUE(!child->bitFields.dirtyDescendents && !child->bitFields.dirtyContent);
-  EXPECT_TRUE(root->bitFields.dirtyDescendents && !root->bitFields.dirtyContent);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(!grandChild->bitFields.dirtyDescendents && !grandChild->bitFields.dirtyContent);
+      EXPECT_TRUE(grandChild->layerContent != nullptr);
+      EXPECT_TRUE(!child->bitFields.dirtyDescendents && !child->bitFields.dirtyContent);
+      EXPECT_TRUE(root->bitFields.dirtyDescendents && !root->bitFields.dirtyContent));
 }
 
-TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
+TGFX_TEST_PRIVATE(LayerCacheTest, DirtyRegionTest) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -551,7 +553,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer1->setPath(path1);
   // rootLayer->addChild(shapeLayer1);
   auto bounds1 = shapeLayer1->getBounds();
-  shapeLayer1->getGlobalMatrix().mapRect(&bounds1);
+  TGFX_PRIVATE_ACCESS(shapeLayer1->getGlobalMatrix().mapRect(&bounds1));
 
   auto shapeLayer2 = ShapeLayer::Make();
   shapeLayer2->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -560,7 +562,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer2->setPath(path2);
   // rootLayer->addChild(shapeLayer2);
   auto bounds2 = shapeLayer2->getBounds();
-  shapeLayer2->getGlobalMatrix().mapRect(&bounds2);
+  TGFX_PRIVATE_ACCESS(shapeLayer2->getGlobalMatrix().mapRect(&bounds2));
 
   auto shapeLayer3 = ShapeLayer::Make();
   shapeLayer3->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -569,7 +571,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer3->setPath(path3);
   // rootLayer->addChild(shapeLayer3);
   auto bounds3 = shapeLayer3->getBounds();
-  shapeLayer3->getGlobalMatrix().mapRect(&bounds3);
+  TGFX_PRIVATE_ACCESS(shapeLayer3->getGlobalMatrix().mapRect(&bounds3));
 
   auto shapeLayer4 = ShapeLayer::Make();
   shapeLayer4->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -578,7 +580,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer4->setPath(path4);
   // rootLayer->addChild(shapeLayer4);
   auto bounds4 = shapeLayer4->getBounds();
-  shapeLayer4->getGlobalMatrix().mapRect(&bounds4);
+  TGFX_PRIVATE_ACCESS(shapeLayer4->getGlobalMatrix().mapRect(&bounds4));
 
   auto shapeLayer5 = ShapeLayer::Make();
   shapeLayer5->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -587,7 +589,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer5->setPath(path5);
   // rootLayer->addChild(shapeLayer5);
   auto bounds5 = shapeLayer5->getBounds();
-  shapeLayer5->getGlobalMatrix().mapRect(&bounds5);
+  TGFX_PRIVATE_ACCESS(shapeLayer5->getGlobalMatrix().mapRect(&bounds5));
 
   auto shapeLayer6 = ShapeLayer::Make();
   shapeLayer6->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -596,7 +598,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer6->setPath(path6);
   // rootLayer->addChild(shapeLayer6);
   auto bounds6 = shapeLayer6->getBounds();
-  shapeLayer6->getGlobalMatrix().mapRect(&bounds6);
+  TGFX_PRIVATE_ACCESS(shapeLayer6->getGlobalMatrix().mapRect(&bounds6));
 
   auto shapeLayer7 = ShapeLayer::Make();
   shapeLayer7->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -605,7 +607,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer7->setPath(path7);
   // rootLayer->addChild(shapeLayer7);
   auto bounds7 = shapeLayer7->getBounds();
-  shapeLayer7->getGlobalMatrix().mapRect(&bounds7);
+  TGFX_PRIVATE_ACCESS(shapeLayer7->getGlobalMatrix().mapRect(&bounds7));
 
   auto shapeLayer8 = ShapeLayer::Make();
   shapeLayer8->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -614,7 +616,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer8->setPath(path8);
   // rootLayer->addChild(shapeLayer8);
   auto bounds8 = shapeLayer8->getBounds();
-  shapeLayer8->getGlobalMatrix().mapRect(&bounds8);
+  TGFX_PRIVATE_ACCESS(shapeLayer8->getGlobalMatrix().mapRect(&bounds8));
 
   auto shapeLayer9 = ShapeLayer::Make();
   shapeLayer9->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -623,7 +625,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer9->setPath(path9);
   // rootLayer->addChild(shapeLayer9);
   auto bounds9 = shapeLayer9->getBounds();
-  shapeLayer9->getGlobalMatrix().mapRect(&bounds9);
+  TGFX_PRIVATE_ACCESS(shapeLayer9->getGlobalMatrix().mapRect(&bounds9));
 
   auto shapeLayer10 = ShapeLayer::Make();
   shapeLayer10->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -632,7 +634,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer10->setPath(path10);
   // rootLayer->addChild(shapeLayer10);
   auto bounds10 = shapeLayer10->getBounds();
-  shapeLayer10->getGlobalMatrix().mapRect(&bounds10);
+  TGFX_PRIVATE_ACCESS(shapeLayer10->getGlobalMatrix().mapRect(&bounds10));
 
   auto shapeLayer11 = ShapeLayer::Make();
   shapeLayer11->setStrokeStyle(ShapeStyle::Make(Color::Black()));
@@ -641,7 +643,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   shapeLayer11->setPath(path11);
   // rootLayer->addChild(shapeLayer11);
   auto bounds11 = shapeLayer11->getBounds();
-  shapeLayer11->getGlobalMatrix().mapRect(&bounds11);
+  TGFX_PRIVATE_ACCESS(shapeLayer11->getGlobalMatrix().mapRect(&bounds11));
 
   displayList->render(surface.get());
   displayList->showDirtyRegions(true);
@@ -763,7 +765,7 @@ TGFX_TEST(LayerCacheTest, DirtyRegionTest) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerCacheTest/DirtyRegionTest11"));
 }
 
-TGFX_TEST(LayerCacheTest, TileClearWhenAllLayersRemoved) {
+TGFX_TEST_PRIVATE(LayerCacheTest, TileClearWhenAllLayersRemoved) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -785,15 +787,16 @@ TGFX_TEST(LayerCacheTest, TileClearWhenAllLayersRemoved) {
   rootLayer->addChild(blueRect);
   displayList->render(surface.get());
 
-  EXPECT_EQ(displayList->tileCaches.size(), 1u);
-  auto result = displayList->tileCaches.find(1000);
-  EXPECT_TRUE(result != displayList->tileCaches.end());
-  EXPECT_EQ(result->second->tileMap.size(), 4u);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_EQ(displayList->tileCaches.size(), 1u);
+      auto result = displayList->tileCaches.find(1000);
+      EXPECT_TRUE(result != displayList->tileCaches.end());
+      EXPECT_EQ(result->second->tileMap.size(), 4u));
 
   blueRect->removeFromParent();
   displayList->render(surface.get());
 
-  EXPECT_TRUE(displayList->tileCaches.empty());
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(displayList->tileCaches.empty()));
 
   // Test 1: Add a layer that only covers part of tile(0,0)
   // Red rectangle at (20,20) with size 60x60, only covers (20,20)-(80,80) in tile(0,0)
@@ -824,7 +827,7 @@ TGFX_TEST(LayerCacheTest, TileClearWhenAllLayersRemoved) {
  * When a shape layer uses a blend mode other than SrcOver, the layer needs pass-through background
  * mode to composite correctly, which is incompatible with subtree caching.
  */
-TGFX_TEST(LayerCacheTest, ContentBlendModeDisablesCache) {
+TGFX_TEST_PRIVATE(LayerCacheTest, ContentBlendModeDisablesCache) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -855,13 +858,13 @@ TGFX_TEST(LayerCacheTest, ContentBlendModeDisablesCache) {
 
   // First render
   displayList->render(surface.get());
-  EXPECT_TRUE(blendLayer->subtreeCache == nullptr);
-  EXPECT_TRUE(blendLayer->bitFields.hasBlendMode);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(blendLayer->subtreeCache == nullptr);
+                       EXPECT_TRUE(blendLayer->bitFields.hasBlendMode));
 
   // Second render - should still not create cache due to content blend mode
   displayList->render(surface.get());
-  EXPECT_TRUE(blendLayer->subtreeCache == nullptr);
-  EXPECT_TRUE(blendLayer->bitFields.hasBlendMode);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(blendLayer->subtreeCache == nullptr);
+                       EXPECT_TRUE(blendLayer->bitFields.hasBlendMode));
 
   // Compare the rendering result to ensure blend mode works correctly
   EXPECT_TRUE(Baseline::Compare(surface, "LayerCacheTest/ContentBlendModeDisablesCache"));
@@ -872,7 +875,7 @@ TGFX_TEST(LayerCacheTest, ContentBlendModeDisablesCache) {
  * When two layers overlap and both are modified, their dirty regions may cover the same tiles.
  * The tile should only be recycled once, not multiple times.
  */
-TGFX_TEST(LayerCacheTest, OverlappingDirtyRegions) {
+TGFX_TEST_PRIVATE(LayerCacheTest, OverlappingDirtyRegions) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -900,19 +903,17 @@ TGFX_TEST(LayerCacheTest, OverlappingDirtyRegions) {
   rootLayer->addChild(blueRect);
 
   displayList->render(surface.get());
-  EXPECT_EQ(displayList->tileCaches.size(), 1u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(displayList->tileCaches.size(), 1u));
 
   redRect->removeFromParent();
   blueRect->removeFromParent();
 
   displayList->render(surface.get());
 
-  EXPECT_EQ(displayList->tileCaches.size(), 0lu);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(displayList->tileCaches.size(), 0lu));
 
-  auto emptyTilesAfter = displayList->emptyTiles.size();
-  EXPECT_EQ(9lu, emptyTilesAfter);
+  TGFX_PRIVATE_ACCESS(auto emptyTilesAfter = displayList->emptyTiles.size();
+                       EXPECT_EQ(9lu, emptyTilesAfter));
 }
-
-#endif  // TGFX_TEST_ACCESS_PRIVATE
 
 }  // namespace tgfx

--- a/test/src/LayerCacheTest.cpp
+++ b/test/src/LayerCacheTest.cpp
@@ -29,6 +29,8 @@
 
 namespace tgfx {
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
+
 TGFX_TEST(LayerCacheTest, LayerCache) {
   ContextScope scope;
   auto context = scope.getContext();
@@ -910,5 +912,7 @@ TGFX_TEST(LayerCacheTest, OverlappingDirtyRegions) {
   auto emptyTilesAfter = displayList->emptyTiles.size();
   EXPECT_EQ(9lu, emptyTilesAfter);
 }
+
+#endif  // TGFX_TEST_ACCESS_PRIVATE
 
 }  // namespace tgfx

--- a/test/src/LayerFilterTest.cpp
+++ b/test/src/LayerFilterTest.cpp
@@ -185,9 +185,11 @@ TGFX_TEST(LayerFilterTest, blurLayerFilter) {
   auto imageFilter = std::static_pointer_cast<GaussianBlurImageFilter>(blur->getImageFilter(0.5f));
   auto imageFilter2 = std::static_pointer_cast<GaussianBlurImageFilter>(
       ImageFilter::Blur(65.f, 65.f, TileMode::Clamp));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(imageFilter->blurrinessX, imageFilter2->blurrinessX);
   EXPECT_EQ(imageFilter->blurrinessY, imageFilter2->blurrinessY);
   EXPECT_EQ(imageFilter->tileMode, imageFilter2->tileMode);
+#endif
 
   EXPECT_EQ(blur->getImageFilter(0.5f)->filterBounds(Rect::MakeWH(200, 200)),
             imageFilter2->filterBounds(Rect::MakeWH(200, 200)));

--- a/test/src/LayerFilterTest.cpp
+++ b/test/src/LayerFilterTest.cpp
@@ -185,11 +185,9 @@ TGFX_TEST(LayerFilterTest, blurLayerFilter) {
   auto imageFilter = std::static_pointer_cast<GaussianBlurImageFilter>(blur->getImageFilter(0.5f));
   auto imageFilter2 = std::static_pointer_cast<GaussianBlurImageFilter>(
       ImageFilter::Blur(65.f, 65.f, TileMode::Clamp));
-  TGFX_PRIVATE_ACCESS(
-    EXPECT_EQ(imageFilter->blurrinessX, imageFilter2->blurrinessX);
-    EXPECT_EQ(imageFilter->blurrinessY, imageFilter2->blurrinessY);
-    EXPECT_EQ(imageFilter->tileMode, imageFilter2->tileMode);
-  )
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(imageFilter->blurrinessX, imageFilter2->blurrinessX);
+                      EXPECT_EQ(imageFilter->blurrinessY, imageFilter2->blurrinessY);
+                      EXPECT_EQ(imageFilter->tileMode, imageFilter2->tileMode);)
 
   EXPECT_EQ(blur->getImageFilter(0.5f)->filterBounds(Rect::MakeWH(200, 200)),
             imageFilter2->filterBounds(Rect::MakeWH(200, 200)));

--- a/test/src/LayerFilterTest.cpp
+++ b/test/src/LayerFilterTest.cpp
@@ -185,11 +185,11 @@ TGFX_TEST(LayerFilterTest, blurLayerFilter) {
   auto imageFilter = std::static_pointer_cast<GaussianBlurImageFilter>(blur->getImageFilter(0.5f));
   auto imageFilter2 = std::static_pointer_cast<GaussianBlurImageFilter>(
       ImageFilter::Blur(65.f, 65.f, TileMode::Clamp));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(imageFilter->blurrinessX, imageFilter2->blurrinessX);
-  EXPECT_EQ(imageFilter->blurrinessY, imageFilter2->blurrinessY);
-  EXPECT_EQ(imageFilter->tileMode, imageFilter2->tileMode);
-#endif
+  TGFX_PRIVATE_ACCESS(
+    EXPECT_EQ(imageFilter->blurrinessX, imageFilter2->blurrinessX);
+    EXPECT_EQ(imageFilter->blurrinessY, imageFilter2->blurrinessY);
+    EXPECT_EQ(imageFilter->tileMode, imageFilter2->tileMode);
+  )
 
   EXPECT_EQ(blur->getImageFilter(0.5f)->filterBounds(Rect::MakeWH(200, 200)),
             imageFilter2->filterBounds(Rect::MakeWH(200, 200)));

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -370,6 +370,7 @@ TGFX_TEST(LayerMaskTest, textMask) {
 }
 
 TGFX_TEST(LayerMaskTest, MaskOnwer) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -408,6 +409,7 @@ TGFX_TEST(LayerMaskTest, MaskOnwer) {
   layer2->setMask(nullptr);
   EXPECT_EQ(layer->mask(), nullptr);
   EXPECT_EQ(mask->maskOwner, nullptr);
+#endif
 }
 
 TGFX_TEST(LayerMaskTest, MaskAlpha) {
@@ -527,7 +529,11 @@ TGFX_TEST(LayerMaskTest, HighZoomWithMask) {
   ASSERT_TRUE(context != nullptr);
   auto proxy =
       RenderTargetProxy::Make(context, 1622, 1436, false, 1, false, ImageOrigin::BottomLeft);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto surface = Surface::MakeFrom(std::move(proxy), 0, true);
+#else
+  auto surface = Surface::Make(context, 1622, 1436);
+#endif
   auto displayList = std::make_unique<DisplayList>();
 
   // Root layer with matrix3D transform
@@ -601,7 +607,11 @@ TGFX_TEST(LayerMaskTest, HighZoomWithMask) {
   // Test Tiled mode
   auto proxy2 =
       RenderTargetProxy::Make(context, 1622, 1436, false, 1, false, ImageOrigin::BottomLeft);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto surface2 = Surface::MakeFrom(std::move(proxy2), 0, true);
+#else
+  auto surface2 = Surface::Make(context, 1622, 1436);
+#endif
   auto displayList2 = std::make_unique<DisplayList>();
   displayList2->root()->addChild(root);
   displayList2->setRenderMode(RenderMode::Tiled);
@@ -753,6 +763,7 @@ TGFX_TEST(LayerMaskTest, RoundRectMaskWithTiledRender) {
 }
 
 TGFX_TEST(LayerMaskTest, MaskInvalidation) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -851,6 +862,7 @@ TGFX_TEST(LayerMaskTest, MaskInvalidation) {
   EXPECT_FALSE(child->bitFields.dirtyTransform);
   EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
   EXPECT_FALSE(root->bitFields.dirtyDescendents);
+#endif
 }
 
 TGFX_TEST(LayerMaskTest, solidLayerWithTwoFillMask) {

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -600,7 +600,8 @@ TGFX_TEST(LayerMaskTest, HighZoomWithMask) {
   // Test Tiled mode
   auto texture2 = context->gpu()->createTexture({1622, 1436, PixelFormat::RGBA_8888});
   ASSERT_TRUE(texture2 != nullptr);
-  auto surface2 = Surface::MakeFrom(context, texture2->getBackendTexture(), ImageOrigin::BottomLeft);
+  auto surface2 =
+      Surface::MakeFrom(context, texture2->getBackendTexture(), ImageOrigin::BottomLeft);
   auto displayList2 = std::make_unique<DisplayList>();
   displayList2->root()->addChild(root);
   displayList2->setRenderMode(RenderMode::Tiled);
@@ -783,14 +784,14 @@ TGFX_TEST_PRIVATE(LayerMaskTest, MaskInvalidation) {
 
   // Verify all dirty flags are cleared after render.
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
-                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
+                      EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Set mask, both child and maskLayer should be marked dirty.
   child->setMask(maskLayer);
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(child->bitFields.dirtyTransform);
-                       EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_TRUE(root->bitFields.dirtyDescendents));
+                      EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_TRUE(root->bitFields.dirtyDescendents));
 
   // Second render with mask. maskLayer should be hidden (used as mask, skipped via maskOwner).
   displayList->render(surface.get());
@@ -798,14 +799,14 @@ TGFX_TEST_PRIVATE(LayerMaskTest, MaskInvalidation) {
 
   // Verify dirty flags are cleared again.
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
-                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
+                      EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Remove mask, both child and old maskLayer should be marked dirty.
   child->setMask(nullptr);
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(child->bitFields.dirtyTransform);
-                       EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_TRUE(root->bitFields.dirtyDescendents));
+                      EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_TRUE(root->bitFields.dirtyDescendents));
 
   // Third render without mask. Both child and maskLayer should be visible again.
   displayList->render(surface.get());
@@ -813,8 +814,8 @@ TGFX_TEST_PRIVATE(LayerMaskTest, MaskInvalidation) {
 
   // Verify dirty flags are cleared.
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
-                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
+                      EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Create a second mask and set it on child.
   Path maskPath2;
@@ -830,15 +831,15 @@ TGFX_TEST_PRIVATE(LayerMaskTest, MaskInvalidation) {
 
   // Verify dirty flags are cleared.
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
-                       EXPECT_FALSE(maskLayer2->bitFields.dirtyTransform);
-                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
+                      EXPECT_FALSE(maskLayer2->bitFields.dirtyTransform);
+                      EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Switch mask from maskLayer2 to maskLayer. Both old and new mask should be marked dirty.
   child->setMask(maskLayer);
   TGFX_PRIVATE_ACCESS(EXPECT_TRUE(child->bitFields.dirtyTransform);
-                       EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_TRUE(maskLayer2->bitFields.dirtyTransform);
-                       EXPECT_TRUE(root->bitFields.dirtyDescendents));
+                      EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_TRUE(maskLayer2->bitFields.dirtyTransform);
+                      EXPECT_TRUE(root->bitFields.dirtyDescendents));
 
   // Remove maskLayer2 so it won't render as a normal child.
   maskLayer2->removeFromParent();
@@ -848,8 +849,8 @@ TGFX_TEST_PRIVATE(LayerMaskTest, MaskInvalidation) {
 
   // Verify dirty flags are cleared.
   TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
-                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
+                      EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                      EXPECT_FALSE(root->bitFields.dirtyDescendents));
 }
 
 TGFX_TEST(LayerMaskTest, solidLayerWithTwoFillMask) {

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -16,7 +16,6 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "gpu/proxies/RenderTargetProxy.h"
 #include "layers/RootLayer.h"
 #include "tgfx/layers/DisplayList.h"
 #include "tgfx/layers/ImageLayer.h"
@@ -369,8 +368,7 @@ TGFX_TEST(LayerMaskTest, textMask) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/textMask"));
 }
 
-TGFX_TEST(LayerMaskTest, MaskOnwer) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerMaskTest, MaskOnwer) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -394,22 +392,21 @@ TGFX_TEST(LayerMaskTest, MaskOnwer) {
 
   layer->setMask(mask);
   EXPECT_EQ(layer->mask(), mask);
-  EXPECT_EQ(mask->maskOwner, layer.get());
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(mask->maskOwner, layer.get()));
 
   layer2->setMask(mask);
   EXPECT_EQ(layer->mask(), nullptr);
-  EXPECT_EQ(mask->maskOwner, layer2.get());
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(mask->maskOwner, layer2.get()));
 
-  EXPECT_TRUE(layer2->bitFields.dirtyContent);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(layer2->bitFields.dirtyContent));
   displayList->render(surface.get());
-  EXPECT_FALSE(layer->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(layer->bitFields.dirtyDescendents));
   mask->setAlpha(0.5f);
-  EXPECT_TRUE(layer->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(layer->bitFields.dirtyDescendents));
 
   layer2->setMask(nullptr);
   EXPECT_EQ(layer->mask(), nullptr);
-  EXPECT_EQ(mask->maskOwner, nullptr);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(mask->maskOwner, nullptr));
 }
 
 TGFX_TEST(LayerMaskTest, MaskAlpha) {
@@ -527,13 +524,9 @@ TGFX_TEST(LayerMaskTest, HighZoomWithMask) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
-  auto proxy =
-      RenderTargetProxy::Make(context, 1622, 1436, false, 1, false, ImageOrigin::BottomLeft);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto surface = Surface::MakeFrom(std::move(proxy), 0, true);
-#else
-  auto surface = Surface::Make(context, 1622, 1436);
-#endif
+  auto texture = context->gpu()->createTexture({1622, 1436, PixelFormat::RGBA_8888});
+  ASSERT_TRUE(texture != nullptr);
+  auto surface = Surface::MakeFrom(context, texture->getBackendTexture(), ImageOrigin::BottomLeft);
   auto displayList = std::make_unique<DisplayList>();
 
   // Root layer with matrix3D transform
@@ -605,13 +598,9 @@ TGFX_TEST(LayerMaskTest, HighZoomWithMask) {
   backgroundBlurLayer->setLayerStyles({BackgroundBlurStyle::Make(10, 10)});
   rectLayer->addChild(backgroundBlurLayer);
   // Test Tiled mode
-  auto proxy2 =
-      RenderTargetProxy::Make(context, 1622, 1436, false, 1, false, ImageOrigin::BottomLeft);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto surface2 = Surface::MakeFrom(std::move(proxy2), 0, true);
-#else
-  auto surface2 = Surface::Make(context, 1622, 1436);
-#endif
+  auto texture2 = context->gpu()->createTexture({1622, 1436, PixelFormat::RGBA_8888});
+  ASSERT_TRUE(texture2 != nullptr);
+  auto surface2 = Surface::MakeFrom(context, texture2->getBackendTexture(), ImageOrigin::BottomLeft);
   auto displayList2 = std::make_unique<DisplayList>();
   displayList2->root()->addChild(root);
   displayList2->setRenderMode(RenderMode::Tiled);
@@ -762,8 +751,7 @@ TGFX_TEST(LayerMaskTest, RoundRectMaskWithTiledRender) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/RoundRectMaskWithTiledRender"));
 }
 
-TGFX_TEST(LayerMaskTest, MaskInvalidation) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerMaskTest, MaskInvalidation) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -794,39 +782,39 @@ TGFX_TEST(LayerMaskTest, MaskInvalidation) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskInvalidation_NoMask"));
 
   // Verify all dirty flags are cleared after render.
-  EXPECT_FALSE(child->bitFields.dirtyTransform);
-  EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_FALSE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
+                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Set mask, both child and maskLayer should be marked dirty.
   child->setMask(maskLayer);
-  EXPECT_TRUE(child->bitFields.dirtyTransform);
-  EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_TRUE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(child->bitFields.dirtyTransform);
+                       EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_TRUE(root->bitFields.dirtyDescendents));
 
   // Second render with mask. maskLayer should be hidden (used as mask, skipped via maskOwner).
   displayList->render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskInvalidation_WithMask"));
 
   // Verify dirty flags are cleared again.
-  EXPECT_FALSE(child->bitFields.dirtyTransform);
-  EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_FALSE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
+                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Remove mask, both child and old maskLayer should be marked dirty.
   child->setMask(nullptr);
-  EXPECT_TRUE(child->bitFields.dirtyTransform);
-  EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_TRUE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(child->bitFields.dirtyTransform);
+                       EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_TRUE(root->bitFields.dirtyDescendents));
 
   // Third render without mask. Both child and maskLayer should be visible again.
   displayList->render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskInvalidation_NoMask"));
 
   // Verify dirty flags are cleared.
-  EXPECT_FALSE(child->bitFields.dirtyTransform);
-  EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_FALSE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
+                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Create a second mask and set it on child.
   Path maskPath2;
@@ -841,16 +829,16 @@ TGFX_TEST(LayerMaskTest, MaskInvalidation) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskInvalidation_SwitchMask"));
 
   // Verify dirty flags are cleared.
-  EXPECT_FALSE(child->bitFields.dirtyTransform);
-  EXPECT_FALSE(maskLayer2->bitFields.dirtyTransform);
-  EXPECT_FALSE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
+                       EXPECT_FALSE(maskLayer2->bitFields.dirtyTransform);
+                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
 
   // Switch mask from maskLayer2 to maskLayer. Both old and new mask should be marked dirty.
   child->setMask(maskLayer);
-  EXPECT_TRUE(child->bitFields.dirtyTransform);
-  EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_TRUE(maskLayer2->bitFields.dirtyTransform);
-  EXPECT_TRUE(root->bitFields.dirtyDescendents);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(child->bitFields.dirtyTransform);
+                       EXPECT_TRUE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_TRUE(maskLayer2->bitFields.dirtyTransform);
+                       EXPECT_TRUE(root->bitFields.dirtyDescendents));
 
   // Remove maskLayer2 so it won't render as a normal child.
   maskLayer2->removeFromParent();
@@ -859,10 +847,9 @@ TGFX_TEST(LayerMaskTest, MaskInvalidation) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskInvalidation_WithMask"));
 
   // Verify dirty flags are cleared.
-  EXPECT_FALSE(child->bitFields.dirtyTransform);
-  EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
-  EXPECT_FALSE(root->bitFields.dirtyDescendents);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(child->bitFields.dirtyTransform);
+                       EXPECT_FALSE(maskLayer->bitFields.dirtyTransform);
+                       EXPECT_FALSE(root->bitFields.dirtyDescendents));
 }
 
 TGFX_TEST(LayerMaskTest, solidLayerWithTwoFillMask) {

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -176,13 +176,17 @@ TGFX_TEST(LayerTest, LayerTreeCircle) {
 
   EXPECT_FALSE(grandChild->addChild(parent));
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_FALSE(parent->addChild(displayList->_root));
 
   EXPECT_FALSE(parent->contains(displayList->_root));
+#endif
 
   EXPECT_FALSE(child->contains(parent));
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(displayList->_root, displayList->_root);
+#endif
 
   EXPECT_FALSE(grandChild->contains(parent));
 
@@ -252,6 +256,7 @@ TGFX_TEST(LayerTest, imageLayer) {
 }
 
 TGFX_TEST(LayerTest, Layer_getTotalMatrix) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto parent = Layer::Make();
   // Should have no effect on the total matrix since it has no parent.
   parent->setMatrix(Matrix::MakeTrans(10, 10));
@@ -285,6 +290,7 @@ TGFX_TEST(LayerTest, Layer_getTotalMatrix) {
   EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix.getTranslateX(), grandChildTotalMatrix.getTranslateX());
   EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix.getTranslateY(),
                   grandChildTotalMatrix.getTranslateX() + 10.0f * std::sqrt(2.0f));
+#endif
 }
 
 /**
@@ -331,7 +337,9 @@ TGFX_TEST(LayerTest, Layer_localToGlobal) {
   auto layerA2 = Layer::Make();
   layerA2->setMatrix(Matrix::MakeTrans(10, 10) * Matrix::MakeRotate(45.0f));
   layerA1->addChild(layerA2);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto layer2GlobalMat = layerA2->getGlobalMatrix();
+#endif
 
   auto layerA3 = Layer::Make();
   layerA3->setMatrix(Matrix::MakeTrans(10 * std::sqrt(2.0f), 10 * std::sqrt(2.0f)) *
@@ -345,8 +353,10 @@ TGFX_TEST(LayerTest, Layer_localToGlobal) {
 
   auto pointEInLayer2 = Point::Make(8, 8);
   auto pointEInGlobal = layerA2->localToGlobal(pointEInLayer2);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_EQ(pointEInGlobal, Point::Make(layer2GlobalMat.getTranslateX(),
                                         layer2GlobalMat.getTranslateY() + 8.0f * std::sqrt(2.0f)));
+#endif
 
   auto layer4 = Layer::Make();
   layer4->setMatrix(Matrix::MakeTrans(5, -5) * Matrix::MakeRotate(-60.0f));
@@ -1032,7 +1042,9 @@ TGFX_TEST(LayerTest, hitTestPoint) {
   shaperLayer1->setMatrix(Matrix::MakeTrans(100.0f, 50.0f));
   rootLayer->addChild(shaperLayer1);
   auto shaperLayer1Bounds = shaperLayer1->getBounds();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   shaperLayer1->getGlobalMatrix().mapRect(&shaperLayer1Bounds);
+#endif
   printf("shaperLayer1Bounds: (%f, %f, %f, %f)\n", shaperLayer1Bounds.left, shaperLayer1Bounds.top,
          shaperLayer1Bounds.right, shaperLayer1Bounds.bottom);
 
@@ -1047,7 +1059,9 @@ TGFX_TEST(LayerTest, hitTestPoint) {
   shaperLayer2->setFillStyle(fillStyle2);
   rootLayer->addChild(shaperLayer2);
   auto shaperLayer2Bounds = shaperLayer2->getBounds();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   shaperLayer2->getGlobalMatrix().mapRect(&shaperLayer2Bounds);
+#endif
   printf("shaperLayer2Bounds: (%f, %f, %f, %f)\n", shaperLayer2Bounds.left, shaperLayer2Bounds.top,
          shaperLayer2Bounds.right, shaperLayer2Bounds.bottom);
 
@@ -1613,7 +1627,11 @@ TGFX_TEST(LayerTest, BottomLeftSurface) {
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
   auto proxy = RenderTargetProxy::Make(context, 200, 200, false, 1, false, ImageOrigin::BottomLeft);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto surface = Surface::MakeFrom(std::move(proxy), 0, true);
+#else
+  auto surface = Surface::Make(context, 200, 200);
+#endif
 
   // parent
   auto parentFrame = tgfx::Rect::MakeXYWH(60, 110, 40, 40);
@@ -1714,6 +1732,7 @@ TGFX_TEST(LayerTest, PartialDrawLayer) {
 }
 
 TGFX_TEST(LayerTest, ContourTest) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1829,9 +1848,11 @@ TGFX_TEST(LayerTest, ContourTest) {
   canvas->clear();
   canvas->drawPicture(allPicture);
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/ContourTest"));
+#endif
 }
 
 TGFX_TEST(LayerTest, ContourMatchesContent) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1912,9 +1933,11 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   gradientContext.finishRecordingAsPicture();
   // Gradient with opaque colors should match.
   EXPECT_TRUE(gradientMatch);
+#endif
 }
 
 TGFX_TEST(LayerTest, ContourContainsOpaqueBounds) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1964,9 +1987,11 @@ TGFX_TEST(LayerTest, ContourContainsOpaqueBounds) {
   auto picture2 = contourContext2.finishRecordingAsPicture();
   // Both parent and child contours should be drawn.
   EXPECT_EQ(picture2->drawCount, 2u);
+#endif
 }
 
 TGFX_TEST(LayerTest, GetContourImage) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1997,9 +2022,11 @@ TGFX_TEST(LayerTest, GetContourImage) {
   canvas->clear();
   canvas->drawImage(contourImage, offset.x, offset.y);
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/GetContourImage"));
+#endif
 }
 
 TGFX_TEST(LayerTest, ContourWithMask) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -2036,6 +2063,7 @@ TGFX_TEST(LayerTest, ContourWithMask) {
   drawCanvas->clear();
   drawCanvas->drawPicture(picture);
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/ContourWithMask"));
+#endif
 }
 
 TGFX_TEST(LayerTest, DiffFilterModeImagePattern) {
@@ -2450,6 +2478,7 @@ TGFX_TEST(LayerTest, DisplayListBackground) {
 }
 
 TGFX_TEST(LayerTest, LayerRecorder) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -2653,9 +2682,11 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     ASSERT_TRUE(content != nullptr);
     EXPECT_EQ(content->type(), LayerContent::Type::Rect);
   }
+#endif
 }
 
 TGFX_TEST(LayerTest, LayerRecorderMatrix) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -2764,6 +2795,7 @@ TGFX_TEST(LayerTest, LayerRecorderMatrix) {
   canvas2->concat(Matrix::MakeTrans(150, 0));
   content7->drawDefault(canvas2, 1.0f, true);
   EXPECT_TRUE(Baseline::Compare(surface2, "LayerTest/LayerRecorderMatrixStroke"));
+#endif
 }
 
 TGFX_TEST(LayerTest, GetRotateBounds) {
@@ -2936,6 +2968,7 @@ TGFX_TEST(LayerTest, SetChildrenOptimization) {
   EXPECT_EQ(grandChildLayer->children().size(), 0u);
 
   // Test Case 10: Root layer as child (should be prevented)
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto rootLayer = RootLayer::Make();
   rootLayer->_root = rootLayer.get();
 
@@ -2947,6 +2980,7 @@ TGFX_TEST(LayerTest, SetChildrenOptimization) {
   EXPECT_EQ(parent->children()[0], layerA);
   EXPECT_EQ(parent->children()[1], layerB);
   EXPECT_FALSE(parent->contains(rootLayer));
+#endif
 
   // Test Case 11: Self as child (should be prevented)
   std::vector<std::shared_ptr<Layer>> selfAsChild = {layerA, parent, layerB};
@@ -2993,6 +3027,7 @@ TGFX_TEST(LayerTest, SetChildrenOptimization) {
 }
 
 TGFX_TEST(LayerTest, SetChildrenLISValidation) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   // Test that the LIS algorithm correctly identifies which layers need to be marked dirty
   // by verifying that layers maintaining relative order are not unnecessarily invalidated
 
@@ -3112,6 +3147,7 @@ TGFX_TEST(LayerTest, SetChildrenLISValidation) {
   singleParent->setChildren(single);
   EXPECT_EQ(singleParent->children().size(), 1u);
   EXPECT_FALSE(singleLayer->bitFields.dirtyTransform);
+#endif
 }
 
 TGFX_TEST(LayerTest, Layer3DContextAPI) {

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -21,7 +21,6 @@
 #include "core/filters/GaussianBlurImageFilter.h"
 #include "core/shaders/GradientShader.h"
 #include "core/utils/MathExtra.h"
-#include "gpu/proxies/RenderTargetProxy.h"
 #include "layers/DrawArgs.h"
 #include "layers/OpaqueContext.h"
 #include "layers/RootLayer.h"
@@ -176,17 +175,14 @@ TGFX_TEST(LayerTest, LayerTreeCircle) {
 
   EXPECT_FALSE(grandChild->addChild(parent));
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_FALSE(parent->addChild(displayList->_root));
-
-  EXPECT_FALSE(parent->contains(displayList->_root));
-#endif
+  TGFX_PRIVATE_ACCESS(
+    EXPECT_FALSE(parent->addChild(displayList->_root));
+    EXPECT_FALSE(parent->contains(displayList->_root));
+  )
 
   EXPECT_FALSE(child->contains(parent));
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(displayList->_root, displayList->_root);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(displayList->_root, displayList->_root);)
 
   EXPECT_FALSE(grandChild->contains(parent));
 
@@ -255,8 +251,7 @@ TGFX_TEST(LayerTest, imageLayer) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/imageLayer"));
 }
 
-TGFX_TEST(LayerTest, Layer_getTotalMatrix) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, Layer_getTotalMatrix) {
   auto parent = Layer::Make();
   // Should have no effect on the total matrix since it has no parent.
   parent->setMatrix(Matrix::MakeTrans(10, 10));
@@ -274,8 +269,8 @@ TGFX_TEST(LayerTest, Layer_getTotalMatrix) {
   child->addChild(grandChild);
   grandChild->addChild(greatGrandson);
 
-  auto greatGrandsonTotalMatrix = greatGrandson->getGlobalMatrix();
-  EXPECT_EQ(greatGrandsonTotalMatrix, Matrix3D::MakeTranslate(30, 30, 0));
+  TGFX_PRIVATE_ACCESS(auto greatGrandsonTotalMatrix = greatGrandson->getGlobalMatrix();
+                       EXPECT_EQ(greatGrandsonTotalMatrix, Matrix3D::MakeTranslate(30, 30, 0)));
 
   EXPECT_EQ(greatGrandson->matrix(), Matrix::MakeTrans(10, 10));
   EXPECT_EQ(grandChild->matrix(), Matrix::MakeTrans(10, 10));
@@ -285,12 +280,13 @@ TGFX_TEST(LayerTest, Layer_getTotalMatrix) {
   auto rotateMat = Matrix::MakeRotate(45);
   greatGrandson->setMatrix(rotateMat * greatGrandson->matrix());
 
-  greatGrandsonTotalMatrix = greatGrandson->getGlobalMatrix();
-  auto grandChildTotalMatrix = grandChild->getGlobalMatrix();
-  EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix.getTranslateX(), grandChildTotalMatrix.getTranslateX());
-  EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix.getTranslateY(),
-                  grandChildTotalMatrix.getTranslateX() + 10.0f * std::sqrt(2.0f));
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto greatGrandsonTotalMatrix2 = greatGrandson->getGlobalMatrix();
+      auto grandChildTotalMatrix = grandChild->getGlobalMatrix();
+      EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix2.getTranslateX(),
+                       grandChildTotalMatrix.getTranslateX());
+      EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix2.getTranslateY(),
+                       grandChildTotalMatrix.getTranslateX() + 10.0f * std::sqrt(2.0f)));
 }
 
 /**
@@ -337,9 +333,7 @@ TGFX_TEST(LayerTest, Layer_localToGlobal) {
   auto layerA2 = Layer::Make();
   layerA2->setMatrix(Matrix::MakeTrans(10, 10) * Matrix::MakeRotate(45.0f));
   layerA1->addChild(layerA2);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto layer2GlobalMat = layerA2->getGlobalMatrix();
-#endif
+  TGFX_PRIVATE_ACCESS(auto layer2GlobalMat = layerA2->getGlobalMatrix();)
 
   auto layerA3 = Layer::Make();
   layerA3->setMatrix(Matrix::MakeTrans(10 * std::sqrt(2.0f), 10 * std::sqrt(2.0f)) *
@@ -353,10 +347,10 @@ TGFX_TEST(LayerTest, Layer_localToGlobal) {
 
   auto pointEInLayer2 = Point::Make(8, 8);
   auto pointEInGlobal = layerA2->localToGlobal(pointEInLayer2);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_EQ(pointEInGlobal, Point::Make(layer2GlobalMat.getTranslateX(),
-                                        layer2GlobalMat.getTranslateY() + 8.0f * std::sqrt(2.0f)));
-#endif
+  TGFX_PRIVATE_ACCESS(
+    EXPECT_EQ(pointEInGlobal, Point::Make(layer2GlobalMat.getTranslateX(),
+                                          layer2GlobalMat.getTranslateY() + 8.0f * std::sqrt(2.0f)));
+  )
 
   auto layer4 = Layer::Make();
   layer4->setMatrix(Matrix::MakeTrans(5, -5) * Matrix::MakeRotate(-60.0f));
@@ -1042,9 +1036,7 @@ TGFX_TEST(LayerTest, hitTestPoint) {
   shaperLayer1->setMatrix(Matrix::MakeTrans(100.0f, 50.0f));
   rootLayer->addChild(shaperLayer1);
   auto shaperLayer1Bounds = shaperLayer1->getBounds();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  shaperLayer1->getGlobalMatrix().mapRect(&shaperLayer1Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(shaperLayer1->getGlobalMatrix().mapRect(&shaperLayer1Bounds);)
   printf("shaperLayer1Bounds: (%f, %f, %f, %f)\n", shaperLayer1Bounds.left, shaperLayer1Bounds.top,
          shaperLayer1Bounds.right, shaperLayer1Bounds.bottom);
 
@@ -1059,9 +1051,7 @@ TGFX_TEST(LayerTest, hitTestPoint) {
   shaperLayer2->setFillStyle(fillStyle2);
   rootLayer->addChild(shaperLayer2);
   auto shaperLayer2Bounds = shaperLayer2->getBounds();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  shaperLayer2->getGlobalMatrix().mapRect(&shaperLayer2Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(shaperLayer2->getGlobalMatrix().mapRect(&shaperLayer2Bounds);)
   printf("shaperLayer2Bounds: (%f, %f, %f, %f)\n", shaperLayer2Bounds.left, shaperLayer2Bounds.top,
          shaperLayer2Bounds.right, shaperLayer2Bounds.bottom);
 
@@ -1626,12 +1616,9 @@ TGFX_TEST(LayerTest, BottomLeftSurface) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
-  auto proxy = RenderTargetProxy::Make(context, 200, 200, false, 1, false, ImageOrigin::BottomLeft);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto surface = Surface::MakeFrom(std::move(proxy), 0, true);
-#else
-  auto surface = Surface::Make(context, 200, 200);
-#endif
+  auto texture = context->gpu()->createTexture({200, 200, PixelFormat::RGBA_8888});
+  ASSERT_TRUE(texture != nullptr);
+  auto surface = Surface::MakeFrom(context, texture->getBackendTexture(), ImageOrigin::BottomLeft);
 
   // parent
   auto parentFrame = tgfx::Rect::MakeXYWH(60, 110, 40, 40);
@@ -1731,8 +1718,7 @@ TGFX_TEST(LayerTest, PartialDrawLayer) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/PartialDrawLayer_shapeLayer"));
 }
 
-TGFX_TEST(LayerTest, ContourTest) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, ContourTest) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1755,10 +1741,11 @@ TGFX_TEST(LayerTest, ContourTest) {
   allSolidLayer->addFillStyle(ShapeStyle::Make(Color::Red()));
   allSolidLayer->addFillStyle(ShapeStyle::Make(Color::Blue()));
   OpaqueContext allSolidContext;
-  auto allSolidCanvas = allSolidContext.beginRecording();
-  allSolidLayer->drawContour(drawArgs, allSolidCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      auto allSolidCanvas = allSolidContext.beginRecording();
+      allSolidLayer->drawContour(drawArgs, allSolidCanvas, 1.0f, BlendMode::SrcOver));
   auto allSolidPicture = allSolidContext.finishRecordingAsPicture();
-  EXPECT_EQ(allSolidPicture->drawCount, 1u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(allSolidPicture->drawCount, 1u));
 
   // Case 2: Same geometry with all image shader fills should collect all (no dedup).
   auto allImageLayer = ShapeLayer::Make();
@@ -1768,10 +1755,11 @@ TGFX_TEST(LayerTest, ContourTest) {
   allImageLayer->addFillStyle(imageStyle1);
   allImageLayer->addFillStyle(imageStyle2);
   OpaqueContext allImageContext;
-  auto allImageCanvas = allImageContext.beginRecording();
-  allImageLayer->drawContour(drawArgs, allImageCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      auto allImageCanvas = allImageContext.beginRecording();
+      allImageLayer->drawContour(drawArgs, allImageCanvas, 1.0f, BlendMode::SrcOver));
   auto allImagePicture = allImageContext.finishRecordingAsPicture();
-  EXPECT_EQ(allImagePicture->drawCount, 2u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(allImagePicture->drawCount, 2u));
 
   // Case 3: Same geometry with image-image-solid order should dedup to 1 contour.
   // This exposes the bug where single-pass logic collects both image shaders first,
@@ -1785,10 +1773,11 @@ TGFX_TEST(LayerTest, ContourTest) {
   mixedFillsLayer->addFillStyle(ShapeStyle::Make(Color::Green()));
   OpaqueContext mixedFillsContext;
   auto mixedFillsCanvas = mixedFillsContext.beginRecording();
-  mixedFillsLayer->drawContour(drawArgs, mixedFillsCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      mixedFillsLayer->drawContour(drawArgs, mixedFillsCanvas, 1.0f, BlendMode::SrcOver));
   auto mixedFillsPicture = mixedFillsContext.finishRecordingAsPicture();
   // Should be 1 (only first collected). Buggy single-pass would return 2.
-  EXPECT_EQ(mixedFillsPicture->drawCount, 1u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(mixedFillsPicture->drawCount, 1u));
 
   // Case 4: Multiple groups with different dedup requirements.
   // Group 1 (image-image): collect all (2). Group 2 (solid-solid): dedup to 1.
@@ -1807,10 +1796,11 @@ TGFX_TEST(LayerTest, ContourTest) {
   twoGroupsLayer->addChild(childLayer);
   OpaqueContext twoGroupsContext;
   auto twoGroupsCanvas = twoGroupsContext.beginRecording();
-  twoGroupsLayer->drawContour(drawArgs, twoGroupsCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      twoGroupsLayer->drawContour(drawArgs, twoGroupsCanvas, 1.0f, BlendMode::SrcOver));
   auto twoGroupsPicture = twoGroupsContext.finishRecordingAsPicture();
   // Group 1: 2 (all image shaders), Group 2: 1 (deduped) = 3 total.
-  EXPECT_EQ(twoGroupsPicture->drawCount, 3u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(twoGroupsPicture->drawCount, 3u));
 
   // Case 5: Stroke contour test - same geometry with same stroke should dedup.
   // ShapeLayer without fillStyle adds a transparent fill content (no stroke),
@@ -1824,10 +1814,11 @@ TGFX_TEST(LayerTest, ContourTest) {
   strokeTestLayer->addStrokeStyle(ShapeStyle::Make(Color::Blue()));
   OpaqueContext strokeTestContext;
   auto strokeTestCanvas = strokeTestContext.beginRecording();
-  strokeTestLayer->drawContour(drawArgs, strokeTestCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      strokeTestLayer->drawContour(drawArgs, strokeTestCanvas, 1.0f, BlendMode::SrcOver));
   auto strokeTestPicture = strokeTestContext.finishRecordingAsPicture();
   // 1 (transparent fill) + 1 (strokes deduped) = 2 contours.
-  EXPECT_EQ(strokeTestPicture->drawCount, 2u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(strokeTestPicture->drawCount, 2u));
 
   // Draw all to canvas for baseline comparison.
   auto rootLayer = ShapeLayer::Make();
@@ -1838,21 +1829,19 @@ TGFX_TEST(LayerTest, ContourTest) {
   rootLayer->addChild(strokeTestLayer);
   OpaqueContext allContext;
   auto allCanvas = allContext.beginRecording();
-  rootLayer->drawContour(drawArgs, allCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(rootLayer->drawContour(drawArgs, allCanvas, 1.0f, BlendMode::SrcOver));
   auto allPicture = allContext.finishRecordingAsPicture();
   // 1 + 2 + 1 + 3 + 2 = 9
-  EXPECT_EQ(allPicture->drawCount, 9u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(allPicture->drawCount, 9u));
 
   surface = Surface::Make(context, 200, 300);
   auto canvas = surface->getCanvas();
   canvas->clear();
   canvas->drawPicture(allPicture);
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/ContourTest"));
-#endif
 }
 
-TGFX_TEST(LayerTest, ContourMatchesContent) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1867,9 +1856,11 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   opaqueLayer->addFillStyle(ShapeStyle::Make(Color::Red()));
   OpaqueContext opaqueContext;
   auto opaqueCanvas = opaqueContext.beginRecording();
-  bool opaqueMatch = opaqueLayer->drawContour(drawArgs, opaqueCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      bool opaqueMatch =
+          opaqueLayer->drawContour(drawArgs, opaqueCanvas, 1.0f, BlendMode::SrcOver);
+      EXPECT_TRUE(opaqueMatch));
   opaqueContext.finishRecordingAsPicture();
-  EXPECT_TRUE(opaqueMatch);
 
   // Case 2: Transparent fill (alpha = 0) should not match content.
   auto transparentLayer = ShapeLayer::Make();
@@ -1877,10 +1868,11 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   transparentLayer->addFillStyle(ShapeStyle::Make(Color::FromRGBA(255, 0, 0, 0)));
   OpaqueContext transparentContext;
   auto transparentCanvas = transparentContext.beginRecording();
-  bool transparentMatch =
-      transparentLayer->drawContour(drawArgs, transparentCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      bool transparentMatch =
+          transparentLayer->drawContour(drawArgs, transparentCanvas, 1.0f, BlendMode::SrcOver);
+      EXPECT_FALSE(transparentMatch));
   transparentContext.finishRecordingAsPicture();
-  EXPECT_FALSE(transparentMatch);
 
   // Case 3: Image shader fill should match content.
   auto image = MakeImage("resources/apitest/imageReplacement.png");
@@ -1890,9 +1882,10 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   imageLayer->addFillStyle(ShapeStyle::Make(imageShader));
   OpaqueContext imageContext;
   auto imageCanvas = imageContext.beginRecording();
-  bool imageMatch = imageLayer->drawContour(drawArgs, imageCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      bool imageMatch = imageLayer->drawContour(drawArgs, imageCanvas, 1.0f, BlendMode::SrcOver);
+      EXPECT_TRUE(imageMatch));
   imageContext.finishRecordingAsPicture();
-  EXPECT_TRUE(imageMatch);
 
   // Case 4: Layer with filter should not match content (child layer check).
   auto parentLayer = Layer::Make();
@@ -1903,9 +1896,11 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   parentLayer->addChild(filterLayer);
   OpaqueContext filterContext;
   auto filterCanvas = filterContext.beginRecording();
-  bool filterMatch = parentLayer->drawContour(drawArgs, filterCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      bool filterMatch =
+          parentLayer->drawContour(drawArgs, filterCanvas, 1.0f, BlendMode::SrcOver);
+      EXPECT_FALSE(filterMatch));
   filterContext.finishRecordingAsPicture();
-  EXPECT_FALSE(filterMatch);
 
   // Case 5: Layer with layerStyle should not match content (child layer check).
   auto parentLayer2 = Layer::Make();
@@ -1916,9 +1911,11 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   parentLayer2->addChild(styleLayer);
   OpaqueContext styleContext;
   auto styleCanvas = styleContext.beginRecording();
-  bool styleMatch = parentLayer2->drawContour(drawArgs, styleCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      bool styleMatch =
+          parentLayer2->drawContour(drawArgs, styleCanvas, 1.0f, BlendMode::SrcOver);
+      EXPECT_FALSE(styleMatch));
   styleContext.finishRecordingAsPicture();
-  EXPECT_FALSE(styleMatch);
 
   // Case 6: Gradient shader should check isOpaque().
   auto gradientShader = Shader::MakeLinearGradient(Point::Make(0, 0), Point::Make(100, 100),
@@ -1928,16 +1925,15 @@ TGFX_TEST(LayerTest, ContourMatchesContent) {
   gradientLayer->addFillStyle(ShapeStyle::Make(gradientShader));
   OpaqueContext gradientContext;
   auto gradientCanvas = gradientContext.beginRecording();
-  bool gradientMatch =
-      gradientLayer->drawContour(drawArgs, gradientCanvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(
+      bool gradientMatch =
+          gradientLayer->drawContour(drawArgs, gradientCanvas, 1.0f, BlendMode::SrcOver);
+      // Gradient with opaque colors should match.
+      EXPECT_TRUE(gradientMatch));
   gradientContext.finishRecordingAsPicture();
-  // Gradient with opaque colors should match.
-  EXPECT_TRUE(gradientMatch);
-#endif
 }
 
-TGFX_TEST(LayerTest, ContourContainsOpaqueBounds) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, ContourContainsOpaqueBounds) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -1961,11 +1957,11 @@ TGFX_TEST(LayerTest, ContourContainsOpaqueBounds) {
 
   OpaqueContext contourContext;
   auto canvas = contourContext.beginRecording();
-  parentLayer->drawContour(drawArgs, canvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(parentLayer->drawContour(drawArgs, canvas, 1.0f, BlendMode::SrcOver));
   auto picture = contourContext.finishRecordingAsPicture();
   // Parent contour drawn, child skipped due to containsOpaqueBounds optimization.
   // Only 1 draw call for parent.
-  EXPECT_EQ(picture->drawCount, 1u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(picture->drawCount, 1u));
 
   // Now test with child not covered (partially outside).
   auto parentLayer2 = ShapeLayer::Make();
@@ -1983,15 +1979,13 @@ TGFX_TEST(LayerTest, ContourContainsOpaqueBounds) {
 
   OpaqueContext contourContext2;
   auto canvas2 = contourContext2.beginRecording();
-  parentLayer2->drawContour(drawArgs, canvas2, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(parentLayer2->drawContour(drawArgs, canvas2, 1.0f, BlendMode::SrcOver));
   auto picture2 = contourContext2.finishRecordingAsPicture();
   // Both parent and child contours should be drawn.
-  EXPECT_EQ(picture2->drawCount, 2u);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(picture2->drawCount, 2u));
 }
 
-TGFX_TEST(LayerTest, GetContourImage) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, GetContourImage) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -2008,25 +2002,23 @@ TGFX_TEST(LayerTest, GetContourImage) {
   DrawArgs drawArgs = DrawArgs(context);
   Point offset = {};
   bool contourMatchesContent = false;
-  auto contourImage =
-      shapeLayer->getContentContourImage(drawArgs, 1.0f, &offset, &contourMatchesContent);
-  EXPECT_TRUE(contourImage != nullptr);
-  EXPECT_EQ(offset.x, 10.0f);
-  EXPECT_EQ(offset.y, 10.0f);
-  EXPECT_EQ(contourImage->width(), 80);
-  EXPECT_EQ(contourImage->height(), 80);
-  EXPECT_TRUE(contourMatchesContent);
-
-  // Draw the contour image to verify.
-  auto canvas = surface->getCanvas();
-  canvas->clear();
-  canvas->drawImage(contourImage, offset.x, offset.y);
+  TGFX_PRIVATE_ACCESS(
+      auto contourImage =
+          shapeLayer->getContentContourImage(drawArgs, 1.0f, &offset, &contourMatchesContent);
+      EXPECT_TRUE(contourImage != nullptr);
+      EXPECT_EQ(offset.x, 10.0f);
+      EXPECT_EQ(offset.y, 10.0f);
+      EXPECT_EQ(contourImage->width(), 80);
+      EXPECT_EQ(contourImage->height(), 80);
+      EXPECT_TRUE(contourMatchesContent);
+      // Draw the contour image to verify.
+      auto canvas = surface->getCanvas();
+      canvas->clear();
+      canvas->drawImage(contourImage, offset.x, offset.y));
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/GetContourImage"));
-#endif
 }
 
-TGFX_TEST(LayerTest, ContourWithMask) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, ContourWithMask) {
   ContextScope scope;
   auto context = scope.getContext();
   EXPECT_TRUE(context != nullptr);
@@ -2052,10 +2044,10 @@ TGFX_TEST(LayerTest, ContourWithMask) {
 
   OpaqueContext contourContext;
   auto canvas = contourContext.beginRecording();
-  shapeLayer->drawContour(drawArgs, canvas, 1.0f, BlendMode::SrcOver);
+  TGFX_PRIVATE_ACCESS(shapeLayer->drawContour(drawArgs, canvas, 1.0f, BlendMode::SrcOver));
   auto picture = contourContext.finishRecordingAsPicture();
   // The mask clips the shape, so we should have 1 contour (the masked shape).
-  EXPECT_EQ(picture->drawCount, 1u);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(picture->drawCount, 1u));
 
   // Draw to surface for visual verification.
   surface = Surface::Make(context, 200, 200);
@@ -2063,7 +2055,6 @@ TGFX_TEST(LayerTest, ContourWithMask) {
   drawCanvas->clear();
   drawCanvas->drawPicture(picture);
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/ContourWithMask"));
-#endif
 }
 
 TGFX_TEST(LayerTest, DiffFilterModeImagePattern) {
@@ -2477,8 +2468,7 @@ TGFX_TEST(LayerTest, DisplayListBackground) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/DisplayListBackground_TiledRender"));
 }
 
-TGFX_TEST(LayerTest, LayerRecorder) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -2502,17 +2492,18 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     recorder.addRect(Rect::MakeXYWH(70, 10, 50, 50), redPaint);
     recorder.addRect(Rect::MakeXYWH(130, 10, 50, 50), redPaint);
     recorder.addRect(Rect::MakeXYWH(10, 70, 50, 50), bluePaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be ComposeContent with 2 items: RectsContent (3 rects) + RectContent (1 rect)
-    EXPECT_EQ(content->type(), LayerContent::Type::Compose);
-    auto composeContent = static_cast<ComposeContent*>(content.get());
-    EXPECT_EQ(composeContent->contents.size(), 2u);
-    EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Rects);
-    auto rectsContent = static_cast<RectsContent*>(composeContent->contents[0].get());
-    EXPECT_EQ(rectsContent->rects.size(), 3u);
-    EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Rect);
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be ComposeContent with 2 items: RectsContent (3 rects) + RectContent (1 rect)
+        EXPECT_EQ(content->type(), LayerContent::Type::Compose);
+        auto composeContent = static_cast<ComposeContent*>(content.get());
+        EXPECT_EQ(composeContent->contents.size(), 2u);
+        EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Rects);
+        auto rectsContent = static_cast<RectsContent*>(composeContent->contents[0].get());
+        EXPECT_EQ(rectsContent->rects.size(), 3u);
+        EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Rect);
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_MultipleRects"));
   }
 
@@ -2532,17 +2523,18 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     recorder.addRRect(rRect2, redPaint);
     recorder.addRRect(rRect3, redPaint);
     recorder.addRRect(rRect4, bluePaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be ComposeContent with 2 items: RRectsContent (3 rrects) + RRectContent (1 rrect)
-    EXPECT_EQ(content->type(), LayerContent::Type::Compose);
-    auto composeContent = static_cast<ComposeContent*>(content.get());
-    EXPECT_EQ(composeContent->contents.size(), 2u);
-    EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::RRects);
-    auto rrectsContent = static_cast<RRectsContent*>(composeContent->contents[0].get());
-    EXPECT_EQ(rrectsContent->rRects.size(), 3u);
-    EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::RRect);
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be ComposeContent with 2 items: RRectsContent (3 rrects) + RRectContent (1 rrect)
+        EXPECT_EQ(content->type(), LayerContent::Type::Compose);
+        auto composeContent = static_cast<ComposeContent*>(content.get());
+        EXPECT_EQ(composeContent->contents.size(), 2u);
+        EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::RRects);
+        auto rrectsContent = static_cast<RRectsContent*>(composeContent->contents[0].get());
+        EXPECT_EQ(rrectsContent->rRects.size(), 3u);
+        EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::RRect);
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_MultipleRRects"));
   }
 
@@ -2562,17 +2554,18 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     recorder.addPath(path2, redPaint);
     recorder.addPath(path3, redPaint);
     recorder.addPath(path4, bluePaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be ComposeContent with 2 items: ShapeContent (merged paths) + PathContent
-    EXPECT_EQ(content->type(), LayerContent::Type::Compose);
-    auto composeContent = static_cast<ComposeContent*>(content.get());
-    ASSERT_TRUE(composeContent->contents.size() == 4u);
-    EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Path);
-    EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Path);
-    EXPECT_EQ(composeContent->contents[2]->type(), LayerContent::Type::Path);
-    EXPECT_EQ(composeContent->contents[3]->type(), LayerContent::Type::Path);
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be ComposeContent with 2 items: ShapeContent (merged paths) + PathContent
+        EXPECT_EQ(content->type(), LayerContent::Type::Compose);
+        auto composeContent = static_cast<ComposeContent*>(content.get());
+        ASSERT_TRUE(composeContent->contents.size() == 4u);
+        EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Path);
+        EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Path);
+        EXPECT_EQ(composeContent->contents[2]->type(), LayerContent::Type::Path);
+        EXPECT_EQ(composeContent->contents[3]->type(), LayerContent::Type::Path);
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_MultiplePaths"));
   }
 
@@ -2587,16 +2580,17 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     Path path = {};
     path.addOval(Rect::MakeXYWH(130, 10, 50, 50));
     recorder.addPath(path, redPaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be ComposeContent with 3 items: RectContent + RRectContent + PathContent
-    EXPECT_EQ(content->type(), LayerContent::Type::Compose);
-    auto composeContent = static_cast<ComposeContent*>(content.get());
-    EXPECT_EQ(composeContent->contents.size(), 3u);
-    EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Rect);
-    EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::RRect);
-    EXPECT_EQ(composeContent->contents[2]->type(), LayerContent::Type::Path);
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be ComposeContent with 3 items: RectContent + RRectContent + PathContent
+        EXPECT_EQ(content->type(), LayerContent::Type::Compose);
+        auto composeContent = static_cast<ComposeContent*>(content.get());
+        EXPECT_EQ(composeContent->contents.size(), 3u);
+        EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Rect);
+        EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::RRect);
+        EXPECT_EQ(composeContent->contents[2]->type(), LayerContent::Type::Path);
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_MixedShapes"));
   }
 
@@ -2609,13 +2603,14 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     auto font = Font(typeface, 24);
     auto textBlob = TextBlob::MakeFrom("Hello", font);
     recorder.addTextBlob(textBlob, redPaint, 50, 100);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be single TextContent
-    EXPECT_EQ(content->type(), LayerContent::Type::Text);
-    auto textContent = static_cast<TextContent*>(content.get());
-    EXPECT_EQ(textContent->offset, Point::Make(50, 100));
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be single TextContent
+        EXPECT_EQ(content->type(), LayerContent::Type::Text);
+        auto textContent = static_cast<TextContent*>(content.get());
+        EXPECT_EQ(textContent->offset, Point::Make(50, 100));
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_TextBlobWithOffset"));
   }
 
@@ -2628,11 +2623,12 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     linePath.lineTo(100, 100);
     recorder.addPath(linePath, redPaint);  // Fill style, should be ignored
     recorder.addRect(Rect::MakeXYWH(10, 70, 50, 50), bluePaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be single RectContent (line path ignored)
-    EXPECT_EQ(content->type(), LayerContent::Type::Rect);
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be single RectContent (line path ignored)
+        EXPECT_EQ(content->type(), LayerContent::Type::Rect);
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_LinePathFill"));
   }
 
@@ -2644,11 +2640,12 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     linePath.moveTo(10, 50);
     linePath.lineTo(190, 50);
     recorder.addPath(linePath, strokePaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    // Should be single RectContent (line converted to rect)
-    EXPECT_EQ(content->type(), LayerContent::Type::Rect);
-    content->drawDefault(surface->getCanvas(), 1.0f, true);
+    TGFX_PRIVATE_ACCESS(
+        auto content = recorder.finishRecording();
+        ASSERT_TRUE(content != nullptr);
+        // Should be single RectContent (line converted to rect)
+        EXPECT_EQ(content->type(), LayerContent::Type::Rect);
+        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_LinePathStroke"));
   }
 
@@ -2656,9 +2653,9 @@ TGFX_TEST(LayerTest, LayerRecorder) {
   {
     LayerRecorder recorder = {};
     recorder.addRect(Rect::MakeXYWH(10, 10, 50, 50), redPaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    EXPECT_EQ(content->type(), LayerContent::Type::Rect);
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording();
+                         ASSERT_TRUE(content != nullptr);
+                         EXPECT_EQ(content->type(), LayerContent::Type::Rect));
   }
 
   // Test 9: Single rrect should be RRectContent, not RRectsContent
@@ -2667,9 +2664,9 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     RRect rRect = {};
     rRect.setRectXY(Rect::MakeXYWH(10, 10, 50, 50), 10, 10);
     recorder.addRRect(rRect, redPaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    EXPECT_EQ(content->type(), LayerContent::Type::RRect);
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording();
+                         ASSERT_TRUE(content != nullptr);
+                         EXPECT_EQ(content->type(), LayerContent::Type::RRect));
   }
 
   // Test 10: RRect with zero radius should be converted to Rect
@@ -2678,15 +2675,13 @@ TGFX_TEST(LayerTest, LayerRecorder) {
     RRect rRect = {};
     rRect.setRectXY(Rect::MakeXYWH(10, 10, 50, 50), 0, 0);
     recorder.addRRect(rRect, redPaint);
-    auto content = recorder.finishRecording();
-    ASSERT_TRUE(content != nullptr);
-    EXPECT_EQ(content->type(), LayerContent::Type::Rect);
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording();
+                         ASSERT_TRUE(content != nullptr);
+                         EXPECT_EQ(content->type(), LayerContent::Type::Rect));
   }
-#endif
 }
 
-TGFX_TEST(LayerTest, LayerRecorderMatrix) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, LayerRecorderMatrix) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -2708,10 +2703,11 @@ TGFX_TEST(LayerTest, LayerRecorderMatrix) {
   recorder1.setMatrix(matrix1);
   recorder1.addRect(Rect::MakeXYWH(10, 10, 50, 50), redFill);
   recorder1.addRect(Rect::MakeXYWH(80, 10, 50, 50), redFill);
-  auto content1 = recorder1.finishRecording();
-  EXPECT_EQ(content1->type(), LayerContent::Type::Matrix);
-  auto matrixContent = static_cast<MatrixContent*>(content1.get());
-  EXPECT_EQ(matrixContent->content->type(), LayerContent::Type::Rects);
+  std::unique_ptr<LayerContent> content1;
+  TGFX_PRIVATE_ACCESS(content1 = recorder1.finishRecording();
+                       EXPECT_EQ(content1->type(), LayerContent::Type::Matrix);
+                       auto matrixContent = static_cast<MatrixContent*>(content1.get());
+                       EXPECT_EQ(matrixContent->content->type(), LayerContent::Type::Rects));
 
   // Test 2: Different matrices create Compose
   auto matrix2 = Matrix::MakeRotate(60, 50, 50);
@@ -2720,25 +2716,28 @@ TGFX_TEST(LayerTest, LayerRecorderMatrix) {
   recorder2.addRect(Rect::MakeXYWH(10, 10, 50, 50), blueStroke);
   recorder2.setMatrix(matrix2);
   recorder2.addRect(Rect::MakeXYWH(80, 10, 50, 50), blueStroke);
-  auto content2 = recorder2.finishRecording();
-  EXPECT_EQ(content2->type(), LayerContent::Type::Compose);
-  auto composeContent = static_cast<ComposeContent*>(content2.get());
-  EXPECT_EQ(composeContent->contents.size(), 2u);
-  EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Matrix);
-  EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Matrix);
+  std::unique_ptr<LayerContent> content2;
+  TGFX_PRIVATE_ACCESS(content2 = recorder2.finishRecording();
+                       EXPECT_EQ(content2->type(), LayerContent::Type::Compose);
+                       auto composeContent = static_cast<ComposeContent*>(content2.get());
+                       EXPECT_EQ(composeContent->contents.size(), 2u);
+                       EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Matrix);
+                       EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Matrix));
 
   // Test 3: Nullopt matrix should not create MatrixContent
   LayerRecorder recorder3 = {};
   recorder3.addRect(Rect::MakeXYWH(10, 10, 50, 50), greenFill);
-  auto content3 = recorder3.finishRecording();
-  EXPECT_EQ(content3->type(), LayerContent::Type::Rect);
+  std::unique_ptr<LayerContent> content3;
+  TGFX_PRIVATE_ACCESS(content3 = recorder3.finishRecording();
+                       EXPECT_EQ(content3->type(), LayerContent::Type::Rect));
 
   // Test 4: Identity matrix should not create MatrixContent
   LayerRecorder recorder4 = {};
   recorder4.setMatrix(Matrix::I());
   recorder4.addRect(Rect::MakeXYWH(10, 10, 50, 50), blueStroke);
-  auto content4 = recorder4.finishRecording();
-  EXPECT_EQ(content4->type(), LayerContent::Type::Rect);
+  std::unique_ptr<LayerContent> content4;
+  TGFX_PRIVATE_ACCESS(content4 = recorder4.finishRecording();
+                       EXPECT_EQ(content4->type(), LayerContent::Type::Rect));
 
   // Test 5: getTightBounds with transformed content
   auto bounds = content1->getTightBounds(Matrix::I());
@@ -2749,7 +2748,8 @@ TGFX_TEST(LayerTest, LayerRecorderMatrix) {
   LayerRecorder recorder5 = {};
   recorder5.setMatrix(Matrix::MakeRotate(45, 50, 50));
   recorder5.addRect(Rect::MakeXYWH(0, 0, 100, 100), greenFill);
-  auto content5 = recorder5.finishRecording();
+  std::unique_ptr<LayerContent> content5;
+  TGFX_PRIVATE_ACCESS(content5 = recorder5.finishRecording());
   EXPECT_TRUE(content5->hitTestPoint(50, 50));
   EXPECT_FALSE(content5->hitTestPoint(0, 0));
   EXPECT_TRUE(content5->hitTestPoint(50, -15));
@@ -2782,11 +2782,13 @@ TGFX_TEST(LayerTest, LayerRecorderMatrix) {
   auto scaledShape = Shape::ApplyMatrix(Shape::MakeFrom(rectPath), Matrix::MakeScale(2.0f));
   LayerRecorder recorder6 = {};
   recorder6.addShape(scaledShape, strokePaint);
-  auto content6 = recorder6.finishRecording();
+  std::unique_ptr<LayerContent> content6;
+  TGFX_PRIVATE_ACCESS(content6 = recorder6.finishRecording());
 
   LayerRecorder recorder7 = {};
   recorder7.addRect(Rect::MakeWH(100, 100), strokePaint);
-  auto content7 = recorder7.finishRecording();
+  std::unique_ptr<LayerContent> content7;
+  TGFX_PRIVATE_ACCESS(content7 = recorder7.finishRecording());
 
   auto surface2 = Surface::Make(context, 350, 200);
   auto canvas2 = surface2->getCanvas();
@@ -2795,7 +2797,6 @@ TGFX_TEST(LayerTest, LayerRecorderMatrix) {
   canvas2->concat(Matrix::MakeTrans(150, 0));
   content7->drawDefault(canvas2, 1.0f, true);
   EXPECT_TRUE(Baseline::Compare(surface2, "LayerTest/LayerRecorderMatrixStroke"));
-#endif
 }
 
 TGFX_TEST(LayerTest, GetRotateBounds) {
@@ -2968,19 +2969,19 @@ TGFX_TEST(LayerTest, SetChildrenOptimization) {
   EXPECT_EQ(grandChildLayer->children().size(), 0u);
 
   // Test Case 10: Root layer as child (should be prevented)
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto rootLayer = RootLayer::Make();
-  rootLayer->_root = rootLayer.get();
+  TGFX_PRIVATE_ACCESS(
+    auto rootLayer = RootLayer::Make();
+    rootLayer->_root = rootLayer.get();
 
-  std::vector<std::shared_ptr<Layer>> withRoot = {layerA, rootLayer, layerB};
-  parent->setChildren(withRoot);
+    std::vector<std::shared_ptr<Layer>> withRoot = {layerA, rootLayer, layerB};
+    parent->setChildren(withRoot);
 
-  // Root layer should be rejected, only layerA and layerB should be added
-  EXPECT_EQ(parent->children().size(), 2u);
-  EXPECT_EQ(parent->children()[0], layerA);
-  EXPECT_EQ(parent->children()[1], layerB);
-  EXPECT_FALSE(parent->contains(rootLayer));
-#endif
+    // Root layer should be rejected, only layerA and layerB should be added
+    EXPECT_EQ(parent->children().size(), 2u);
+    EXPECT_EQ(parent->children()[0], layerA);
+    EXPECT_EQ(parent->children()[1], layerB);
+    EXPECT_FALSE(parent->contains(rootLayer));
+  )
 
   // Test Case 11: Self as child (should be prevented)
   std::vector<std::shared_ptr<Layer>> selfAsChild = {layerA, parent, layerB};
@@ -3026,8 +3027,7 @@ TGFX_TEST(LayerTest, SetChildrenOptimization) {
   EXPECT_EQ(parent->children()[2], layerB);
 }
 
-TGFX_TEST(LayerTest, SetChildrenLISValidation) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(LayerTest, SetChildrenLISValidation) {
   // Test that the LIS algorithm correctly identifies which layers need to be marked dirty
   // by verifying that layers maintaining relative order are not unnecessarily invalidated
 
@@ -3059,10 +3059,11 @@ TGFX_TEST(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[1], layerA);
   EXPECT_EQ(root->children()[2], layerB);
   EXPECT_EQ(root->children()[3], layerC);
-  EXPECT_TRUE(layerD->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerA->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerB->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerC->bitFields.dirtyTransform);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_TRUE(layerD->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerA->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerC->bitFields.dirtyTransform));
 
   root->updateDirtyRegions();
 
@@ -3078,10 +3079,11 @@ TGFX_TEST(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[1], layerB);
   EXPECT_EQ(root->children()[2], layerC);
   EXPECT_EQ(root->children()[3], layerA);
-  EXPECT_FALSE(layerD->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerB->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerC->bitFields.dirtyTransform);
-  EXPECT_TRUE(layerA->bitFields.dirtyTransform);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_FALSE(layerD->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerC->bitFields.dirtyTransform);
+      EXPECT_TRUE(layerA->bitFields.dirtyTransform));
 
   root->updateDirtyRegions();
 
@@ -3098,18 +3100,11 @@ TGFX_TEST(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[2], layerB);
   EXPECT_EQ(root->children()[3], layerD);
   int dirtyCount = 0;
-  if (layerA->bitFields.dirtyTransform) {
-    dirtyCount++;
-  }
-  if (layerC->bitFields.dirtyTransform) {
-    dirtyCount++;
-  }
-  if (layerB->bitFields.dirtyTransform) {
-    dirtyCount++;
-  }
-  if (layerD->bitFields.dirtyTransform) {
-    dirtyCount++;
-  }
+  TGFX_PRIVATE_ACCESS(
+      if (layerA->bitFields.dirtyTransform) { dirtyCount++; }
+      if (layerC->bitFields.dirtyTransform) { dirtyCount++; }
+      if (layerB->bitFields.dirtyTransform) { dirtyCount++; }
+      if (layerD->bitFields.dirtyTransform) { dirtyCount++; });
   EXPECT_EQ(dirtyCount, 3);
 
   root->updateDirtyRegions();
@@ -3123,10 +3118,11 @@ TGFX_TEST(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[1], layerC);
   EXPECT_EQ(root->children()[2], layerB);
   EXPECT_EQ(root->children()[3], layerD);
-  EXPECT_FALSE(layerA->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerC->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerB->bitFields.dirtyTransform);
-  EXPECT_FALSE(layerD->bitFields.dirtyTransform);
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_FALSE(layerA->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerC->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
+      EXPECT_FALSE(layerD->bitFields.dirtyTransform));
 
   // Scenario 5: Single element - edge case
   auto displayList2 = std::make_unique<DisplayList>();
@@ -3139,15 +3135,14 @@ TGFX_TEST(LayerTest, SetChildrenLISValidation) {
 
   EXPECT_EQ(singleParent->children().size(), 1u);
   EXPECT_EQ(singleParent->children()[0], singleLayer);
-  EXPECT_TRUE(singleLayer->bitFields.dirtyTransform);
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(singleLayer->bitFields.dirtyTransform));
 
   singleParent->updateDirtyRegions();
 
   // Reorder with same single element - no change, not dirty
   singleParent->setChildren(single);
   EXPECT_EQ(singleParent->children().size(), 1u);
-  EXPECT_FALSE(singleLayer->bitFields.dirtyTransform);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(singleLayer->bitFields.dirtyTransform));
 }
 
 TGFX_TEST(LayerTest, Layer3DContextAPI) {

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -175,10 +175,8 @@ TGFX_TEST(LayerTest, LayerTreeCircle) {
 
   EXPECT_FALSE(grandChild->addChild(parent));
 
-  TGFX_PRIVATE_ACCESS(
-    EXPECT_FALSE(parent->addChild(displayList->_root));
-    EXPECT_FALSE(parent->contains(displayList->_root));
-  )
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(parent->addChild(displayList->_root));
+                      EXPECT_FALSE(parent->contains(displayList->_root));)
 
   EXPECT_FALSE(child->contains(parent));
 
@@ -270,7 +268,7 @@ TGFX_TEST_PRIVATE(LayerTest, Layer_getTotalMatrix) {
   grandChild->addChild(greatGrandson);
 
   TGFX_PRIVATE_ACCESS(auto greatGrandsonTotalMatrix = greatGrandson->getGlobalMatrix();
-                       EXPECT_EQ(greatGrandsonTotalMatrix, Matrix3D::MakeTranslate(30, 30, 0)));
+                      EXPECT_EQ(greatGrandsonTotalMatrix, Matrix3D::MakeTranslate(30, 30, 0)));
 
   EXPECT_EQ(greatGrandson->matrix(), Matrix::MakeTrans(10, 10));
   EXPECT_EQ(grandChild->matrix(), Matrix::MakeTrans(10, 10));
@@ -282,11 +280,10 @@ TGFX_TEST_PRIVATE(LayerTest, Layer_getTotalMatrix) {
 
   TGFX_PRIVATE_ACCESS(
       auto greatGrandsonTotalMatrix2 = greatGrandson->getGlobalMatrix();
-      auto grandChildTotalMatrix = grandChild->getGlobalMatrix();
-      EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix2.getTranslateX(),
-                       grandChildTotalMatrix.getTranslateX());
+      auto grandChildTotalMatrix = grandChild->getGlobalMatrix(); EXPECT_FLOAT_EQ(
+          greatGrandsonTotalMatrix2.getTranslateX(), grandChildTotalMatrix.getTranslateX());
       EXPECT_FLOAT_EQ(greatGrandsonTotalMatrix2.getTranslateY(),
-                       grandChildTotalMatrix.getTranslateX() + 10.0f * std::sqrt(2.0f)));
+                      grandChildTotalMatrix.getTranslateX() + 10.0f * std::sqrt(2.0f)));
 }
 
 /**
@@ -347,10 +344,9 @@ TGFX_TEST(LayerTest, Layer_localToGlobal) {
 
   auto pointEInLayer2 = Point::Make(8, 8);
   auto pointEInGlobal = layerA2->localToGlobal(pointEInLayer2);
-  TGFX_PRIVATE_ACCESS(
-    EXPECT_EQ(pointEInGlobal, Point::Make(layer2GlobalMat.getTranslateX(),
-                                          layer2GlobalMat.getTranslateY() + 8.0f * std::sqrt(2.0f)));
-  )
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(pointEInGlobal, Point::Make(layer2GlobalMat.getTranslateX(),
+                                                            layer2GlobalMat.getTranslateY() +
+                                                                8.0f * std::sqrt(2.0f)));)
 
   auto layer4 = Layer::Make();
   layer4->setMatrix(Matrix::MakeTrans(5, -5) * Matrix::MakeRotate(-60.0f));
@@ -1857,8 +1853,7 @@ TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   OpaqueContext opaqueContext;
   auto opaqueCanvas = opaqueContext.beginRecording();
   TGFX_PRIVATE_ACCESS(
-      bool opaqueMatch =
-          opaqueLayer->drawContour(drawArgs, opaqueCanvas, 1.0f, BlendMode::SrcOver);
+      bool opaqueMatch = opaqueLayer->drawContour(drawArgs, opaqueCanvas, 1.0f, BlendMode::SrcOver);
       EXPECT_TRUE(opaqueMatch));
   opaqueContext.finishRecordingAsPicture();
 
@@ -1868,10 +1863,9 @@ TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   transparentLayer->addFillStyle(ShapeStyle::Make(Color::FromRGBA(255, 0, 0, 0)));
   OpaqueContext transparentContext;
   auto transparentCanvas = transparentContext.beginRecording();
-  TGFX_PRIVATE_ACCESS(
-      bool transparentMatch =
-          transparentLayer->drawContour(drawArgs, transparentCanvas, 1.0f, BlendMode::SrcOver);
-      EXPECT_FALSE(transparentMatch));
+  TGFX_PRIVATE_ACCESS(bool transparentMatch = transparentLayer->drawContour(
+                          drawArgs, transparentCanvas, 1.0f, BlendMode::SrcOver);
+                      EXPECT_FALSE(transparentMatch));
   transparentContext.finishRecordingAsPicture();
 
   // Case 3: Image shader fill should match content.
@@ -1882,9 +1876,9 @@ TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   imageLayer->addFillStyle(ShapeStyle::Make(imageShader));
   OpaqueContext imageContext;
   auto imageCanvas = imageContext.beginRecording();
-  TGFX_PRIVATE_ACCESS(
-      bool imageMatch = imageLayer->drawContour(drawArgs, imageCanvas, 1.0f, BlendMode::SrcOver);
-      EXPECT_TRUE(imageMatch));
+  TGFX_PRIVATE_ACCESS(bool imageMatch =
+                          imageLayer->drawContour(drawArgs, imageCanvas, 1.0f, BlendMode::SrcOver);
+                      EXPECT_TRUE(imageMatch));
   imageContext.finishRecordingAsPicture();
 
   // Case 4: Layer with filter should not match content (child layer check).
@@ -1897,8 +1891,7 @@ TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   OpaqueContext filterContext;
   auto filterCanvas = filterContext.beginRecording();
   TGFX_PRIVATE_ACCESS(
-      bool filterMatch =
-          parentLayer->drawContour(drawArgs, filterCanvas, 1.0f, BlendMode::SrcOver);
+      bool filterMatch = parentLayer->drawContour(drawArgs, filterCanvas, 1.0f, BlendMode::SrcOver);
       EXPECT_FALSE(filterMatch));
   filterContext.finishRecordingAsPicture();
 
@@ -1912,8 +1905,7 @@ TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   OpaqueContext styleContext;
   auto styleCanvas = styleContext.beginRecording();
   TGFX_PRIVATE_ACCESS(
-      bool styleMatch =
-          parentLayer2->drawContour(drawArgs, styleCanvas, 1.0f, BlendMode::SrcOver);
+      bool styleMatch = parentLayer2->drawContour(drawArgs, styleCanvas, 1.0f, BlendMode::SrcOver);
       EXPECT_FALSE(styleMatch));
   styleContext.finishRecordingAsPicture();
 
@@ -1925,11 +1917,10 @@ TGFX_TEST_PRIVATE(LayerTest, ContourMatchesContent) {
   gradientLayer->addFillStyle(ShapeStyle::Make(gradientShader));
   OpaqueContext gradientContext;
   auto gradientCanvas = gradientContext.beginRecording();
-  TGFX_PRIVATE_ACCESS(
-      bool gradientMatch =
-          gradientLayer->drawContour(drawArgs, gradientCanvas, 1.0f, BlendMode::SrcOver);
-      // Gradient with opaque colors should match.
-      EXPECT_TRUE(gradientMatch));
+  TGFX_PRIVATE_ACCESS(bool gradientMatch = gradientLayer->drawContour(drawArgs, gradientCanvas,
+                                                                      1.0f, BlendMode::SrcOver);
+                      // Gradient with opaque colors should match.
+                      EXPECT_TRUE(gradientMatch));
   gradientContext.finishRecordingAsPicture();
 }
 
@@ -2002,19 +1993,14 @@ TGFX_TEST_PRIVATE(LayerTest, GetContourImage) {
   DrawArgs drawArgs = DrawArgs(context);
   Point offset = {};
   bool contourMatchesContent = false;
-  TGFX_PRIVATE_ACCESS(
-      auto contourImage =
-          shapeLayer->getContentContourImage(drawArgs, 1.0f, &offset, &contourMatchesContent);
-      EXPECT_TRUE(contourImage != nullptr);
-      EXPECT_EQ(offset.x, 10.0f);
-      EXPECT_EQ(offset.y, 10.0f);
-      EXPECT_EQ(contourImage->width(), 80);
-      EXPECT_EQ(contourImage->height(), 80);
-      EXPECT_TRUE(contourMatchesContent);
-      // Draw the contour image to verify.
-      auto canvas = surface->getCanvas();
-      canvas->clear();
-      canvas->drawImage(contourImage, offset.x, offset.y));
+  TGFX_PRIVATE_ACCESS(auto contourImage = shapeLayer->getContentContourImage(
+                          drawArgs, 1.0f, &offset, &contourMatchesContent);
+                      EXPECT_TRUE(contourImage != nullptr); EXPECT_EQ(offset.x, 10.0f);
+                      EXPECT_EQ(offset.y, 10.0f); EXPECT_EQ(contourImage->width(), 80);
+                      EXPECT_EQ(contourImage->height(), 80); EXPECT_TRUE(contourMatchesContent);
+                      // Draw the contour image to verify.
+                      auto canvas = surface->getCanvas();
+                      canvas->clear(); canvas->drawImage(contourImage, offset.x, offset.y));
   EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/GetContourImage"));
 }
 
@@ -2493,8 +2479,7 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     recorder.addRect(Rect::MakeXYWH(130, 10, 50, 50), redPaint);
     recorder.addRect(Rect::MakeXYWH(10, 70, 50, 50), bluePaint);
     TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
+        auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
         // Should be ComposeContent with 2 items: RectsContent (3 rects) + RectContent (1 rect)
         EXPECT_EQ(content->type(), LayerContent::Type::Compose);
         auto composeContent = static_cast<ComposeContent*>(content.get());
@@ -2524,8 +2509,7 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     recorder.addRRect(rRect3, redPaint);
     recorder.addRRect(rRect4, bluePaint);
     TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
+        auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
         // Should be ComposeContent with 2 items: RRectsContent (3 rrects) + RRectContent (1 rrect)
         EXPECT_EQ(content->type(), LayerContent::Type::Compose);
         auto composeContent = static_cast<ComposeContent*>(content.get());
@@ -2555,8 +2539,7 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     recorder.addPath(path3, redPaint);
     recorder.addPath(path4, bluePaint);
     TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
+        auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
         // Should be ComposeContent with 2 items: ShapeContent (merged paths) + PathContent
         EXPECT_EQ(content->type(), LayerContent::Type::Compose);
         auto composeContent = static_cast<ComposeContent*>(content.get());
@@ -2581,8 +2564,7 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     path.addOval(Rect::MakeXYWH(130, 10, 50, 50));
     recorder.addPath(path, redPaint);
     TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
+        auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
         // Should be ComposeContent with 3 items: RectContent + RRectContent + PathContent
         EXPECT_EQ(content->type(), LayerContent::Type::Compose);
         auto composeContent = static_cast<ComposeContent*>(content.get());
@@ -2603,14 +2585,12 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     auto font = Font(typeface, 24);
     auto textBlob = TextBlob::MakeFrom("Hello", font);
     recorder.addTextBlob(textBlob, redPaint, 50, 100);
-    TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
-        // Should be single TextContent
-        EXPECT_EQ(content->type(), LayerContent::Type::Text);
-        auto textContent = static_cast<TextContent*>(content.get());
-        EXPECT_EQ(textContent->offset, Point::Make(50, 100));
-        content->drawDefault(surface->getCanvas(), 1.0f, true));
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
+                        // Should be single TextContent
+                        EXPECT_EQ(content->type(), LayerContent::Type::Text);
+                        auto textContent = static_cast<TextContent*>(content.get());
+                        EXPECT_EQ(textContent->offset, Point::Make(50, 100));
+                        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_TextBlobWithOffset"));
   }
 
@@ -2623,12 +2603,10 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     linePath.lineTo(100, 100);
     recorder.addPath(linePath, redPaint);  // Fill style, should be ignored
     recorder.addRect(Rect::MakeXYWH(10, 70, 50, 50), bluePaint);
-    TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
-        // Should be single RectContent (line path ignored)
-        EXPECT_EQ(content->type(), LayerContent::Type::Rect);
-        content->drawDefault(surface->getCanvas(), 1.0f, true));
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
+                        // Should be single RectContent (line path ignored)
+                        EXPECT_EQ(content->type(), LayerContent::Type::Rect);
+                        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_LinePathFill"));
   }
 
@@ -2640,12 +2618,10 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     linePath.moveTo(10, 50);
     linePath.lineTo(190, 50);
     recorder.addPath(linePath, strokePaint);
-    TGFX_PRIVATE_ACCESS(
-        auto content = recorder.finishRecording();
-        ASSERT_TRUE(content != nullptr);
-        // Should be single RectContent (line converted to rect)
-        EXPECT_EQ(content->type(), LayerContent::Type::Rect);
-        content->drawDefault(surface->getCanvas(), 1.0f, true));
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
+                        // Should be single RectContent (line converted to rect)
+                        EXPECT_EQ(content->type(), LayerContent::Type::Rect);
+                        content->drawDefault(surface->getCanvas(), 1.0f, true));
     EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/LayerRecorder_LinePathStroke"));
   }
 
@@ -2653,9 +2629,8 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
   {
     LayerRecorder recorder = {};
     recorder.addRect(Rect::MakeXYWH(10, 10, 50, 50), redPaint);
-    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording();
-                         ASSERT_TRUE(content != nullptr);
-                         EXPECT_EQ(content->type(), LayerContent::Type::Rect));
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
+                        EXPECT_EQ(content->type(), LayerContent::Type::Rect));
   }
 
   // Test 9: Single rrect should be RRectContent, not RRectsContent
@@ -2664,9 +2639,8 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     RRect rRect = {};
     rRect.setRectXY(Rect::MakeXYWH(10, 10, 50, 50), 10, 10);
     recorder.addRRect(rRect, redPaint);
-    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording();
-                         ASSERT_TRUE(content != nullptr);
-                         EXPECT_EQ(content->type(), LayerContent::Type::RRect));
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
+                        EXPECT_EQ(content->type(), LayerContent::Type::RRect));
   }
 
   // Test 10: RRect with zero radius should be converted to Rect
@@ -2675,9 +2649,8 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorder) {
     RRect rRect = {};
     rRect.setRectXY(Rect::MakeXYWH(10, 10, 50, 50), 0, 0);
     recorder.addRRect(rRect, redPaint);
-    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording();
-                         ASSERT_TRUE(content != nullptr);
-                         EXPECT_EQ(content->type(), LayerContent::Type::Rect));
+    TGFX_PRIVATE_ACCESS(auto content = recorder.finishRecording(); ASSERT_TRUE(content != nullptr);
+                        EXPECT_EQ(content->type(), LayerContent::Type::Rect));
   }
 }
 
@@ -2705,9 +2678,9 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorderMatrix) {
   recorder1.addRect(Rect::MakeXYWH(80, 10, 50, 50), redFill);
   std::unique_ptr<LayerContent> content1;
   TGFX_PRIVATE_ACCESS(content1 = recorder1.finishRecording();
-                       EXPECT_EQ(content1->type(), LayerContent::Type::Matrix);
-                       auto matrixContent = static_cast<MatrixContent*>(content1.get());
-                       EXPECT_EQ(matrixContent->content->type(), LayerContent::Type::Rects));
+                      EXPECT_EQ(content1->type(), LayerContent::Type::Matrix);
+                      auto matrixContent = static_cast<MatrixContent*>(content1.get());
+                      EXPECT_EQ(matrixContent->content->type(), LayerContent::Type::Rects));
 
   // Test 2: Different matrices create Compose
   auto matrix2 = Matrix::MakeRotate(60, 50, 50);
@@ -2718,18 +2691,18 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorderMatrix) {
   recorder2.addRect(Rect::MakeXYWH(80, 10, 50, 50), blueStroke);
   std::unique_ptr<LayerContent> content2;
   TGFX_PRIVATE_ACCESS(content2 = recorder2.finishRecording();
-                       EXPECT_EQ(content2->type(), LayerContent::Type::Compose);
-                       auto composeContent = static_cast<ComposeContent*>(content2.get());
-                       EXPECT_EQ(composeContent->contents.size(), 2u);
-                       EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Matrix);
-                       EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Matrix));
+                      EXPECT_EQ(content2->type(), LayerContent::Type::Compose);
+                      auto composeContent = static_cast<ComposeContent*>(content2.get());
+                      EXPECT_EQ(composeContent->contents.size(), 2u);
+                      EXPECT_EQ(composeContent->contents[0]->type(), LayerContent::Type::Matrix);
+                      EXPECT_EQ(composeContent->contents[1]->type(), LayerContent::Type::Matrix));
 
   // Test 3: Nullopt matrix should not create MatrixContent
   LayerRecorder recorder3 = {};
   recorder3.addRect(Rect::MakeXYWH(10, 10, 50, 50), greenFill);
   std::unique_ptr<LayerContent> content3;
   TGFX_PRIVATE_ACCESS(content3 = recorder3.finishRecording();
-                       EXPECT_EQ(content3->type(), LayerContent::Type::Rect));
+                      EXPECT_EQ(content3->type(), LayerContent::Type::Rect));
 
   // Test 4: Identity matrix should not create MatrixContent
   LayerRecorder recorder4 = {};
@@ -2737,7 +2710,7 @@ TGFX_TEST_PRIVATE(LayerTest, LayerRecorderMatrix) {
   recorder4.addRect(Rect::MakeXYWH(10, 10, 50, 50), blueStroke);
   std::unique_ptr<LayerContent> content4;
   TGFX_PRIVATE_ACCESS(content4 = recorder4.finishRecording();
-                       EXPECT_EQ(content4->type(), LayerContent::Type::Rect));
+                      EXPECT_EQ(content4->type(), LayerContent::Type::Rect));
 
   // Test 5: getTightBounds with transformed content
   auto bounds = content1->getTightBounds(Matrix::I());
@@ -2970,18 +2943,14 @@ TGFX_TEST(LayerTest, SetChildrenOptimization) {
 
   // Test Case 10: Root layer as child (should be prevented)
   TGFX_PRIVATE_ACCESS(
-    auto rootLayer = RootLayer::Make();
-    rootLayer->_root = rootLayer.get();
+      auto rootLayer = RootLayer::Make(); rootLayer->_root = rootLayer.get();
 
-    std::vector<std::shared_ptr<Layer>> withRoot = {layerA, rootLayer, layerB};
-    parent->setChildren(withRoot);
+      std::vector<std::shared_ptr<Layer>> withRoot = {layerA, rootLayer, layerB};
+      parent->setChildren(withRoot);
 
-    // Root layer should be rejected, only layerA and layerB should be added
-    EXPECT_EQ(parent->children().size(), 2u);
-    EXPECT_EQ(parent->children()[0], layerA);
-    EXPECT_EQ(parent->children()[1], layerB);
-    EXPECT_FALSE(parent->contains(rootLayer));
-  )
+      // Root layer should be rejected, only layerA and layerB should be added
+      EXPECT_EQ(parent->children().size(), 2u); EXPECT_EQ(parent->children()[0], layerA);
+      EXPECT_EQ(parent->children()[1], layerB); EXPECT_FALSE(parent->contains(rootLayer));)
 
   // Test Case 11: Self as child (should be prevented)
   std::vector<std::shared_ptr<Layer>> selfAsChild = {layerA, parent, layerB};
@@ -3059,11 +3028,10 @@ TGFX_TEST_PRIVATE(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[1], layerA);
   EXPECT_EQ(root->children()[2], layerB);
   EXPECT_EQ(root->children()[3], layerC);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_TRUE(layerD->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerA->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerC->bitFields.dirtyTransform));
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(layerD->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerA->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerC->bitFields.dirtyTransform));
 
   root->updateDirtyRegions();
 
@@ -3079,11 +3047,10 @@ TGFX_TEST_PRIVATE(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[1], layerB);
   EXPECT_EQ(root->children()[2], layerC);
   EXPECT_EQ(root->children()[3], layerA);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_FALSE(layerD->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerC->bitFields.dirtyTransform);
-      EXPECT_TRUE(layerA->bitFields.dirtyTransform));
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(layerD->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerC->bitFields.dirtyTransform);
+                      EXPECT_TRUE(layerA->bitFields.dirtyTransform));
 
   root->updateDirtyRegions();
 
@@ -3101,10 +3068,13 @@ TGFX_TEST_PRIVATE(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[3], layerD);
   int dirtyCount = 0;
   TGFX_PRIVATE_ACCESS(
-      if (layerA->bitFields.dirtyTransform) { dirtyCount++; }
-      if (layerC->bitFields.dirtyTransform) { dirtyCount++; }
-      if (layerB->bitFields.dirtyTransform) { dirtyCount++; }
-      if (layerD->bitFields.dirtyTransform) { dirtyCount++; });
+      if (layerA->bitFields.dirtyTransform) {
+        dirtyCount++;
+      } if (layerC->bitFields.dirtyTransform) {
+        dirtyCount++;
+      } if (layerB->bitFields.dirtyTransform) {
+        dirtyCount++;
+      } if (layerD->bitFields.dirtyTransform) { dirtyCount++; });
   EXPECT_EQ(dirtyCount, 3);
 
   root->updateDirtyRegions();
@@ -3118,11 +3088,10 @@ TGFX_TEST_PRIVATE(LayerTest, SetChildrenLISValidation) {
   EXPECT_EQ(root->children()[1], layerC);
   EXPECT_EQ(root->children()[2], layerB);
   EXPECT_EQ(root->children()[3], layerD);
-  TGFX_PRIVATE_ACCESS(
-      EXPECT_FALSE(layerA->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerC->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
-      EXPECT_FALSE(layerD->bitFields.dirtyTransform));
+  TGFX_PRIVATE_ACCESS(EXPECT_FALSE(layerA->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerC->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerB->bitFields.dirtyTransform);
+                      EXPECT_FALSE(layerD->bitFields.dirtyTransform));
 
   // Scenario 5: Single element - edge case
   auto displayList2 = std::make_unique<DisplayList>();

--- a/test/src/MultisampleTestEffect.cpp
+++ b/test/src/MultisampleTestEffect.cpp
@@ -54,7 +54,7 @@ static std::string GetFinalShaderCode(const char* codeSnippet, bool isDesktop) {
 
 std::shared_ptr<MultisampleTestEffect> MultisampleTestEffect::Make(
     const MultisampleConfig& config) {
-  return std::make_shared<MultisampleTestEffect>(config);
+  return std::shared_ptr<MultisampleTestEffect>(new MultisampleTestEffect(config));
 }
 
 MultisampleTestEffect::MultisampleTestEffect(const MultisampleConfig& config) : config(config) {

--- a/test/src/PathShapeTest.cpp
+++ b/test/src/PathShapeTest.cpp
@@ -195,19 +195,18 @@ TGFX_TEST(PathShapeTest, simpleShape) {
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/shape"));
 }
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-static std::vector<Resource*> FindResourceByDomainID(Context* context, uint32_t domainID) {
-  std::vector<Resource*> resources = {};
-  auto resourceCache = context->resourceCache();
-  for (auto& item : resourceCache->uniqueKeyMap) {
-    auto resource = item.second;
-    if (resource->uniqueKey.domainID() == domainID) {
-      resources.push_back(resource);
-    }
-  }
-  return resources;
-}
-#endif
+TGFX_PRIVATE_ACCESS(
+    static std::vector<Resource*> FindResourceByDomainID(Context* context, uint32_t domainID) {
+      std::vector<Resource*> resources = {};
+      auto resourceCache = context->resourceCache();
+      for (auto& item : resourceCache->uniqueKeyMap) {
+        auto resource = item.second;
+        if (resource->uniqueKey.domainID() == domainID) {
+          resources.push_back(resource);
+        }
+      }
+      return resources;
+    })
 
 TGFX_TEST(PathShapeTest, inversePath) {
   ContextScope scope;
@@ -254,11 +253,10 @@ TGFX_TEST(PathShapeTest, inversePath) {
   canvas->drawPath(path, paint);
   canvas->restore();
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/inversePath_rect"));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto uniqueKey = PathRef::GetUniqueKey(path);
-  auto cachesBefore = FindResourceByDomainID(context, uniqueKey.domainID());
-  EXPECT_EQ(cachesBefore.size(), 1u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto uniqueKey = PathRef::GetUniqueKey(path);
+      auto cachesBefore = FindResourceByDomainID(context, uniqueKey.domainID());
+      EXPECT_EQ(cachesBefore.size(), 1u));
   canvas->clear();
   canvas->clipPath(clipPath);
   auto shape = Shape::MakeFrom(path);
@@ -266,15 +264,13 @@ TGFX_TEST(PathShapeTest, inversePath) {
   canvas->translate(-50, -50);
   canvas->drawShape(shape, paint);
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/inversePath_rect"));
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto cachesAfter = FindResourceByDomainID(context, uniqueKey.domainID());
-  EXPECT_EQ(cachesAfter.size(), 1u);
-  EXPECT_TRUE(cachesBefore.front() == cachesAfter.front());
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto cachesAfter = FindResourceByDomainID(context, uniqueKey.domainID());
+      EXPECT_EQ(cachesAfter.size(), 1u);
+      EXPECT_TRUE(cachesBefore.front() == cachesAfter.front()));
 }
 
-TGFX_TEST(PathShapeTest, drawShape) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(PathShapeTest, drawShape) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -295,9 +291,11 @@ TGFX_TEST(PathShapeTest, drawShape) {
   EXPECT_FALSE(mergedShape->isSimplePath());
   auto transShape = Shape::ApplyMatrix(shape, Matrix::MakeTrans(10, 10));
   mergedShape = Shape::Merge({transShape, shape, shape2});
-  EXPECT_EQ(mergedShape->type(), Shape::Type::Append);
-  auto appendShape = std::static_pointer_cast<AppendShape>(mergedShape);
-  EXPECT_EQ(appendShape->shapes.size(), 3u);
+  TGFX_PRIVATE_ACCESS({
+    EXPECT_EQ(mergedShape->type(), Shape::Type::Append);
+    auto appendShape = std::static_pointer_cast<AppendShape>(mergedShape);
+    EXPECT_EQ(appendShape->shapes.size(), 3u);
+  })
 
   Paint paint;
   paint.setStyle(PaintStyle::Stroke);
@@ -342,7 +340,6 @@ TGFX_TEST(PathShapeTest, drawShape) {
   canvas->setMatrix(matrix);
   canvas->drawShape(textShape, paint);
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/drawShape"));
-#endif
 }
 
 TGFX_TEST(PathShapeTest, inverseFillType) {
@@ -398,8 +395,7 @@ TGFX_TEST(PathShapeTest, inverseFillType) {
   EXPECT_TRUE(shape->isInverseFillType());
 }
 
-TGFX_TEST(PathShapeTest, MergeShapeFillType) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(PathShapeTest, MergeShapeFillType) {
   // MergeShape always produces EvenOdd fill type regardless of input fill types.
   Path rectPath;
   rectPath.addRect(Rect::MakeXYWH(0, 0, 100, 100));
@@ -474,14 +470,12 @@ TGFX_TEST(PathShapeTest, MergeShapeFillType) {
   auto matrixShape = Shape::ApplyMatrix(shape1, matrix);
   auto fillTypeMatrixShape = Shape::ApplyFillType(matrixShape, PathFillType::EvenOdd);
   ASSERT_TRUE(fillTypeMatrixShape != nullptr);
-  EXPECT_EQ(fillTypeMatrixShape->type(), Shape::Type::Matrix);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(fillTypeMatrixShape->type(), Shape::Type::Matrix);)
   EXPECT_EQ(fillTypeMatrixShape->fillType(), PathFillType::EvenOdd);
   EXPECT_EQ(fillTypeMatrixShape->getBounds(), matrixShape->getBounds());
-#endif
 }
 
-TGFX_TEST(PathShapeTest, ReverseShape) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(PathShapeTest, ReverseShape) {
   Path path;
   path.moveTo(0, 0);
   path.lineTo(100, 0);
@@ -517,9 +511,8 @@ TGFX_TEST(PathShapeTest, ReverseShape) {
   auto matrixShape = Shape::ApplyMatrix(shape, matrix);
   auto reversedMatrixShape = Shape::ApplyReverse(matrixShape);
   ASSERT_TRUE(reversedMatrixShape != nullptr);
-  EXPECT_EQ(reversedMatrixShape->type(), Shape::Type::Matrix);
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(reversedMatrixShape->type(), Shape::Type::Matrix);)
   EXPECT_EQ(reversedMatrixShape->getBounds(), matrixShape->getBounds());
-#endif
 }
 
 TGFX_TEST(PathShapeTest, Path_addArc) {

--- a/test/src/PathShapeTest.cpp
+++ b/test/src/PathShapeTest.cpp
@@ -195,18 +195,18 @@ TGFX_TEST(PathShapeTest, simpleShape) {
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/shape"));
 }
 
-TGFX_PRIVATE_ACCESS(
-    static std::vector<Resource*> FindResourceByDomainID(Context* context, uint32_t domainID) {
-      std::vector<Resource*> resources = {};
-      auto resourceCache = context->resourceCache();
-      for (auto& item : resourceCache->uniqueKeyMap) {
-        auto resource = item.second;
-        if (resource->uniqueKey.domainID() == domainID) {
-          resources.push_back(resource);
-        }
-      }
-      return resources;
-    })
+TGFX_PRIVATE_ACCESS(static std::vector<Resource*> FindResourceByDomainID(Context* context,
+                                                                         uint32_t domainID) {
+  std::vector<Resource*> resources = {};
+  auto resourceCache = context->resourceCache();
+  for (auto& item : resourceCache->uniqueKeyMap) {
+    auto resource = item.second;
+    if (resource->uniqueKey.domainID() == domainID) {
+      resources.push_back(resource);
+    }
+  }
+  return resources;
+})
 
 TGFX_TEST(PathShapeTest, inversePath) {
   ContextScope scope;
@@ -253,10 +253,9 @@ TGFX_TEST(PathShapeTest, inversePath) {
   canvas->drawPath(path, paint);
   canvas->restore();
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/inversePath_rect"));
-  TGFX_PRIVATE_ACCESS(
-      auto uniqueKey = PathRef::GetUniqueKey(path);
-      auto cachesBefore = FindResourceByDomainID(context, uniqueKey.domainID());
-      EXPECT_EQ(cachesBefore.size(), 1u));
+  TGFX_PRIVATE_ACCESS(auto uniqueKey = PathRef::GetUniqueKey(path);
+                      auto cachesBefore = FindResourceByDomainID(context, uniqueKey.domainID());
+                      EXPECT_EQ(cachesBefore.size(), 1u));
   canvas->clear();
   canvas->clipPath(clipPath);
   auto shape = Shape::MakeFrom(path);
@@ -264,10 +263,9 @@ TGFX_TEST(PathShapeTest, inversePath) {
   canvas->translate(-50, -50);
   canvas->drawShape(shape, paint);
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/inversePath_rect"));
-  TGFX_PRIVATE_ACCESS(
-      auto cachesAfter = FindResourceByDomainID(context, uniqueKey.domainID());
-      EXPECT_EQ(cachesAfter.size(), 1u);
-      EXPECT_TRUE(cachesBefore.front() == cachesAfter.front()));
+  TGFX_PRIVATE_ACCESS(auto cachesAfter = FindResourceByDomainID(context, uniqueKey.domainID());
+                      EXPECT_EQ(cachesAfter.size(), 1u);
+                      EXPECT_TRUE(cachesBefore.front() == cachesAfter.front()));
 }
 
 TGFX_TEST_PRIVATE(PathShapeTest, drawShape) {

--- a/test/src/PathShapeTest.cpp
+++ b/test/src/PathShapeTest.cpp
@@ -195,6 +195,7 @@ TGFX_TEST(PathShapeTest, simpleShape) {
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/shape"));
 }
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
 static std::vector<Resource*> FindResourceByDomainID(Context* context, uint32_t domainID) {
   std::vector<Resource*> resources = {};
   auto resourceCache = context->resourceCache();
@@ -206,6 +207,7 @@ static std::vector<Resource*> FindResourceByDomainID(Context* context, uint32_t 
   }
   return resources;
 }
+#endif
 
 TGFX_TEST(PathShapeTest, inversePath) {
   ContextScope scope;
@@ -252,9 +254,11 @@ TGFX_TEST(PathShapeTest, inversePath) {
   canvas->drawPath(path, paint);
   canvas->restore();
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/inversePath_rect"));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto uniqueKey = PathRef::GetUniqueKey(path);
   auto cachesBefore = FindResourceByDomainID(context, uniqueKey.domainID());
   EXPECT_EQ(cachesBefore.size(), 1u);
+#endif
   canvas->clear();
   canvas->clipPath(clipPath);
   auto shape = Shape::MakeFrom(path);
@@ -262,12 +266,15 @@ TGFX_TEST(PathShapeTest, inversePath) {
   canvas->translate(-50, -50);
   canvas->drawShape(shape, paint);
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/inversePath_rect"));
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto cachesAfter = FindResourceByDomainID(context, uniqueKey.domainID());
   EXPECT_EQ(cachesAfter.size(), 1u);
   EXPECT_TRUE(cachesBefore.front() == cachesAfter.front());
+#endif
 }
 
 TGFX_TEST(PathShapeTest, drawShape) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -335,6 +342,7 @@ TGFX_TEST(PathShapeTest, drawShape) {
   canvas->setMatrix(matrix);
   canvas->drawShape(textShape, paint);
   EXPECT_TRUE(Baseline::Compare(surface, "PathShapeTest/drawShape"));
+#endif
 }
 
 TGFX_TEST(PathShapeTest, inverseFillType) {
@@ -391,6 +399,7 @@ TGFX_TEST(PathShapeTest, inverseFillType) {
 }
 
 TGFX_TEST(PathShapeTest, MergeShapeFillType) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   // MergeShape always produces EvenOdd fill type regardless of input fill types.
   Path rectPath;
   rectPath.addRect(Rect::MakeXYWH(0, 0, 100, 100));
@@ -468,9 +477,11 @@ TGFX_TEST(PathShapeTest, MergeShapeFillType) {
   EXPECT_EQ(fillTypeMatrixShape->type(), Shape::Type::Matrix);
   EXPECT_EQ(fillTypeMatrixShape->fillType(), PathFillType::EvenOdd);
   EXPECT_EQ(fillTypeMatrixShape->getBounds(), matrixShape->getBounds());
+#endif
 }
 
 TGFX_TEST(PathShapeTest, ReverseShape) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   Path path;
   path.moveTo(0, 0);
   path.lineTo(100, 0);
@@ -508,6 +519,7 @@ TGFX_TEST(PathShapeTest, ReverseShape) {
   ASSERT_TRUE(reversedMatrixShape != nullptr);
   EXPECT_EQ(reversedMatrixShape->type(), Shape::Type::Matrix);
   EXPECT_EQ(reversedMatrixShape->getBounds(), matrixShape->getBounds());
+#endif
 }
 
 TGFX_TEST(PathShapeTest, Path_addArc) {

--- a/test/src/ReadPixelsTest.cpp
+++ b/test/src/ReadPixelsTest.cpp
@@ -448,43 +448,43 @@ TGFX_TEST(ReadPixelsTest, JpegCodec) {
   CHECK_PIXELS(RGB565Info, pixels, "JpegCodec_Encode_RGB565");
 }
 
-TGFX_TEST(ReadPixelsTest, NativeCodec) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto rgbaCodec = MakeNativeCodec("resources/apitest/imageReplacement.png");
-  auto colorSpace = rgbaCodec->colorSpace();
-  ASSERT_TRUE(rgbaCodec != nullptr);
-  EXPECT_EQ(rgbaCodec->width(), 110);
-  EXPECT_EQ(rgbaCodec->height(), 110);
-  EXPECT_EQ(rgbaCodec->orientation(), Orientation::TopLeft);
-  auto RGBAInfo = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::RGBA_8888,
-                                  AlphaType::Premultiplied, 0, colorSpace);
-  Buffer buffer(RGBAInfo.byteSize());
-  auto pixels = buffer.data();
-  ASSERT_TRUE(pixels);
-  EXPECT_TRUE(rgbaCodec->readPixels(RGBAInfo, pixels));
-  CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Decode_RGBA");
-  auto bytes = ImageCodec::Encode(Pixmap(RGBAInfo, pixels), EncodedFormat::PNG, 100);
-  auto codec = ImageCodec::MakeNativeCodec(bytes);
-  ASSERT_TRUE(codec != nullptr);
-  ASSERT_EQ(codec->width(), 110);
-  ASSERT_EQ(codec->height(), 110);
-  ASSERT_EQ(codec->orientation(), Orientation::TopLeft);
-  buffer.clear();
-  EXPECT_TRUE(codec->readPixels(RGBAInfo, pixels));
-  CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Encode_RGBA");
+TGFX_TEST_PRIVATE(ReadPixelsTest, NativeCodec) {
+  TGFX_PRIVATE_ACCESS({
+    auto rgbaCodec = MakeNativeCodec("resources/apitest/imageReplacement.png");
+    auto colorSpace = rgbaCodec->colorSpace();
+    ASSERT_TRUE(rgbaCodec != nullptr);
+    EXPECT_EQ(rgbaCodec->width(), 110);
+    EXPECT_EQ(rgbaCodec->height(), 110);
+    EXPECT_EQ(rgbaCodec->orientation(), Orientation::TopLeft);
+    auto RGBAInfo = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::RGBA_8888,
+                                    AlphaType::Premultiplied, 0, colorSpace);
+    Buffer buffer(RGBAInfo.byteSize());
+    auto pixels = buffer.data();
+    ASSERT_TRUE(pixels);
+    EXPECT_TRUE(rgbaCodec->readPixels(RGBAInfo, pixels));
+    CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Decode_RGBA");
+    auto bytes = ImageCodec::Encode(Pixmap(RGBAInfo, pixels), EncodedFormat::PNG, 100);
+    auto codec = ImageCodec::MakeNativeCodec(bytes);
+    ASSERT_TRUE(codec != nullptr);
+    ASSERT_EQ(codec->width(), 110);
+    ASSERT_EQ(codec->height(), 110);
+    ASSERT_EQ(codec->orientation(), Orientation::TopLeft);
+    buffer.clear();
+    EXPECT_TRUE(codec->readPixels(RGBAInfo, pixels));
+    CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Encode_RGBA");
 
-  auto A8Info = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::ALPHA_8,
-                                AlphaType::Premultiplied, 0, colorSpace);
-  buffer.clear();
-  EXPECT_TRUE(rgbaCodec->readPixels(A8Info, pixels));
-  CHECK_PIXELS(A8Info, pixels, "NativeCodec_Decode_Alpha8");
-  bytes = ImageCodec::Encode(Pixmap(A8Info, pixels), EncodedFormat::PNG, 100);
-  codec = ImageCodec::MakeNativeCodec(bytes);
-  ASSERT_TRUE(codec != nullptr);
-  buffer.clear();
-  EXPECT_TRUE(codec->readPixels(A8Info, pixels));
-  CHECK_PIXELS(A8Info, pixels, "NativeCodec_Encode_Alpha8");
-#endif
+    auto A8Info = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::ALPHA_8,
+                                  AlphaType::Premultiplied, 0, colorSpace);
+    buffer.clear();
+    EXPECT_TRUE(rgbaCodec->readPixels(A8Info, pixels));
+    CHECK_PIXELS(A8Info, pixels, "NativeCodec_Decode_Alpha8");
+    bytes = ImageCodec::Encode(Pixmap(A8Info, pixels), EncodedFormat::PNG, 100);
+    codec = ImageCodec::MakeNativeCodec(bytes);
+    ASSERT_TRUE(codec != nullptr);
+    buffer.clear();
+    EXPECT_TRUE(codec->readPixels(A8Info, pixels));
+    CHECK_PIXELS(A8Info, pixels, "NativeCodec_Encode_Alpha8");
+  })
 }
 
 TGFX_TEST(ReadPixelsTest, ReadScaleCodec) {

--- a/test/src/ReadPixelsTest.cpp
+++ b/test/src/ReadPixelsTest.cpp
@@ -448,44 +448,42 @@ TGFX_TEST(ReadPixelsTest, JpegCodec) {
   CHECK_PIXELS(RGB565Info, pixels, "JpegCodec_Encode_RGB565");
 }
 
-TGFX_TEST_PRIVATE(ReadPixelsTest, NativeCodec) {
-  TGFX_PRIVATE_ACCESS({
-    auto rgbaCodec = MakeNativeCodec("resources/apitest/imageReplacement.png");
-    auto colorSpace = rgbaCodec->colorSpace();
-    ASSERT_TRUE(rgbaCodec != nullptr);
-    EXPECT_EQ(rgbaCodec->width(), 110);
-    EXPECT_EQ(rgbaCodec->height(), 110);
-    EXPECT_EQ(rgbaCodec->orientation(), Orientation::TopLeft);
-    auto RGBAInfo = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::RGBA_8888,
-                                    AlphaType::Premultiplied, 0, colorSpace);
-    Buffer buffer(RGBAInfo.byteSize());
-    auto pixels = buffer.data();
-    ASSERT_TRUE(pixels);
-    EXPECT_TRUE(rgbaCodec->readPixels(RGBAInfo, pixels));
-    CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Decode_RGBA");
-    auto bytes = ImageCodec::Encode(Pixmap(RGBAInfo, pixels), EncodedFormat::PNG, 100);
-    auto codec = ImageCodec::MakeNativeCodec(bytes);
-    ASSERT_TRUE(codec != nullptr);
-    ASSERT_EQ(codec->width(), 110);
-    ASSERT_EQ(codec->height(), 110);
-    ASSERT_EQ(codec->orientation(), Orientation::TopLeft);
-    buffer.clear();
-    EXPECT_TRUE(codec->readPixels(RGBAInfo, pixels));
-    CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Encode_RGBA");
-
-    auto A8Info = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::ALPHA_8,
+TGFX_TEST_PRIVATE(ReadPixelsTest, NativeCodec){TGFX_PRIVATE_ACCESS({
+  auto rgbaCodec = MakeNativeCodec("resources/apitest/imageReplacement.png");
+  auto colorSpace = rgbaCodec->colorSpace();
+  ASSERT_TRUE(rgbaCodec != nullptr);
+  EXPECT_EQ(rgbaCodec->width(), 110);
+  EXPECT_EQ(rgbaCodec->height(), 110);
+  EXPECT_EQ(rgbaCodec->orientation(), Orientation::TopLeft);
+  auto RGBAInfo = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::RGBA_8888,
                                   AlphaType::Premultiplied, 0, colorSpace);
-    buffer.clear();
-    EXPECT_TRUE(rgbaCodec->readPixels(A8Info, pixels));
-    CHECK_PIXELS(A8Info, pixels, "NativeCodec_Decode_Alpha8");
-    bytes = ImageCodec::Encode(Pixmap(A8Info, pixels), EncodedFormat::PNG, 100);
-    codec = ImageCodec::MakeNativeCodec(bytes);
-    ASSERT_TRUE(codec != nullptr);
-    buffer.clear();
-    EXPECT_TRUE(codec->readPixels(A8Info, pixels));
-    CHECK_PIXELS(A8Info, pixels, "NativeCodec_Encode_Alpha8");
-  })
-}
+  Buffer buffer(RGBAInfo.byteSize());
+  auto pixels = buffer.data();
+  ASSERT_TRUE(pixels);
+  EXPECT_TRUE(rgbaCodec->readPixels(RGBAInfo, pixels));
+  CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Decode_RGBA");
+  auto bytes = ImageCodec::Encode(Pixmap(RGBAInfo, pixels), EncodedFormat::PNG, 100);
+  auto codec = ImageCodec::MakeNativeCodec(bytes);
+  ASSERT_TRUE(codec != nullptr);
+  ASSERT_EQ(codec->width(), 110);
+  ASSERT_EQ(codec->height(), 110);
+  ASSERT_EQ(codec->orientation(), Orientation::TopLeft);
+  buffer.clear();
+  EXPECT_TRUE(codec->readPixels(RGBAInfo, pixels));
+  CHECK_PIXELS(RGBAInfo, pixels, "NativeCodec_Encode_RGBA");
+
+  auto A8Info = ImageInfo::Make(rgbaCodec->width(), rgbaCodec->height(), ColorType::ALPHA_8,
+                                AlphaType::Premultiplied, 0, colorSpace);
+  buffer.clear();
+  EXPECT_TRUE(rgbaCodec->readPixels(A8Info, pixels));
+  CHECK_PIXELS(A8Info, pixels, "NativeCodec_Decode_Alpha8");
+  bytes = ImageCodec::Encode(Pixmap(A8Info, pixels), EncodedFormat::PNG, 100);
+  codec = ImageCodec::MakeNativeCodec(bytes);
+  ASSERT_TRUE(codec != nullptr);
+  buffer.clear();
+  EXPECT_TRUE(codec->readPixels(A8Info, pixels));
+  CHECK_PIXELS(A8Info, pixels, "NativeCodec_Encode_Alpha8");
+})}
 
 TGFX_TEST(ReadPixelsTest, ReadScaleCodec) {
   auto codec = MakeImageCodec("resources/apitest/rotation.jpg");

--- a/test/src/ReadPixelsTest.cpp
+++ b/test/src/ReadPixelsTest.cpp
@@ -449,6 +449,7 @@ TGFX_TEST(ReadPixelsTest, JpegCodec) {
 }
 
 TGFX_TEST(ReadPixelsTest, NativeCodec) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto rgbaCodec = MakeNativeCodec("resources/apitest/imageReplacement.png");
   auto colorSpace = rgbaCodec->colorSpace();
   ASSERT_TRUE(rgbaCodec != nullptr);
@@ -483,6 +484,7 @@ TGFX_TEST(ReadPixelsTest, NativeCodec) {
   buffer.clear();
   EXPECT_TRUE(codec->readPixels(A8Info, pixels));
   CHECK_PIXELS(A8Info, pixels, "NativeCodec_Encode_Alpha8");
+#endif
 }
 
 TGFX_TEST(ReadPixelsTest, ReadScaleCodec) {

--- a/test/src/ResourceTest.cpp
+++ b/test/src/ResourceTest.cpp
@@ -35,19 +35,15 @@ namespace tgfx {
 
 TGFX_TEST(ResourceTest, TaskRelease) {
   Task::ReleaseThreads();
-  TGFX_PRIVATE_ACCESS(
-    auto group = TaskGroup::GetInstance();
-    std::thread* thead = nullptr;
-    group->threads->try_dequeue(thead);
-    EXPECT_EQ(thead, nullptr);
-    EXPECT_EQ(group->waitingThreads, 0);
-    EXPECT_EQ(group->totalThreads, 0);
-    for (auto& queue : group->priorityQueues) {
-      std::shared_ptr<Task> task = nullptr;
-      queue->try_dequeue(task);
-      EXPECT_EQ(task, nullptr);
-    }
-  )
+  TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance(); std::thread* thead = nullptr;
+                      group->threads->try_dequeue(thead); EXPECT_EQ(thead, nullptr);
+                      EXPECT_EQ(group->waitingThreads, 0); EXPECT_EQ(group->totalThreads, 0);
+                      for (auto& queue
+                           : group->priorityQueues) {
+                        std::shared_ptr<Task> task = nullptr;
+                        queue->try_dequeue(task);
+                        EXPECT_EQ(task, nullptr);
+                      })
 }
 
 // ==================== Resource Cache Tests ====================

--- a/test/src/ResourceTest.cpp
+++ b/test/src/ResourceTest.cpp
@@ -35,6 +35,7 @@ namespace tgfx {
 
 TGFX_TEST(ResourceTest, TaskRelease) {
   Task::ReleaseThreads();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto group = TaskGroup::GetInstance();
   std::thread* thead = nullptr;
   group->threads->try_dequeue(thead);
@@ -46,6 +47,7 @@ TGFX_TEST(ResourceTest, TaskRelease) {
     queue->try_dequeue(task);
     EXPECT_EQ(task, nullptr);
   }
+#endif
 }
 
 // ==================== Resource Cache Tests ====================

--- a/test/src/ResourceTest.cpp
+++ b/test/src/ResourceTest.cpp
@@ -35,19 +35,19 @@ namespace tgfx {
 
 TGFX_TEST(ResourceTest, TaskRelease) {
   Task::ReleaseThreads();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto group = TaskGroup::GetInstance();
-  std::thread* thead = nullptr;
-  group->threads->try_dequeue(thead);
-  EXPECT_EQ(thead, nullptr);
-  EXPECT_EQ(group->waitingThreads, 0);
-  EXPECT_EQ(group->totalThreads, 0);
-  for (auto& queue : group->priorityQueues) {
-    std::shared_ptr<Task> task = nullptr;
-    queue->try_dequeue(task);
-    EXPECT_EQ(task, nullptr);
-  }
-#endif
+  TGFX_PRIVATE_ACCESS(
+    auto group = TaskGroup::GetInstance();
+    std::thread* thead = nullptr;
+    group->threads->try_dequeue(thead);
+    EXPECT_EQ(thead, nullptr);
+    EXPECT_EQ(group->waitingThreads, 0);
+    EXPECT_EQ(group->totalThreads, 0);
+    for (auto& queue : group->priorityQueues) {
+      std::shared_ptr<Task> task = nullptr;
+      queue->try_dequeue(task);
+      EXPECT_EQ(task, nullptr);
+    }
+  )
 }
 
 // ==================== Resource Cache Tests ====================

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -566,9 +566,10 @@ TGFX_TEST(SVGExportTest, GradientMask) {
   Buffer buffer(readStream->size());
   readStream->read(buffer.data(), buffer.size());
   auto compareString = std::string(static_cast<char*>(buffer.data()), buffer.size());
-  // The baseline SVG file from resources/ may contain '\r\n' line endings on Windows due to Git
-  // checkout CRLF conversion. Runtime-generated SVG strings use '\n' only, so strip '\r' before
-  // comparison. Other SVG tests compare against in-memory strings and are not affected.
+  // Only this code path reads a baseline SVG file from disk, which may contain '\r\n' line endings
+  // on Windows due to Git checkout CRLF conversion. Strip '\r' so it matches the runtime-generated
+  // SVG string that uses '\n' only. Other SVG tests compare against in-memory strings and are not
+  // affected by CRLF conversion.
   compareString.erase(std::remove(compareString.begin(), compareString.end(), '\r'),
                       compareString.end());
 

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -101,6 +101,8 @@ TGFX_TEST(SVGExportTest, PureColorFile) {
   tgfx::Paint paint;
   paint.setColor(Color::Blue());
 
+  // The writer must be destroyed before reading. On Windows, fopen() holds an exclusive file lock
+  // that prevents a second fopen() on the same path until fclose() is called in the destructor.
   {
     auto SVGStream = WriteStream::MakeFromFile(path);
     auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200),
@@ -168,6 +170,8 @@ TGFX_TEST(SVGExportTest, OpacityColorFile) {
   paint.setColor(Color::Blue());
   paint.setAlpha(0.5f);
 
+  // The writer must be destroyed before reading. On Windows, fopen() holds an exclusive file lock
+  // that prevents a second fopen() on the same path until fclose() is called in the destructor.
   {
     auto SVGStream = WriteStream::MakeFromFile(path);
     auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200),
@@ -459,6 +463,8 @@ TGFX_TEST(SVGExportTest, EmojiTextFile) {
   Paint paint;
   paint.setColor(Color::Red());
 
+  // The writer must be destroyed before reading. On Windows, fopen() holds an exclusive file lock
+  // that prevents a second fopen() on the same path until fclose() is called in the destructor.
   {
     auto SVGStream = WriteStream::MakeFromFile(path);
     auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(400, 200),
@@ -560,7 +566,9 @@ TGFX_TEST(SVGExportTest, GradientMask) {
   Buffer buffer(readStream->size());
   readStream->read(buffer.data(), buffer.size());
   auto compareString = std::string(static_cast<char*>(buffer.data()), buffer.size());
-  // Remove '\r' to handle Windows line endings from Git checkout.
+  // The baseline SVG file from resources/ may contain '\r\n' line endings on Windows due to Git
+  // checkout CRLF conversion. Runtime-generated SVG strings use '\n' only, so strip '\r' before
+  // comparison. Other SVG tests compare against in-memory strings and are not affected.
   compareString.erase(std::remove(compareString.begin(), compareString.end(), '\r'),
                       compareString.end());
 

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -16,6 +16,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include <filesystem>
 #include <string>
 #include "base/TGFXTest.h"
@@ -100,21 +101,25 @@ TGFX_TEST(SVGExportTest, PureColorFile) {
   tgfx::Paint paint;
   paint.setColor(Color::Blue());
 
-  auto SVGStream = WriteStream::MakeFromFile(path);
-  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200),
-                                    SVGExportFlags::DisablePrettyXML);
-  auto canvas = exporter->getCanvas();
+  {
+    auto SVGStream = WriteStream::MakeFromFile(path);
+    auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200),
+                                      SVGExportFlags::DisablePrettyXML);
+    auto canvas = exporter->getCanvas();
 
-  canvas->drawRect(Rect::MakeXYWH(50, 50, 100, 100), paint);
+    canvas->drawRect(Rect::MakeXYWH(50, 50, 100, 100), paint);
 
-  exporter->close();
+    exporter->close();
+  }
 
-  auto readStream = Stream::MakeFromFile(path);
-  EXPECT_TRUE(readStream != nullptr);
-  EXPECT_EQ(readStream->size(), 211U);
-  Buffer buffer(readStream->size());
-  readStream->read(buffer.data(), buffer.size());
-  EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), compareString);
+  {
+    auto readStream = Stream::MakeFromFile(path);
+    EXPECT_TRUE(readStream != nullptr);
+    EXPECT_EQ(readStream->size(), 211U);
+    Buffer buffer(readStream->size());
+    readStream->read(buffer.data(), buffer.size());
+    EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), compareString);
+  }
 
   std::filesystem::remove(path);
 }
@@ -163,21 +168,25 @@ TGFX_TEST(SVGExportTest, OpacityColorFile) {
   paint.setColor(Color::Blue());
   paint.setAlpha(0.5f);
 
-  auto SVGStream = WriteStream::MakeFromFile(path);
-  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200),
-                                    SVGExportFlags::DisablePrettyXML);
-  auto canvas = exporter->getCanvas();
+  {
+    auto SVGStream = WriteStream::MakeFromFile(path);
+    auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200),
+                                      SVGExportFlags::DisablePrettyXML);
+    auto canvas = exporter->getCanvas();
 
-  canvas->drawCircle(100, 100, 100, paint);
+    canvas->drawCircle(100, 100, 100, paint);
 
-  exporter->close();
+    exporter->close();
+  }
 
-  auto readStream = Stream::MakeFromFile(path);
-  EXPECT_TRUE(readStream != nullptr);
-  EXPECT_EQ(readStream->size(), 219U);
-  Buffer buffer(readStream->size());
-  readStream->read(buffer.data(), buffer.size());
-  EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), compareString);
+  {
+    auto readStream = Stream::MakeFromFile(path);
+    EXPECT_TRUE(readStream != nullptr);
+    EXPECT_EQ(readStream->size(), 219U);
+    Buffer buffer(readStream->size());
+    readStream->read(buffer.data(), buffer.size());
+    EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), compareString);
+  }
 
   std::filesystem::remove(path);
 }
@@ -450,21 +459,25 @@ TGFX_TEST(SVGExportTest, EmojiTextFile) {
   Paint paint;
   paint.setColor(Color::Red());
 
-  auto SVGStream = WriteStream::MakeFromFile(path);
-  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(400, 200),
-                                    SVGExportFlags::DisablePrettyXML);
-  auto canvas = exporter->getCanvas();
+  {
+    auto SVGStream = WriteStream::MakeFromFile(path);
+    auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(400, 200),
+                                      SVGExportFlags::DisablePrettyXML);
+    auto canvas = exporter->getCanvas();
 
-  canvas->drawSimpleText("🤡👻🐠🤩😃🤪", 0, 80, font, paint);
+    canvas->drawSimpleText("🤡👻🐠🤩😃🤪", 0, 80, font, paint);
 
-  exporter->close();
+    exporter->close();
+  }
 
-  auto readStream = Stream::MakeFromFile(path);
-  EXPECT_TRUE(readStream != nullptr);
-  EXPECT_EQ(readStream->size(), 346U);
-  Buffer buffer(readStream->size());
-  readStream->read(buffer.data(), buffer.size());
-  EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), compareString);
+  {
+    auto readStream = Stream::MakeFromFile(path);
+    EXPECT_TRUE(readStream != nullptr);
+    EXPECT_EQ(readStream->size(), 346U);
+    Buffer buffer(readStream->size());
+    readStream->read(buffer.data(), buffer.size());
+    EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), compareString);
+  }
 
   std::filesystem::remove(path);
 }
@@ -547,8 +560,11 @@ TGFX_TEST(SVGExportTest, GradientMask) {
   Buffer buffer(readStream->size());
   readStream->read(buffer.data(), buffer.size());
   auto compareString = std::string(static_cast<char*>(buffer.data()), buffer.size());
+  // Remove '\r' to handle Windows line endings from Git checkout.
+  compareString.erase(std::remove(compareString.begin(), compareString.end(), '\r'),
+                      compareString.end());
 
-  EXPECT_EQ(std::string((char*)buffer.data(), buffer.size()), SVGString);
+  EXPECT_EQ(compareString, SVGString);
 }
 
 TGFX_TEST(SVGExportTest, ImageMask) {

--- a/test/src/SVGRenderTest.cpp
+++ b/test/src/SVGRenderTest.cpp
@@ -682,38 +682,39 @@ TGFX_TEST(SVGRenderTest, ProtocolFilterReadWrite) {
     if (filter) {
       auto type = Types::Get(filter.get());
       TGFX_PRIVATE_ACCESS(
-        if (type == Types::ImageFilterType::Blur) {
-          auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(filter);
-          auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(blurFilter);
-          EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
-          EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
-          EXPECT_EQ(blur1->tileMode, blur2->tileMode);
-        } else if (type == Types::ImageFilterType::DropShadow) {
-          auto dropShadow1 = std::static_pointer_cast<DropShadowImageFilter>(filter);
-          auto dropShadow2 = std::static_pointer_cast<DropShadowImageFilter>(dropShadowFilter);
-          EXPECT_EQ(dropShadow1->dx, dropShadow2->dx);
-          EXPECT_EQ(dropShadow1->dy, dropShadow2->dy);
-          EXPECT_EQ(dropShadow1->color, dropShadow2->color);
-          EXPECT_EQ(dropShadow1->shadowOnly, dropShadow2->shadowOnly);
-          auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow1->blurFilter);
-          auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow2->blurFilter);
-          EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
-          EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
-          EXPECT_EQ(blur1->tileMode, blur2->tileMode);
-        } else if (type == Types::ImageFilterType::InnerShadow) {
-          auto innerShadow1 = std::static_pointer_cast<InnerShadowImageFilter>(filter);
-          auto innerShadow2 = std::static_pointer_cast<InnerShadowImageFilter>(innerShadowFilter);
-          EXPECT_EQ(innerShadow1->dx, innerShadow2->dx);
-          EXPECT_EQ(innerShadow1->dy, innerShadow2->dy);
-          EXPECT_EQ(innerShadow1->color, innerShadow2->color);
-          EXPECT_EQ(innerShadow1->shadowOnly, innerShadow2->shadowOnly);
-          auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow1->blurFilter);
-          auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow2->blurFilter);
-          EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
-          EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
-          EXPECT_EQ(blur1->tileMode, blur2->tileMode);
-        }
-      )
+          if (type == Types::ImageFilterType::Blur) {
+            auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(filter);
+            auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(blurFilter);
+            EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
+            EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
+            EXPECT_EQ(blur1->tileMode, blur2->tileMode);
+          } else if (type == Types::ImageFilterType::DropShadow) {
+            auto dropShadow1 = std::static_pointer_cast<DropShadowImageFilter>(filter);
+            auto dropShadow2 = std::static_pointer_cast<DropShadowImageFilter>(dropShadowFilter);
+            EXPECT_EQ(dropShadow1->dx, dropShadow2->dx);
+            EXPECT_EQ(dropShadow1->dy, dropShadow2->dy);
+            EXPECT_EQ(dropShadow1->color, dropShadow2->color);
+            EXPECT_EQ(dropShadow1->shadowOnly, dropShadow2->shadowOnly);
+            auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow1->blurFilter);
+            auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow2->blurFilter);
+            EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
+            EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
+            EXPECT_EQ(blur1->tileMode, blur2->tileMode);
+          } else if (type == Types::ImageFilterType::InnerShadow) {
+            auto innerShadow1 = std::static_pointer_cast<InnerShadowImageFilter>(filter);
+            auto innerShadow2 = std::static_pointer_cast<InnerShadowImageFilter>(innerShadowFilter);
+            EXPECT_EQ(innerShadow1->dx, innerShadow2->dx);
+            EXPECT_EQ(innerShadow1->dy, innerShadow2->dy);
+            EXPECT_EQ(innerShadow1->color, innerShadow2->color);
+            EXPECT_EQ(innerShadow1->shadowOnly, innerShadow2->shadowOnly);
+            auto blur1 =
+                std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow1->blurFilter);
+            auto blur2 =
+                std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow2->blurFilter);
+            EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
+            EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
+            EXPECT_EQ(blur1->tileMode, blur2->tileMode);
+          })
       (void)type;
     }
   }

--- a/test/src/SVGRenderTest.cpp
+++ b/test/src/SVGRenderTest.cpp
@@ -681,6 +681,7 @@ TGFX_TEST(SVGRenderTest, ProtocolFilterReadWrite) {
   for (const auto& [_, filter] : protocolSetter->filterMap) {
     if (filter) {
       auto type = Types::Get(filter.get());
+#ifdef TGFX_TEST_ACCESS_PRIVATE
       if (type == Types::ImageFilterType::Blur) {
         auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(filter);
         auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(blurFilter);
@@ -712,6 +713,9 @@ TGFX_TEST(SVGRenderTest, ProtocolFilterReadWrite) {
         EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
         EXPECT_EQ(blur1->tileMode, blur2->tileMode);
       }
+#else
+      (void)type;
+#endif
     }
   }
 }

--- a/test/src/SVGRenderTest.cpp
+++ b/test/src/SVGRenderTest.cpp
@@ -681,41 +681,40 @@ TGFX_TEST(SVGRenderTest, ProtocolFilterReadWrite) {
   for (const auto& [_, filter] : protocolSetter->filterMap) {
     if (filter) {
       auto type = Types::Get(filter.get());
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-      if (type == Types::ImageFilterType::Blur) {
-        auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(filter);
-        auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(blurFilter);
-        EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
-        EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
-        EXPECT_EQ(blur1->tileMode, blur2->tileMode);
-      } else if (type == Types::ImageFilterType::DropShadow) {
-        auto dropShadow1 = std::static_pointer_cast<DropShadowImageFilter>(filter);
-        auto dropShadow2 = std::static_pointer_cast<DropShadowImageFilter>(dropShadowFilter);
-        EXPECT_EQ(dropShadow1->dx, dropShadow2->dx);
-        EXPECT_EQ(dropShadow1->dy, dropShadow2->dy);
-        EXPECT_EQ(dropShadow1->color, dropShadow2->color);
-        EXPECT_EQ(dropShadow1->shadowOnly, dropShadow2->shadowOnly);
-        auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow1->blurFilter);
-        auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow2->blurFilter);
-        EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
-        EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
-        EXPECT_EQ(blur1->tileMode, blur2->tileMode);
-      } else if (type == Types::ImageFilterType::InnerShadow) {
-        auto innerShadow1 = std::static_pointer_cast<InnerShadowImageFilter>(filter);
-        auto innerShadow2 = std::static_pointer_cast<InnerShadowImageFilter>(innerShadowFilter);
-        EXPECT_EQ(innerShadow1->dx, innerShadow2->dx);
-        EXPECT_EQ(innerShadow1->dy, innerShadow2->dy);
-        EXPECT_EQ(innerShadow1->color, innerShadow2->color);
-        EXPECT_EQ(innerShadow1->shadowOnly, innerShadow2->shadowOnly);
-        auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow1->blurFilter);
-        auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow2->blurFilter);
-        EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
-        EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
-        EXPECT_EQ(blur1->tileMode, blur2->tileMode);
-      }
-#else
+      TGFX_PRIVATE_ACCESS(
+        if (type == Types::ImageFilterType::Blur) {
+          auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(filter);
+          auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(blurFilter);
+          EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
+          EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
+          EXPECT_EQ(blur1->tileMode, blur2->tileMode);
+        } else if (type == Types::ImageFilterType::DropShadow) {
+          auto dropShadow1 = std::static_pointer_cast<DropShadowImageFilter>(filter);
+          auto dropShadow2 = std::static_pointer_cast<DropShadowImageFilter>(dropShadowFilter);
+          EXPECT_EQ(dropShadow1->dx, dropShadow2->dx);
+          EXPECT_EQ(dropShadow1->dy, dropShadow2->dy);
+          EXPECT_EQ(dropShadow1->color, dropShadow2->color);
+          EXPECT_EQ(dropShadow1->shadowOnly, dropShadow2->shadowOnly);
+          auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow1->blurFilter);
+          auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(dropShadow2->blurFilter);
+          EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
+          EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
+          EXPECT_EQ(blur1->tileMode, blur2->tileMode);
+        } else if (type == Types::ImageFilterType::InnerShadow) {
+          auto innerShadow1 = std::static_pointer_cast<InnerShadowImageFilter>(filter);
+          auto innerShadow2 = std::static_pointer_cast<InnerShadowImageFilter>(innerShadowFilter);
+          EXPECT_EQ(innerShadow1->dx, innerShadow2->dx);
+          EXPECT_EQ(innerShadow1->dy, innerShadow2->dy);
+          EXPECT_EQ(innerShadow1->color, innerShadow2->color);
+          EXPECT_EQ(innerShadow1->shadowOnly, innerShadow2->shadowOnly);
+          auto blur1 = std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow1->blurFilter);
+          auto blur2 = std::static_pointer_cast<GaussianBlurImageFilter>(innerShadow2->blurFilter);
+          EXPECT_EQ(blur1->blurrinessX, blur2->blurrinessX);
+          EXPECT_EQ(blur1->blurrinessY, blur2->blurrinessY);
+          EXPECT_EQ(blur1->tileMode, blur2->tileMode);
+        }
+      )
       (void)type;
-#endif
     }
   }
 }

--- a/test/src/StrokeTest.cpp
+++ b/test/src/StrokeTest.cpp
@@ -269,7 +269,8 @@ TGFX_TEST_PRIVATE(StrokeTest, HairlineUniqueKey) {
 
   auto normalStrokeShape1 = Shape::ApplyStroke(shape, &hairlineStroke1);
   auto normalStrokeShape2 = Shape::ApplyStroke(shape, &hairlineStroke2);
-  TGFX_PRIVATE_ACCESS(EXPECT_NE(normalStrokeShape1->getUniqueKey(), normalStrokeShape2->getUniqueKey());)
+  TGFX_PRIVATE_ACCESS(
+      EXPECT_NE(normalStrokeShape1->getUniqueKey(), normalStrokeShape2->getUniqueKey());)
 }
 
 TGFX_TEST(StrokeTest, LineRenderAsHairline) {
@@ -313,10 +314,9 @@ TGFX_TEST(StrokeTest, SquareCapDashStrokeAsSolidStroke) {
   auto matrix = Matrix::MakeTrans(100, 100);
   shapeLayer1->setMatrix(matrix);
 
-  TGFX_PRIVATE_ACCESS(
-      auto simplifiedDashes1 =
-          SimplifyLineDashPattern(shapeLayer1->_lineDashPattern, shapeLayer1->stroke);
-      EXPECT_EQ(simplifiedDashes1.size(), 0u));
+  TGFX_PRIVATE_ACCESS(auto simplifiedDashes1 = SimplifyLineDashPattern(
+                          shapeLayer1->_lineDashPattern, shapeLayer1->stroke);
+                      EXPECT_EQ(simplifiedDashes1.size(), 0u));
 
   Path path2 = {};
   path2.addRect(-90, -90, 90, 90);
@@ -331,12 +331,10 @@ TGFX_TEST(StrokeTest, SquareCapDashStrokeAsSolidStroke) {
   shapeLayer2->setLineCap(LineCap::Square);
   shapeLayer2->setMatrix(Matrix::MakeTrans(100, 100));
 
-  TGFX_PRIVATE_ACCESS(
-      auto simplifiedDashes2 =
-          SimplifyLineDashPattern(shapeLayer2->_lineDashPattern, shapeLayer2->stroke);
-      EXPECT_EQ(simplifiedDashes2.size(), 2u);
-      EXPECT_EQ(simplifiedDashes2[0], 6.f);
-      EXPECT_EQ(simplifiedDashes2[1], 4.f));
+  TGFX_PRIVATE_ACCESS(auto simplifiedDashes2 = SimplifyLineDashPattern(
+                          shapeLayer2->_lineDashPattern, shapeLayer2->stroke);
+                      EXPECT_EQ(simplifiedDashes2.size(), 2u); EXPECT_EQ(simplifiedDashes2[0], 6.f);
+                      EXPECT_EQ(simplifiedDashes2[1], 4.f));
 
   DisplayList displayList;
   displayList.root()->addChild(shapeLayer1);

--- a/test/src/StrokeTest.cpp
+++ b/test/src/StrokeTest.cpp
@@ -248,6 +248,7 @@ TGFX_TEST(StrokeTest, ExtremelyThinStrokeLayer) {
 }
 
 TGFX_TEST(StrokeTest, HairlineUniqueKey) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   Stroke hairlineStroke1(0.f);
   hairlineStroke1.cap = LineCap::Round;
   hairlineStroke1.join = LineJoin::Miter;
@@ -270,6 +271,7 @@ TGFX_TEST(StrokeTest, HairlineUniqueKey) {
   auto normalStrokeShape1 = Shape::ApplyStroke(shape, &hairlineStroke1);
   auto normalStrokeShape2 = Shape::ApplyStroke(shape, &hairlineStroke2);
   EXPECT_NE(normalStrokeShape1->getUniqueKey(), normalStrokeShape2->getUniqueKey());
+#endif
 }
 
 TGFX_TEST(StrokeTest, LineRenderAsHairline) {
@@ -313,9 +315,11 @@ TGFX_TEST(StrokeTest, SquareCapDashStrokeAsSolidStroke) {
   auto matrix = Matrix::MakeTrans(100, 100);
   shapeLayer1->setMatrix(matrix);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto simplifiedDashes1 =
       SimplifyLineDashPattern(shapeLayer1->_lineDashPattern, shapeLayer1->stroke);
   EXPECT_EQ(simplifiedDashes1.size(), 0u);
+#endif
 
   Path path2 = {};
   path2.addRect(-90, -90, 90, 90);
@@ -330,11 +334,13 @@ TGFX_TEST(StrokeTest, SquareCapDashStrokeAsSolidStroke) {
   shapeLayer2->setLineCap(LineCap::Square);
   shapeLayer2->setMatrix(Matrix::MakeTrans(100, 100));
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto simplifiedDashes2 =
       SimplifyLineDashPattern(shapeLayer2->_lineDashPattern, shapeLayer2->stroke);
   EXPECT_EQ(simplifiedDashes2.size(), 2u);
   EXPECT_EQ(simplifiedDashes2[0], 6.f);
   EXPECT_EQ(simplifiedDashes2[1], 4.f);
+#endif
 
   DisplayList displayList;
   displayList.root()->addChild(shapeLayer1);
@@ -928,6 +934,7 @@ TGFX_TEST(StrokeTest, HairlineQuadOnly) {
 }
 
 TGFX_TEST(StrokeTest, HairlineBufferCacheReuse) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -1013,9 +1020,11 @@ TGFX_TEST(StrokeTest, HairlineBufferCacheReuse) {
     ASSERT_TRUE(proxy1 != nullptr);
     ASSERT_TRUE(proxy2 != nullptr);
   }
+#endif
 }
 
 TGFX_TEST(StrokeTest, HairlineShaderProgramCacheReuse) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   ContextScope scope;
   auto context = scope.getContext();
   auto surface = Surface::Make(context, 512, 512);
@@ -1086,6 +1095,7 @@ TGFX_TEST(StrokeTest, HairlineShaderProgramCacheReuse) {
       EXPECT_EQ(currentCount, lastProgramCount);
     }
   }
+#endif
 }
 
 TGFX_TEST(StrokeTest, HairlineComplexPathRendering) {

--- a/test/src/StrokeTest.cpp
+++ b/test/src/StrokeTest.cpp
@@ -247,8 +247,7 @@ TGFX_TEST(StrokeTest, ExtremelyThinStrokeLayer) {
   EXPECT_TRUE(Baseline::Compare(surface, "StrokeTest/ExtremelyThinStrokeLayer"));
 }
 
-TGFX_TEST(StrokeTest, HairlineUniqueKey) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(StrokeTest, HairlineUniqueKey) {
   Stroke hairlineStroke1(0.f);
   hairlineStroke1.cap = LineCap::Round;
   hairlineStroke1.join = LineJoin::Miter;
@@ -263,15 +262,14 @@ TGFX_TEST(StrokeTest, HairlineUniqueKey) {
   auto shape = Shape::MakeFrom(path);
   auto strokeShape1 = Shape::ApplyStroke(shape, &hairlineStroke1);
   auto strokeShape2 = Shape::ApplyStroke(shape, &hairlineStroke2);
-  EXPECT_EQ(strokeShape1->getUniqueKey(), strokeShape2->getUniqueKey());
+  TGFX_PRIVATE_ACCESS(EXPECT_EQ(strokeShape1->getUniqueKey(), strokeShape2->getUniqueKey());)
 
   hairlineStroke1.width = 1.f;
   hairlineStroke2.width = 1.f;
 
   auto normalStrokeShape1 = Shape::ApplyStroke(shape, &hairlineStroke1);
   auto normalStrokeShape2 = Shape::ApplyStroke(shape, &hairlineStroke2);
-  EXPECT_NE(normalStrokeShape1->getUniqueKey(), normalStrokeShape2->getUniqueKey());
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_NE(normalStrokeShape1->getUniqueKey(), normalStrokeShape2->getUniqueKey());)
 }
 
 TGFX_TEST(StrokeTest, LineRenderAsHairline) {
@@ -315,11 +313,10 @@ TGFX_TEST(StrokeTest, SquareCapDashStrokeAsSolidStroke) {
   auto matrix = Matrix::MakeTrans(100, 100);
   shapeLayer1->setMatrix(matrix);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto simplifiedDashes1 =
-      SimplifyLineDashPattern(shapeLayer1->_lineDashPattern, shapeLayer1->stroke);
-  EXPECT_EQ(simplifiedDashes1.size(), 0u);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto simplifiedDashes1 =
+          SimplifyLineDashPattern(shapeLayer1->_lineDashPattern, shapeLayer1->stroke);
+      EXPECT_EQ(simplifiedDashes1.size(), 0u));
 
   Path path2 = {};
   path2.addRect(-90, -90, 90, 90);
@@ -334,13 +331,12 @@ TGFX_TEST(StrokeTest, SquareCapDashStrokeAsSolidStroke) {
   shapeLayer2->setLineCap(LineCap::Square);
   shapeLayer2->setMatrix(Matrix::MakeTrans(100, 100));
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto simplifiedDashes2 =
-      SimplifyLineDashPattern(shapeLayer2->_lineDashPattern, shapeLayer2->stroke);
-  EXPECT_EQ(simplifiedDashes2.size(), 2u);
-  EXPECT_EQ(simplifiedDashes2[0], 6.f);
-  EXPECT_EQ(simplifiedDashes2[1], 4.f);
-#endif
+  TGFX_PRIVATE_ACCESS(
+      auto simplifiedDashes2 =
+          SimplifyLineDashPattern(shapeLayer2->_lineDashPattern, shapeLayer2->stroke);
+      EXPECT_EQ(simplifiedDashes2.size(), 2u);
+      EXPECT_EQ(simplifiedDashes2[0], 6.f);
+      EXPECT_EQ(simplifiedDashes2[1], 4.f));
 
   DisplayList displayList;
   displayList.root()->addChild(shapeLayer1);
@@ -933,8 +929,7 @@ TGFX_TEST(StrokeTest, HairlineQuadOnly) {
   EXPECT_TRUE(Baseline::Compare(surface, "StrokeTest/HairlineQuadOnly"));
 }
 
-TGFX_TEST(StrokeTest, HairlineBufferCacheReuse) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(StrokeTest, HairlineBufferCacheReuse) {
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -951,7 +946,7 @@ TGFX_TEST(StrokeTest, HairlineBufferCacheReuse) {
   };
 
   // Test 1: Verify proxyMap size changes
-  {
+  TGFX_PRIVATE_ACCESS({
     auto& proxyMap = proxyProvider->proxyMap;
     proxyProvider->purgeExpiredProxies();
     size_t initialSize = proxyMap.size();
@@ -972,7 +967,7 @@ TGFX_TEST(StrokeTest, HairlineBufferCacheReuse) {
     proxyProvider->purgeExpiredProxies();
     size_t sizeAfterPurge = proxyMap.size();
     EXPECT_LE(sizeAfterPurge, initialSize + 4);
-  }
+  })
 
   // Test 2: Same shape and hasCap should reuse buffer proxies
   {
@@ -1020,11 +1015,9 @@ TGFX_TEST(StrokeTest, HairlineBufferCacheReuse) {
     ASSERT_TRUE(proxy1 != nullptr);
     ASSERT_TRUE(proxy2 != nullptr);
   }
-#endif
 }
 
-TGFX_TEST(StrokeTest, HairlineShaderProgramCacheReuse) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(StrokeTest, HairlineShaderProgramCacheReuse) {
   ContextScope scope;
   auto context = scope.getContext();
   auto surface = Surface::Make(context, 512, 512);
@@ -1061,7 +1054,8 @@ TGFX_TEST(StrokeTest, HairlineShaderProgramCacheReuse) {
   };
 
   auto globalCache = context->globalCache();
-  auto initialCount = globalCache->programMap.size();
+  size_t initialCount = 0;
+  TGFX_PRIVATE_ACCESS(initialCount = globalCache->programMap.size();)
   size_t lastProgramCount = initialCount;
 
   for (size_t i = 0; i < testCases.size(); ++i) {
@@ -1089,13 +1083,13 @@ TGFX_TEST(StrokeTest, HairlineShaderProgramCacheReuse) {
 
     context->flushAndSubmit();
 
-    auto currentCount = globalCache->programMap.size();
+    size_t currentCount = 0;
+    TGFX_PRIVATE_ACCESS(currentCount = globalCache->programMap.size();)
 
     if (testCase.shouldReuseProgram) {
       EXPECT_EQ(currentCount, lastProgramCount);
     }
   }
-#endif
 }
 
 TGFX_TEST(StrokeTest, HairlineComplexPathRendering) {

--- a/test/src/SurfaceRenderTest.cpp
+++ b/test/src/SurfaceRenderTest.cpp
@@ -67,11 +67,15 @@ TGFX_TEST(SurfaceRenderTest, ImageSnapshot) {
   surface = Surface::Make(context, width, height, false, 4);
   canvas = surface->getCanvas();
   snapshotImage = surface->makeImageSnapshot();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   auto renderTargetProxy = surface->renderContext->renderTarget;
+#endif
   snapshotImage = nullptr;
   canvas->drawImage(image);
   context->flushAndSubmit();
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   EXPECT_TRUE(renderTargetProxy == surface->renderContext->renderTarget);
+#endif
   snapshotImage = surface->makeImageSnapshot();
   snapshotImage2 = surface->makeImageSnapshot();
   EXPECT_TRUE(snapshotImage == snapshotImage2);

--- a/test/src/SurfaceRenderTest.cpp
+++ b/test/src/SurfaceRenderTest.cpp
@@ -67,15 +67,11 @@ TGFX_TEST(SurfaceRenderTest, ImageSnapshot) {
   surface = Surface::Make(context, width, height, false, 4);
   canvas = surface->getCanvas();
   snapshotImage = surface->makeImageSnapshot();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  auto renderTargetProxy = surface->renderContext->renderTarget;
-#endif
+  TGFX_PRIVATE_ACCESS(auto renderTargetProxy = surface->renderContext->renderTarget;)
   snapshotImage = nullptr;
   canvas->drawImage(image);
   context->flushAndSubmit();
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  EXPECT_TRUE(renderTargetProxy == surface->renderContext->renderTarget);
-#endif
+  TGFX_PRIVATE_ACCESS(EXPECT_TRUE(renderTargetProxy == surface->renderContext->renderTarget);)
   snapshotImage = surface->makeImageSnapshot();
   snapshotImage2 = surface->makeImageSnapshot();
   EXPECT_TRUE(snapshotImage == snapshotImage2);

--- a/test/src/TextAlignTest.cpp
+++ b/test/src/TextAlignTest.cpp
@@ -210,7 +210,9 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayerBounds = textLayer->getGlobalMatrix().mapRect(textLayerBounds);
+#endif
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(50.0f, 100.0f));
@@ -224,7 +226,9 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayer2Bounds = textLayer2->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer2Bounds = textLayer2->getGlobalMatrix().mapRect(textLayer2Bounds);
+#endif
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(50.0f, 200.0f));
@@ -238,7 +242,9 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayer3Bounds = textLayer3->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer3Bounds = textLayer3->getGlobalMatrix().mapRect(textLayer3Bounds);
+#endif
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(50.0f, 300.0f));
@@ -252,7 +258,9 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayer4Bounds = textLayer4->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer4Bounds = textLayer4->getGlobalMatrix().mapRect(textLayer4Bounds);
+#endif
 
   auto textLayer5 = TextLayer::Make();
   textLayer5->setMatrix(Matrix::MakeTrans(50.0f, 400.0f));
@@ -266,7 +274,9 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer5->setFont(font);
   parentLayer->addChild(textLayer5);
   auto textLayer5Bounds = textLayer5->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer5Bounds = textLayer5->getGlobalMatrix().mapRect(textLayer5Bounds);
+#endif
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -314,7 +324,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
+#endif
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(100.0f, 0.0f));
@@ -328,7 +340,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayer2Bounds = textLayer2->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer2->getGlobalMatrix().mapRect(&textLayer2Bounds);
+#endif
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(200.0f, 0.0f));
@@ -342,7 +356,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayer3Bounds = textLayer3->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer3->getGlobalMatrix().mapRect(&textLayer3Bounds);
+#endif
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(300.0f, 0.0f));
@@ -356,7 +372,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayer4Bounds = textLayer4->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer4->getGlobalMatrix().mapRect(&textLayer4Bounds);
+#endif
 
   auto textLayer5 = TextLayer::Make();
   textLayer5->setMatrix(Matrix::MakeTrans(0.0f, 300.0f));
@@ -370,7 +388,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer5->setFont(font);
   parentLayer->addChild(textLayer5);
   auto textLayer5Bounds = textLayer5->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer5->getGlobalMatrix().mapRect(&textLayer5Bounds);
+#endif
 
   auto textLayer6 = TextLayer::Make();
   textLayer6->setMatrix(Matrix::MakeTrans(100.0f, 300.0f));
@@ -384,7 +404,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer6->setFont(font);
   parentLayer->addChild(textLayer6);
   auto textLayer6Bounds = textLayer6->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer6->getGlobalMatrix().mapRect(&textLayer6Bounds);
+#endif
 
   auto textLayer7 = TextLayer::Make();
   textLayer7->setMatrix(Matrix::MakeTrans(200.0f, 300.0f));
@@ -398,7 +420,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer7->setFont(font);
   parentLayer->addChild(textLayer7);
   auto textLayer7Bounds = textLayer7->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer7->getGlobalMatrix().mapRect(&textLayer7Bounds);
+#endif
 
   auto textLayer8 = TextLayer::Make();
   textLayer8->setMatrix(Matrix::MakeTrans(300.0f, 300.0f));
@@ -412,7 +436,9 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer8->setFont(font);
   parentLayer->addChild(textLayer8);
   auto textLayer8Bounds = textLayer8->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer8->getGlobalMatrix().mapRect(&textLayer8Bounds);
+#endif
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -462,7 +488,9 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
+#endif
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(0.0f, 50.0f));
@@ -476,7 +504,9 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayer2Bounds = textLayer2->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer2->getGlobalMatrix().mapRect(&textLayer2Bounds);
+#endif
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(0.0f, 100.0f));
@@ -490,7 +520,9 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayer3Bounds = textLayer3->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer3->getGlobalMatrix().mapRect(&textLayer3Bounds);
+#endif
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(0.0f, 150.0f));
@@ -504,7 +536,9 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayer4Bounds = textLayer4->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer4->getGlobalMatrix().mapRect(&textLayer4Bounds);
+#endif
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -626,7 +660,9 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
+#endif
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(0.0f, 100.0f));
@@ -640,7 +676,9 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayerBounds2 = textLayer2->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer2->getGlobalMatrix().mapRect(&textLayerBounds2);
+#endif
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(150.0f, 100.0f));
@@ -654,7 +692,9 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayerBounds3 = textLayer3->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer3->getGlobalMatrix().mapRect(&textLayerBounds3);
+#endif
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(300.0f, 100.0f));
@@ -668,7 +708,9 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayerBounds4 = textLayer4->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer4->getGlobalMatrix().mapRect(&textLayerBounds4);
+#endif
 
   auto textLayer5 = TextLayer::Make();
   textLayer5->setMatrix(Matrix::MakeTrans(450.0f, 100.0f));
@@ -682,7 +724,9 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer5->setFont(font);
   parentLayer->addChild(textLayer5);
   auto textLayerBounds5 = textLayer5->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer5->getGlobalMatrix().mapRect(&textLayerBounds5);
+#endif
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -732,7 +776,9 @@ TGFX_TEST(TextAlignTest, TextAlignBlankLineTest) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
+#endif
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(150.0f, 0.0f));
@@ -761,10 +807,12 @@ TGFX_TEST(TextAlignTest, TextAlignBlankLineTest) {
 }
 
 TGFX_TEST(TextAlignTest, TextAlignPrint) {
+#ifdef TGFX_TEST_ACCESS_PRIVATE
   std::string text = "ab\rcd\nef\r\ngh\n\rij\tk\r\r\rp";
   auto textLayer = TextLayer::Make();
   textLayer->setText(text);
   text = TextLayer::PreprocessNewLines(text);
   EXPECT_EQ(text, "ab\ncd\nef\ngh\n\nij\tk\n\n\np");
+#endif
 }
 }  // namespace tgfx

--- a/test/src/TextAlignTest.cpp
+++ b/test/src/TextAlignTest.cpp
@@ -210,9 +210,7 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayerBounds = textLayer->getGlobalMatrix().mapRect(textLayerBounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayerBounds = textLayer->getGlobalMatrix().mapRect(textLayerBounds));
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(50.0f, 100.0f));
@@ -226,9 +224,7 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayer2Bounds = textLayer2->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer2Bounds = textLayer2->getGlobalMatrix().mapRect(textLayer2Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer2Bounds = textLayer2->getGlobalMatrix().mapRect(textLayer2Bounds));
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(50.0f, 200.0f));
@@ -242,9 +238,7 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayer3Bounds = textLayer3->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer3Bounds = textLayer3->getGlobalMatrix().mapRect(textLayer3Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer3Bounds = textLayer3->getGlobalMatrix().mapRect(textLayer3Bounds));
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(50.0f, 300.0f));
@@ -258,9 +252,7 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayer4Bounds = textLayer4->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer4Bounds = textLayer4->getGlobalMatrix().mapRect(textLayer4Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer4Bounds = textLayer4->getGlobalMatrix().mapRect(textLayer4Bounds));
 
   auto textLayer5 = TextLayer::Make();
   textLayer5->setMatrix(Matrix::MakeTrans(50.0f, 400.0f));
@@ -274,9 +266,7 @@ TGFX_TEST(TextAlignTest, TextAlignWidth1Height10) {
   textLayer5->setFont(font);
   parentLayer->addChild(textLayer5);
   auto textLayer5Bounds = textLayer5->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer5Bounds = textLayer5->getGlobalMatrix().mapRect(textLayer5Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer5Bounds = textLayer5->getGlobalMatrix().mapRect(textLayer5Bounds));
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -324,9 +314,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer->getGlobalMatrix().mapRect(&textLayerBounds));
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(100.0f, 0.0f));
@@ -340,9 +328,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayer2Bounds = textLayer2->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer2->getGlobalMatrix().mapRect(&textLayer2Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer2->getGlobalMatrix().mapRect(&textLayer2Bounds));
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(200.0f, 0.0f));
@@ -356,9 +342,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayer3Bounds = textLayer3->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer3->getGlobalMatrix().mapRect(&textLayer3Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer3->getGlobalMatrix().mapRect(&textLayer3Bounds));
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(300.0f, 0.0f));
@@ -372,9 +356,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayer4Bounds = textLayer4->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer4->getGlobalMatrix().mapRect(&textLayer4Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer4->getGlobalMatrix().mapRect(&textLayer4Bounds));
 
   auto textLayer5 = TextLayer::Make();
   textLayer5->setMatrix(Matrix::MakeTrans(0.0f, 300.0f));
@@ -388,9 +370,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer5->setFont(font);
   parentLayer->addChild(textLayer5);
   auto textLayer5Bounds = textLayer5->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer5->getGlobalMatrix().mapRect(&textLayer5Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer5->getGlobalMatrix().mapRect(&textLayer5Bounds));
 
   auto textLayer6 = TextLayer::Make();
   textLayer6->setMatrix(Matrix::MakeTrans(100.0f, 300.0f));
@@ -404,9 +384,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer6->setFont(font);
   parentLayer->addChild(textLayer6);
   auto textLayer6Bounds = textLayer6->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer6->getGlobalMatrix().mapRect(&textLayer6Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer6->getGlobalMatrix().mapRect(&textLayer6Bounds));
 
   auto textLayer7 = TextLayer::Make();
   textLayer7->setMatrix(Matrix::MakeTrans(200.0f, 300.0f));
@@ -420,9 +398,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer7->setFont(font);
   parentLayer->addChild(textLayer7);
   auto textLayer7Bounds = textLayer7->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer7->getGlobalMatrix().mapRect(&textLayer7Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer7->getGlobalMatrix().mapRect(&textLayer7Bounds));
 
   auto textLayer8 = TextLayer::Make();
   textLayer8->setMatrix(Matrix::MakeTrans(300.0f, 300.0f));
@@ -436,9 +412,7 @@ TGFX_TEST(TextAlignTest, TextAlignSimulateVerticalTextLayout) {
   textLayer8->setFont(font);
   parentLayer->addChild(textLayer8);
   auto textLayer8Bounds = textLayer8->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer8->getGlobalMatrix().mapRect(&textLayer8Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer8->getGlobalMatrix().mapRect(&textLayer8Bounds));
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -488,9 +462,7 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer->getGlobalMatrix().mapRect(&textLayerBounds));
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(0.0f, 50.0f));
@@ -504,9 +476,7 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayer2Bounds = textLayer2->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer2->getGlobalMatrix().mapRect(&textLayer2Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer2->getGlobalMatrix().mapRect(&textLayer2Bounds));
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(0.0f, 100.0f));
@@ -520,9 +490,7 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayer3Bounds = textLayer3->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer3->getGlobalMatrix().mapRect(&textLayer3Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer3->getGlobalMatrix().mapRect(&textLayer3Bounds));
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(0.0f, 150.0f));
@@ -536,9 +504,7 @@ TGFX_TEST(TextAlignTest, SingleLineTextAlign) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayer4Bounds = textLayer4->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer4->getGlobalMatrix().mapRect(&textLayer4Bounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer4->getGlobalMatrix().mapRect(&textLayer4Bounds));
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -660,9 +626,7 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer->getGlobalMatrix().mapRect(&textLayerBounds));
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(0.0f, 100.0f));
@@ -676,9 +640,7 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer2->setFont(font);
   parentLayer->addChild(textLayer2);
   auto textLayerBounds2 = textLayer2->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer2->getGlobalMatrix().mapRect(&textLayerBounds2);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer2->getGlobalMatrix().mapRect(&textLayerBounds2));
 
   auto textLayer3 = TextLayer::Make();
   textLayer3->setMatrix(Matrix::MakeTrans(150.0f, 100.0f));
@@ -692,9 +654,7 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer3->setFont(font);
   parentLayer->addChild(textLayer3);
   auto textLayerBounds3 = textLayer3->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer3->getGlobalMatrix().mapRect(&textLayerBounds3);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer3->getGlobalMatrix().mapRect(&textLayerBounds3));
 
   auto textLayer4 = TextLayer::Make();
   textLayer4->setMatrix(Matrix::MakeTrans(300.0f, 100.0f));
@@ -708,9 +668,7 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer4->setFont(font);
   parentLayer->addChild(textLayer4);
   auto textLayerBounds4 = textLayer4->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer4->getGlobalMatrix().mapRect(&textLayerBounds4);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer4->getGlobalMatrix().mapRect(&textLayerBounds4));
 
   auto textLayer5 = TextLayer::Make();
   textLayer5->setMatrix(Matrix::MakeTrans(450.0f, 100.0f));
@@ -724,9 +682,7 @@ TGFX_TEST(TextAlignTest, FontFallbackTest) {
   textLayer5->setFont(font);
   parentLayer->addChild(textLayer5);
   auto textLayerBounds5 = textLayer5->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer5->getGlobalMatrix().mapRect(&textLayerBounds5);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer5->getGlobalMatrix().mapRect(&textLayerBounds5));
 
   displayList->root()->addChild(rootLayer);
   displayList->render(surface.get());
@@ -776,9 +732,7 @@ TGFX_TEST(TextAlignTest, TextAlignBlankLineTest) {
   textLayer->setFont(font);
   parentLayer->addChild(textLayer);
   auto textLayerBounds = textLayer->getBounds(nullptr, true);
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-  textLayer->getGlobalMatrix().mapRect(&textLayerBounds);
-#endif
+  TGFX_PRIVATE_ACCESS(textLayer->getGlobalMatrix().mapRect(&textLayerBounds));
 
   auto textLayer2 = TextLayer::Make();
   textLayer2->setMatrix(Matrix::MakeTrans(150.0f, 0.0f));
@@ -806,13 +760,13 @@ TGFX_TEST(TextAlignTest, TextAlignBlankLineTest) {
   EXPECT_TRUE(Baseline::Compare(surface, "TextAlignTest/TextAlignBlankLineTest"));
 }
 
-TGFX_TEST(TextAlignTest, TextAlignPrint) {
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_TEST_PRIVATE(TextAlignTest, TextAlignPrint) {
   std::string text = "ab\rcd\nef\r\ngh\n\rij\tk\r\r\rp";
   auto textLayer = TextLayer::Make();
   textLayer->setText(text);
-  text = TextLayer::PreprocessNewLines(text);
-  EXPECT_EQ(text, "ab\ncd\nef\ngh\n\nij\tk\n\n\np");
-#endif
+  TGFX_PRIVATE_ACCESS({
+    text = TextLayer::PreprocessNewLines(text);
+    EXPECT_EQ(text, "ab\ncd\nef\ngh\n\nij\tk\n\n\np");
+  })
 }
 }  // namespace tgfx

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -4814,7 +4814,7 @@ static std::vector<std::shared_ptr<VectorElement>> MakeComplexFitCellContents(
 
 // Non-linear gradient variants: radial, conic, diamond.
 static std::vector<std::shared_ptr<VectorElement>> MakeRadialCellContents(
-    float cx, float cy, int column, float cellSize,     const std::vector<Color>& gradientColors) {
+    float cx, float cy, int column, float cellSize, const std::vector<Color>& gradientColors) {
   auto rect = Rectangle::Make();
   rect->setPosition({cx, cy});
   rect->setSize({cellSize * 0.7f, cellSize * 0.7f});

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -2644,20 +2644,20 @@ TGFX_TEST(VectorLayerTest, Gradient) {
   // rectangle maps the same 0-1 gradient independently, so all three rectangles look identical.
   auto relativeCompare = Gradient::MakeLinear({0, 0.5f}, {1, 0.5f}, compareColors);
   EXPECT_EQ(relativeCompare->fitsToGeometry(), true);
-  auto group5 = std::make_shared<VectorGroup>();
-  auto rect5 = std::make_shared<Rectangle>();
+  auto group5 = VectorGroup::Make();
+  auto rect5 = Rectangle::Make();
   rect5->setPosition({rowCenters[0], 240});
   rect5->setSize({rowRectSize, rowRectSize});
   group5->setElements({rect5, FillStyle::Make(relativeCompare)});
 
-  auto group6 = std::make_shared<VectorGroup>();
-  auto rect6 = std::make_shared<Rectangle>();
+  auto group6 = VectorGroup::Make();
+  auto rect6 = Rectangle::Make();
   rect6->setPosition({rowCenters[1], 240});
   rect6->setSize({rowRectSize, rowRectSize});
   group6->setElements({rect6, FillStyle::Make(relativeCompare)});
 
-  auto group7 = std::make_shared<VectorGroup>();
-  auto rect7 = std::make_shared<Rectangle>();
+  auto group7 = VectorGroup::Make();
+  auto rect7 = Rectangle::Make();
   rect7->setPosition({rowCenters[2], 240});
   rect7->setSize({rowRectSize, rowRectSize});
   group7->setElements({rect7, FillStyle::Make(relativeCompare)});
@@ -2670,20 +2670,20 @@ TGFX_TEST(VectorLayerTest, Gradient) {
                            {rowCenters[2] + rowRectSize * 0.5f, 0}, compareColors);
   absoluteCompare->setFitsToGeometry(false);
   EXPECT_EQ(absoluteCompare->fitsToGeometry(), false);
-  auto group8 = std::make_shared<VectorGroup>();
-  auto rect8 = std::make_shared<Rectangle>();
+  auto group8 = VectorGroup::Make();
+  auto rect8 = Rectangle::Make();
   rect8->setPosition({rowCenters[0], 350});
   rect8->setSize({rowRectSize, rowRectSize});
   group8->setElements({rect8, FillStyle::Make(absoluteCompare)});
 
-  auto group9 = std::make_shared<VectorGroup>();
-  auto rect9 = std::make_shared<Rectangle>();
+  auto group9 = VectorGroup::Make();
+  auto rect9 = Rectangle::Make();
   rect9->setPosition({rowCenters[1], 350});
   rect9->setSize({rowRectSize, rowRectSize});
   group9->setElements({rect9, FillStyle::Make(absoluteCompare)});
 
-  auto group10 = std::make_shared<VectorGroup>();
-  auto rect10 = std::make_shared<Rectangle>();
+  auto group10 = VectorGroup::Make();
+  auto rect10 = Rectangle::Make();
   rect10->setPosition({rowCenters[2], 350});
   rect10->setSize({rowRectSize, rowRectSize});
   group10->setElements({rect10, FillStyle::Make(absoluteCompare)});
@@ -2832,8 +2832,8 @@ TGFX_TEST(VectorLayerTest, ImagePattern) {
   EXPECT_EQ(relativePattern->scaleMode(), ScaleMode::LetterBox);
   std::vector<std::shared_ptr<VectorElement>> contents = {group1, group2, group3};
   for (float cx : rowCenters) {
-    auto rectGroup = std::make_shared<VectorGroup>();
-    auto rect = std::make_shared<Rectangle>();
+    auto rectGroup = VectorGroup::Make();
+    auto rect = Rectangle::Make();
     rect->setPosition({cx, 240});
     rect->setSize({rowRectSize, rowRectSize});
     rectGroup->setElements({rect, FillStyle::Make(relativePattern)});
@@ -2847,8 +2847,8 @@ TGFX_TEST(VectorLayerTest, ImagePattern) {
   auto windowPattern = ImagePattern::Make(image);
   windowPattern->setScaleMode(ScaleMode::None);
   for (float cx : rowCenters) {
-    auto rectGroup = std::make_shared<VectorGroup>();
-    auto rect = std::make_shared<Rectangle>();
+    auto rectGroup = VectorGroup::Make();
+    auto rect = Rectangle::Make();
     rect->setPosition({cx, 350});
     rect->setSize({rowRectSize, rowRectSize});
     rectGroup->setElements({rect, FillStyle::Make(windowPattern)});
@@ -2918,8 +2918,8 @@ TGFX_TEST(VectorLayerTest, ImagePatternScaleMode) {
     auto cellLayer = VectorLayer::Make();
     cellLayer->setMatrix(
         Matrix::MakeTrans(centerX - rectWidth * 0.5f, row1CenterY - rectHeight * 0.5f));
-    auto cellGroup = std::make_shared<VectorGroup>();
-    auto rect = std::make_shared<Rectangle>();
+    auto cellGroup = VectorGroup::Make();
+    auto rect = Rectangle::Make();
     rect->setPosition({rectWidth * 0.5f, rectHeight * 0.5f});
     rect->setSize({rectWidth, rectHeight});
     auto pattern = ImagePattern::Make(image);
@@ -2931,7 +2931,7 @@ TGFX_TEST(VectorLayerTest, ImagePatternScaleMode) {
     cellLayer->setContents({cellGroup});
     displayList->root()->addChild(cellLayer);
 
-    auto labelGroup = std::make_shared<VectorGroup>();
+    auto labelGroup = VectorGroup::Make();
     auto blob = TextBlob::MakeFrom(entries[i].label, labelFont);
     auto text = Text::Make(blob);
     auto labelBounds = blob->getTightBounds();
@@ -2960,8 +2960,8 @@ TGFX_TEST(VectorLayerTest, ImagePatternScaleMode) {
     auto cellLayer = VectorLayer::Make();
     cellLayer->setMatrix(
         Matrix::MakeTrans(centerX - rectWidth * 0.5f, row2CenterY - rectHeight * 0.5f));
-    auto cellGroup = std::make_shared<VectorGroup>();
-    auto rect = std::make_shared<Rectangle>();
+    auto cellGroup = VectorGroup::Make();
+    auto rect = Rectangle::Make();
     rect->setPosition({rectWidth * 0.5f, rectHeight * 0.5f});
     rect->setSize({rectWidth, rectHeight});
     auto pattern = ImagePattern::Make(image);
@@ -2972,7 +2972,7 @@ TGFX_TEST(VectorLayerTest, ImagePatternScaleMode) {
     cellLayer->setContents({cellGroup});
     displayList->root()->addChild(cellLayer);
 
-    auto labelGroup = std::make_shared<VectorGroup>();
+    auto labelGroup = VectorGroup::Make();
     auto blob = TextBlob::MakeFrom(entries[i].label, labelFont);
     auto text = Text::Make(blob);
     auto labelBounds = blob->getTightBounds();
@@ -4647,7 +4647,7 @@ TGFX_TEST(VectorLayerTest, Line) {
   line1->setStartPoint({50, 54});
   line1->setEndPoint({550, 54});
   auto stroke1 = MakeStrokeStyle(Color::Red(), 8.0f);
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setElements({line1, stroke1});
 
   // Line 2: Diagonal line with dashed blue stroke.
@@ -4657,18 +4657,18 @@ TGFX_TEST(VectorLayerTest, Line) {
   auto stroke2 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
   stroke2->setStrokeWidth(8.0f);
   stroke2->setDashes({24.0f, 12.0f});
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setElements({line2, stroke2});
 
   // Line 3: Forward line trimmed to the first half, stroked green.
   auto line3 = Line::Make();
   line3->setStartPoint({50, 346});
   line3->setEndPoint({300, 346});
-  auto trim3 = std::make_shared<TrimPath>();
+  auto trim3 = TrimPath::Make();
   trim3->setStart(0.0f);
   trim3->setEnd(0.5f);
   auto stroke3 = MakeStrokeStyle(Color::Green(), 8.0f);
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setElements({line3, trim3, stroke3});
 
   // Line 4: Reversed line with the same trim; the opposite half should be drawn.
@@ -4676,25 +4676,25 @@ TGFX_TEST(VectorLayerTest, Line) {
   line4->setStartPoint({300, 346});
   line4->setEndPoint({550, 346});
   line4->setReversed(true);
-  auto trim4 = std::make_shared<TrimPath>();
+  auto trim4 = TrimPath::Make();
   trim4->setStart(0.0f);
   trim4->setEnd(0.5f);
   auto stroke4 = MakeStrokeStyle(Color::FromRGBA(255, 128, 0, 255), 8.0f);
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setElements({line4, trim4, stroke4});
 
   // Line 5: Zero-height rectangle with a wide, vertically-oriented fit gradient Outside stroke.
   // The rectangle collapses to a horizontal segment, so Outside stroke should expand it into a
   // band whose gradient direction shows that the fit region tracks the stroked geometry rather
   // than the degenerate original rect.
-  auto degenerateRect = std::make_shared<Rectangle>();
+  auto degenerateRect = Rectangle::Make();
   degenerateRect->setPosition({300, 430});
   degenerateRect->setSize({500, 0});
   auto gradient5 = Gradient::MakeLinear({0.5f, 0.0f}, {0.5f, 1.0f}, {Color::Red(), Color::Blue()});
   auto stroke5 = StrokeStyle::Make(gradient5);
   stroke5->setStrokeWidth(24.0f);
   stroke5->setStrokeAlign(StrokeAlign::Outside);
-  auto group5 = std::make_shared<VectorGroup>();
+  auto group5 = VectorGroup::Make();
   group5->setElements({degenerateRect, stroke5});
 
   vectorLayer->setContents({group1, group2, group3, group4, group5});
@@ -4745,7 +4745,7 @@ TGFX_TEST(VectorLayerTest, FitsToGeometrySwitch) {
 static std::shared_ptr<VectorGroup> WrapInOuterGroup(std::shared_ptr<VectorGroup> inner,
                                                      const Point& center, float rotation,
                                                      const Point& scale) {
-  auto outer = std::make_shared<VectorGroup>();
+  auto outer = VectorGroup::Make();
   outer->setAnchor(center);
   outer->setPosition(center);
   outer->setRotation(rotation);
@@ -4757,7 +4757,7 @@ static std::shared_ptr<VectorGroup> WrapInOuterGroup(std::shared_ptr<VectorGroup
 static std::vector<std::shared_ptr<VectorElement>> MakeRectFitCellContents(
     float cx, float cy, int column, float cellSize, const std::vector<Color>& gradientColors,
     const std::shared_ptr<Image>& image) {
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setPosition({cx, cy});
   rect->setSize({cellSize * 0.7f, cellSize * 0.7f});
   std::vector<std::shared_ptr<VectorElement>> elements = {rect};
@@ -4782,7 +4782,7 @@ static std::vector<std::shared_ptr<VectorElement>> MakeRectFitCellContents(
 static std::vector<std::shared_ptr<VectorElement>> MakeComplexFitCellContents(
     float cx, float cy, int column, float cellSize, const std::vector<Color>& gradientColors,
     const std::shared_ptr<Image>& image) {
-  auto star = std::make_shared<Polystar>();
+  auto star = Polystar::Make();
   star->setPolystarType(PolystarType::Star);
   star->setPosition({cx, cy});
   star->setOuterRadius(cellSize * 0.4f);
@@ -4814,8 +4814,8 @@ static std::vector<std::shared_ptr<VectorElement>> MakeComplexFitCellContents(
 
 // Non-linear gradient variants: radial, conic, diamond.
 static std::vector<std::shared_ptr<VectorElement>> MakeRadialCellContents(
-    float cx, float cy, int column, float cellSize, const std::vector<Color>& gradientColors) {
-  auto rect = std::make_shared<Rectangle>();
+    float cx, float cy, int column, float cellSize,     const std::vector<Color>& gradientColors) {
+  auto rect = Rectangle::Make();
   rect->setPosition({cx, cy});
   rect->setSize({cellSize * 0.7f, cellSize * 0.7f});
   std::shared_ptr<ColorSource> colorSource = nullptr;
@@ -4835,13 +4835,13 @@ static std::vector<std::shared_ptr<VectorElement>> MakeRadialCellContents(
 // letterbox bars show up against a non-white color.
 static std::vector<std::shared_ptr<VectorElement>> MakePatternScaleCellContents(
     float cx, float cy, int column, float cellSize, const std::shared_ptr<Image>& image) {
-  auto backdropRect = std::make_shared<Rectangle>();
+  auto backdropRect = Rectangle::Make();
   backdropRect->setPosition({cx, cy});
   backdropRect->setSize({cellSize * 0.85f, cellSize * 0.5f});
-  auto backdropGroup = std::make_shared<VectorGroup>();
+  auto backdropGroup = VectorGroup::Make();
   backdropGroup->setElements({backdropRect, MakeFillStyle(Color::FromRGBA(220, 220, 220, 255))});
 
-  auto patternRect = std::make_shared<Rectangle>();
+  auto patternRect = Rectangle::Make();
   patternRect->setPosition({cx, cy});
   patternRect->setSize({cellSize * 0.85f, cellSize * 0.5f});
   auto pattern = ImagePattern::Make(image);
@@ -4852,7 +4852,7 @@ static std::vector<std::shared_ptr<VectorElement>> MakePatternScaleCellContents(
   } else {
     pattern->setScaleMode(ScaleMode::Zoom);
   }
-  auto patternGroup = std::make_shared<VectorGroup>();
+  auto patternGroup = VectorGroup::Make();
   patternGroup->setElements({patternRect, FillStyle::Make(pattern)});
 
   return {backdropGroup, patternGroup};
@@ -4862,7 +4862,7 @@ static std::vector<std::shared_ptr<VectorElement>> MakePatternScaleCellContents(
 static std::vector<std::shared_ptr<VectorElement>> MakeAbsoluteCellContents(
     float cx, float cy, int column, float cellSize, const std::vector<Color>& gradientColors,
     const std::shared_ptr<Image>& image) {
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setPosition({cx, cy});
   rect->setSize({cellSize * 0.7f, cellSize * 0.7f});
   std::vector<std::shared_ptr<VectorElement>> elements = {rect};
@@ -4896,7 +4896,7 @@ static std::vector<std::shared_ptr<VectorElement>> MakeAbsoluteCellContents(
 static std::vector<std::shared_ptr<VectorElement>> MakeStrokeAlignCellContents(
     float cx, float cy, int column, float cellSize, const std::vector<Color>& gradientColors,
     const std::shared_ptr<Image>& image) {
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setPosition({cx, cy});
   rect->setSize({cellSize * 0.7f, cellSize * 0.7f});
   std::shared_ptr<ColorSource> source = nullptr;
@@ -4990,7 +4990,7 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
   for (int col = 0; col < 3; col++) {
     float cx = cellCenterX(col);
     float cy = cellCenterY(0);
-    auto cellGroup = std::make_shared<VectorGroup>();
+    auto cellGroup = VectorGroup::Make();
     cellGroup->setElements(MakeRectFitCellContents(cx, cy, col, cellSize, gradientColors, image));
     contents.push_back(cellGroup);
   }
@@ -5011,9 +5011,9 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
     float cx = cellCenterX(col + 3);
     float cy = cellCenterY(0);
     const auto& config = rectNested[static_cast<size_t>(col)];
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setElements(MakeRectFitCellContents(cx, cy, col, cellSize, gradientColors, image));
-    auto middleGroup = std::make_shared<VectorGroup>();
+    auto middleGroup = VectorGroup::Make();
     middleGroup->setAnchor({cx, cy});
     middleGroup->setPosition({cx, cy});
     middleGroup->setRotation(config.middleRotation);
@@ -5033,10 +5033,10 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
     float cx = cellCenterX(col);
     float cy = cellCenterY(1);
     const auto& config = starNested[static_cast<size_t>(col)];
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setElements(
         MakeComplexFitCellContents(cx, cy, col, cellSize, gradientColors, image));
-    auto middleGroup = std::make_shared<VectorGroup>();
+    auto middleGroup = VectorGroup::Make();
     middleGroup->setAnchor({cx, cy});
     middleGroup->setPosition({cx, cy});
     middleGroup->setRotation(config.middleRotation);
@@ -5049,7 +5049,7 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
   for (int col = 0; col < 3; col++) {
     float cx = cellCenterX(col + 3);
     float cy = cellCenterY(1);
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setElements(MakeRadialCellContents(cx, cy, col, cellSize, gradientColors));
     contents.push_back(WrapInOuterGroup(innerGroup, {cx, cy}, 30.0f, {1.0f, 1.0f}));
   }
@@ -5058,7 +5058,7 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
   for (int col = 0; col < 3; col++) {
     float cx = cellCenterX(col);
     float cy = cellCenterY(2);
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setElements(MakePatternScaleCellContents(cx, cy, col, cellSize, image));
     contents.push_back(WrapInOuterGroup(innerGroup, {cx, cy}, 20.0f, {1.0f, 1.0f}));
   }
@@ -5066,7 +5066,7 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
   for (int col = 0; col < 3; col++) {
     float cx = cellCenterX(col + 3);
     float cy = cellCenterY(2);
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setElements(MakeAbsoluteCellContents(cx, cy, col, cellSize, gradientColors, image));
     contents.push_back(WrapInOuterGroup(innerGroup, {cx, cy}, 30.0f, {1.0f, 1.0f}));
   }
@@ -5075,7 +5075,7 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
   for (int col = 0; col < 3; col++) {
     float cx = cellCenterX(col);
     float cy = cellCenterY(3);
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setElements(
         MakeStrokeAlignCellContents(cx, cy, col, cellSize, gradientColors, image));
     contents.push_back(WrapInOuterGroup(innerGroup, {cx, cy}, 25.0f, {1.0f, 1.0f}));
@@ -5084,7 +5084,7 @@ TGFX_TEST(VectorLayerTest, FillInTransformedGroup) {
   for (int col = 0; col < 3; col++) {
     float cx = cellCenterX(col + 3);
     float cy = cellCenterY(3);
-    auto innerGroup = std::make_shared<VectorGroup>();
+    auto innerGroup = VectorGroup::Make();
     innerGroup->setPosition({cx - 22.0f, cy + 12.0f});
     innerGroup->setElements(MakeTextCellContents(col, textFont, gradientColors, image));
     contents.push_back(WrapInOuterGroup(innerGroup, {cx, cy}, 20.0f, {1.0f, 1.0f}));

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -74,8 +74,8 @@ TGFX_TEST(VectorLayerTest, BasicShapes) {
   // Row 1: Rectangle, Ellipse, Triangle
 
   // Group 1: Rectangle with red fill and roundness
-  auto group1 = std::make_shared<VectorGroup>();
-  auto rect = std::make_shared<Rectangle>();
+  auto group1 = VectorGroup::Make();
+  auto rect = Rectangle::Make();
   rect->setPosition({130, 130});
   rect->setSize({160, 160});
   rect->setRoundness(20);
@@ -83,21 +83,21 @@ TGFX_TEST(VectorLayerTest, BasicShapes) {
   group1->setElements({rect, redFill});
 
   // Group 2: Ellipse with blue stroke
-  auto group2 = std::make_shared<VectorGroup>();
-  auto ellipse = std::make_shared<Ellipse>();
+  auto group2 = VectorGroup::Make();
+  auto ellipse = Ellipse::Make();
   ellipse->setPosition({330, 130});
   ellipse->setSize({160, 120});
   auto blueStroke = MakeStrokeStyle(Color::Blue(), 8.0f);
   group2->setElements({ellipse, blueStroke});
 
   // Group 3: Triangle with green fill
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   Path trianglePath = {};
   trianglePath.moveTo(530, 50);
   trianglePath.lineTo(450, 210);
   trianglePath.lineTo(610, 210);
   trianglePath.close();
-  auto shapePath = std::make_shared<ShapePath>();
+  auto shapePath = ShapePath::Make();
   shapePath->setPath(trianglePath);
   auto greenFill = MakeFillStyle(Color::Green());
   group3->setElements({shapePath, greenFill});
@@ -105,8 +105,8 @@ TGFX_TEST(VectorLayerTest, BasicShapes) {
   // Row 2: Star with roundness, Polygon with roundness
 
   // Group 4: Star with yellow fill and roundness
-  auto group4 = std::make_shared<VectorGroup>();
-  auto star = std::make_shared<Polystar>();
+  auto group4 = VectorGroup::Make();
+  auto star = Polystar::Make();
   star->setPosition({130, 330});
   star->setPolystarType(PolystarType::Star);
   star->setPointCount(5);
@@ -118,8 +118,8 @@ TGFX_TEST(VectorLayerTest, BasicShapes) {
   group4->setElements({star, yellowFill});
 
   // Group 5: Six-pointed star without roundness for comparison
-  auto group5 = std::make_shared<VectorGroup>();
-  auto starSharp = std::make_shared<Polystar>();
+  auto group5 = VectorGroup::Make();
+  auto starSharp = Polystar::Make();
   starSharp->setPosition({310, 330});
   starSharp->setPolystarType(PolystarType::Star);
   starSharp->setPointCount(6);
@@ -129,8 +129,8 @@ TGFX_TEST(VectorLayerTest, BasicShapes) {
   group5->setElements({starSharp, orangeFill});
 
   // Group 6: Hexagon with purple stroke and roundness
-  auto group6 = std::make_shared<VectorGroup>();
-  auto polygon = std::make_shared<Polystar>();
+  auto group6 = VectorGroup::Make();
+  auto polygon = Polystar::Make();
   polygon->setPosition({530, 330});
   polygon->setPolystarType(PolystarType::Polygon);
   polygon->setPointCount(6);
@@ -164,11 +164,11 @@ TGFX_TEST(VectorLayerTest, ShapePathPosition) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Circle at position (100, 100) using setPosition()
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   Path circlePath1 = {};
   circlePath1.addOval(Rect::MakeXYWH(-50, -50, 100, 100));
 
-  auto shapePath1 = std::make_shared<ShapePath>();
+  auto shapePath1 = ShapePath::Make();
   shapePath1->setPath(circlePath1);
   shapePath1->setPosition({100, 100});
 
@@ -176,11 +176,11 @@ TGFX_TEST(VectorLayerTest, ShapePathPosition) {
   group1->setElements({shapePath1, redFill});
 
   // Group 2: Circle at position (325, 100) using setPosition()
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   Path circlePath2 = {};
   circlePath2.addOval(Rect::MakeXYWH(-50, -50, 100, 100));
 
-  auto shapePath2 = std::make_shared<ShapePath>();
+  auto shapePath2 = ShapePath::Make();
   shapePath2->setPath(circlePath2);
   shapePath2->setPosition({325, 100});
 
@@ -188,11 +188,11 @@ TGFX_TEST(VectorLayerTest, ShapePathPosition) {
   group2->setElements({shapePath2, blueFill});
 
   // Group 3: Square at position (550, 100) using setPosition()
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   Path squarePath = {};
   squarePath.addRect(Rect::MakeXYWH(-40, -40, 80, 80));
 
-  auto shapePath3 = std::make_shared<ShapePath>();
+  auto shapePath3 = ShapePath::Make();
   shapePath3->setPath(squarePath);
   shapePath3->setPosition({550, 100});
 
@@ -201,11 +201,11 @@ TGFX_TEST(VectorLayerTest, ShapePathPosition) {
 
   // Group 4: Multiple circles testing position offset effect
   // Center circle at (150, 200) - reference
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   Path circlePath4 = {};
   circlePath4.addOval(Rect::MakeXYWH(-35, -35, 70, 70));
 
-  auto shapePath4 = std::make_shared<ShapePath>();
+  auto shapePath4 = ShapePath::Make();
   shapePath4->setPath(circlePath4);
   shapePath4->setPosition({150, 200});
 
@@ -213,11 +213,11 @@ TGFX_TEST(VectorLayerTest, ShapePathPosition) {
   group4->setElements({shapePath4, yellowFill});
 
   // Group 5: Same shape, different position (300, 200)
-  auto group5 = std::make_shared<VectorGroup>();
+  auto group5 = VectorGroup::Make();
   Path circlePath5 = {};
   circlePath5.addOval(Rect::MakeXYWH(-35, -35, 70, 70));
 
-  auto shapePath5 = std::make_shared<ShapePath>();
+  auto shapePath5 = ShapePath::Make();
   shapePath5->setPath(circlePath5);
   shapePath5->setPosition({300, 200});
 
@@ -225,11 +225,11 @@ TGFX_TEST(VectorLayerTest, ShapePathPosition) {
   group5->setElements({shapePath5, orangeFill});
 
   // Group 6: Same shape, yet another position (450, 200)
-  auto group6 = std::make_shared<VectorGroup>();
+  auto group6 = VectorGroup::Make();
   Path circlePath6 = {};
   circlePath6.addOval(Rect::MakeXYWH(-35, -35, 70, 70));
 
-  auto shapePath6 = std::make_shared<ShapePath>();
+  auto shapePath6 = ShapePath::Make();
   shapePath6->setPath(circlePath6);
   shapePath6->setPosition({450, 200});
 
@@ -260,17 +260,17 @@ TGFX_TEST(VectorLayerTest, TrimPath) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: TrimPath Separate (each shape trimmed separately with same params)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({100, 154});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({100, 200});
 
-  auto ellipse1 = std::make_shared<Ellipse>();
+  auto ellipse1 = Ellipse::Make();
   ellipse1->setPosition({110, 0});
   ellipse1->setSize({100, 200});
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.0f);
   trim1->setEnd(0.5f);
   trim1->setTrimType(TrimPathType::Separate);
@@ -279,17 +279,17 @@ TGFX_TEST(VectorLayerTest, TrimPath) {
   group1->setElements({rect1, ellipse1, trim1, stroke1});
 
   // Group 2: TrimPath Continuous (all shapes combined into one path, trimmed as one)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({360, 154});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({100, 200});
 
-  auto ellipse2 = std::make_shared<Ellipse>();
+  auto ellipse2 = Ellipse::Make();
   ellipse2->setPosition({110, 0});
   ellipse2->setSize({100, 200});
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.25f);
   trim2->setEnd(0.75f);
   trim2->setTrimType(TrimPathType::Continuous);
@@ -321,13 +321,13 @@ TGFX_TEST(VectorLayerTest, TrimPathReversed) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Normal trim (start < end), shows 20%-70%
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({154, 154});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({200, 200});
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.2f);
   trim1->setEnd(0.7f);
 
@@ -335,13 +335,13 @@ TGFX_TEST(VectorLayerTest, TrimPathReversed) {
   group1->setElements({rect1, trim1, stroke1});
 
   // Group 2: Reversed trim (start > end), shows 70%-100% and 0%-20% (complement)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({394, 154});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({200, 200});
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.2f);
   trim2->setEnd(0.7f);
   trim2->setOffset(180);
@@ -372,23 +372,23 @@ TGFX_TEST(VectorLayerTest, RoundCorner) {
   auto vectorLayer = VectorLayer::Make();
 
   // Rectangle without RoundCorner
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({150, 150});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({200, 200});
 
   auto fill1 = MakeFillStyle(Color::Red());
   group1->setElements({rect1, fill1});
 
   // Rectangle with RoundCorner
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({390, 150});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({200, 200});
 
-  auto roundCorner = std::make_shared<RoundCorner>();
+  auto roundCorner = RoundCorner::Make();
   roundCorner->setRadius(40.0f);
 
   auto fill2 = MakeFillStyle(Color::Blue());
@@ -417,13 +417,13 @@ TGFX_TEST(VectorLayerTest, MergePath) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Two overlapping rectangles without merge (overlap area is darker)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({130, 130});
 
-  auto rect1a = std::make_shared<Rectangle>();
+  auto rect1a = Rectangle::Make();
   rect1a->setSize({160, 160});
 
-  auto rect1b = std::make_shared<Rectangle>();
+  auto rect1b = Rectangle::Make();
   rect1b->setPosition({60, 40});
   rect1b->setSize({160, 160});
 
@@ -431,17 +431,17 @@ TGFX_TEST(VectorLayerTest, MergePath) {
   group1->setElements({rect1a, rect1b, fill1});
 
   // Group 2: Two rectangles with MergePath XOR (overlap area is hollow)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({410, 130});
 
-  auto rect2a = std::make_shared<Rectangle>();
+  auto rect2a = Rectangle::Make();
   rect2a->setSize({160, 160});
 
-  auto rect2b = std::make_shared<Rectangle>();
+  auto rect2b = Rectangle::Make();
   rect2b->setPosition({60, 40});
   rect2b->setSize({160, 160});
 
-  auto merge = std::make_shared<MergePath>();
+  auto merge = MergePath::Make();
   merge->setMode(MergePathOp::XOR);
 
   auto fill2 = MakeFillStyle(Color::FromRGBA(0, 0, 255, 128));
@@ -470,14 +470,14 @@ TGFX_TEST(VectorLayerTest, MergePathClearsPainters) {
   auto displayList = std::make_unique<DisplayList>();
   auto vectorLayer = VectorLayer::Make();
 
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setPosition({150, 150});
   rect->setSize({200, 200});
 
   // This fill should be cleared by MergePath
   auto redFill = MakeFillStyle(Color::Red());
 
-  auto merge = std::make_shared<MergePath>();
+  auto merge = MergePath::Make();
   merge->setMode(MergePathOp::Append);
 
   // Only this fill should render
@@ -510,16 +510,16 @@ TGFX_TEST(VectorLayerTest, Repeater) {
 
   // Group 1: Repeater BelowOriginal
   // Later copies are drawn on top, so the rightmost (faintest) rectangle is on top
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({112, 132});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({120, 160});
 
   auto fill1 = MakeFillStyle(Color::Red());
   auto stroke1 = MakeStrokeStyle(Color::Black(), 3.0f);
 
-  auto repeater1 = std::make_shared<Repeater>();
+  auto repeater1 = Repeater::Make();
   repeater1->setCopies(4);
   repeater1->setPosition({70, 0});
   repeater1->setOrder(RepeaterOrder::BelowOriginal);
@@ -530,16 +530,16 @@ TGFX_TEST(VectorLayerTest, Repeater) {
 
   // Group 2: Repeater AboveOriginal
   // Earlier copies are drawn on top, so the leftmost (most opaque) rectangle is on top
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({512, 132});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({120, 160});
 
   auto fill2 = MakeFillStyle(Color::Blue());
   auto stroke2 = MakeStrokeStyle(Color::Black(), 3.0f);
 
-  auto repeater2 = std::make_shared<Repeater>();
+  auto repeater2 = Repeater::Make();
   repeater2->setCopies(4);
   repeater2->setPosition({70, 0});
   repeater2->setOrder(RepeaterOrder::AboveOriginal);
@@ -570,13 +570,13 @@ TGFX_TEST(VectorLayerTest, RepeaterTransform) {
   auto displayList = std::make_unique<DisplayList>();
   auto vectorLayer = VectorLayer::Make();
 
-  auto group = std::make_shared<VectorGroup>();
+  auto group = VectorGroup::Make();
   group->setPosition({130, 130});
 
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setSize({160, 40});
 
-  auto repeater = std::make_shared<Repeater>();
+  auto repeater = Repeater::Make();
   repeater->setCopies(8);
   repeater->setPosition(Point::Zero());
   repeater->setRotation(45.0f);
@@ -611,30 +611,30 @@ TGFX_TEST(VectorLayerTest, ModifiersAfterStyles) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: TrimPath after stroke - should still trim
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({150, 152});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({200, 200});
 
   auto stroke1 = MakeStrokeStyle(Color::Red(), 8.0f);
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.0f);
   trim1->setEnd(0.5f);
 
   group1->setElements({rect1, stroke1, trim1});
 
   // Group 2: RoundCorner after fill - should still round
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({390, 152});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({200, 200});
 
   auto fill2 = MakeFillStyle(Color::Blue());
 
-  auto roundCorner = std::make_shared<RoundCorner>();
+  auto roundCorner = RoundCorner::Make();
   roundCorner->setRadius(40.0f);
 
   group2->setElements({rect2, fill2, roundCorner});
@@ -662,36 +662,36 @@ TGFX_TEST(VectorLayerTest, VectorGroupTransform) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group with rotation
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({189, 269});
   group1->setRotation(30.0f);
   group1->setAnchor({80, 80});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({160, 160});
 
   auto fill1 = MakeFillStyle(Color::Red());
   group1->setElements({rect1, fill1});
 
   // Group with scale and alpha
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({409, 269});
   group2->setScale({1.2f, 1.2f});
   group2->setAlpha(0.6f);
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({160, 160});
 
   auto fill2 = MakeFillStyle(Color::Blue());
   group2->setElements({rect2, fill2});
 
   // Group with skew
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({609, 269});
   group3->setSkew(25.0f);
   group3->setSkewAxis(0.0f);
 
-  auto rect3 = std::make_shared<Rectangle>();
+  auto rect3 = Rectangle::Make();
   rect3->setSize({160, 160});
 
   auto fill3 = MakeFillStyle(Color::Green());
@@ -720,26 +720,26 @@ TGFX_TEST(VectorLayerTest, NestedGroups) {
   auto vectorLayer = VectorLayer::Make();
 
   // Outer group
-  auto outerGroup = std::make_shared<VectorGroup>();
+  auto outerGroup = VectorGroup::Make();
   outerGroup->setPosition({206, 206});
   outerGroup->setRotation(45.0f);
 
   // Inner group 1
-  auto innerGroup1 = std::make_shared<VectorGroup>();
+  auto innerGroup1 = VectorGroup::Make();
   innerGroup1->setPosition({-100, 0});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({120, 120});
 
   auto fill1 = MakeFillStyle(Color::Red());
   innerGroup1->setElements({rect1, fill1});
 
   // Inner group 2
-  auto innerGroup2 = std::make_shared<VectorGroup>();
+  auto innerGroup2 = VectorGroup::Make();
   innerGroup2->setPosition({100, 0});
   innerGroup2->setScale({1.3f, 1.3f});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({120, 120});
 
   auto fill2 = MakeFillStyle(Color::FromRGBA(0, 0, 255, 120));
@@ -769,7 +769,7 @@ TGFX_TEST(VectorLayerTest, MultipleFillsAndStrokes) {
   auto displayList = std::make_unique<DisplayList>();
   auto vectorLayer = VectorLayer::Make();
 
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setPosition({180, 180});
   rect->setSize({240, 240});
 
@@ -825,10 +825,10 @@ TGFX_TEST(VectorLayerTest, FillRule) {
   concentricPath.close();
 
   // Group 1: Winding fill rule - both rectangles filled solid
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({50, 50});
 
-  auto shape1 = std::make_shared<ShapePath>();
+  auto shape1 = ShapePath::Make();
   shape1->setPath(concentricPath);
 
   auto fill1 = FillStyle::Make(SolidColor::Make(Color::Red()));
@@ -837,10 +837,10 @@ TGFX_TEST(VectorLayerTest, FillRule) {
   group1->setElements({shape1, fill1});
 
   // Group 2: EvenOdd fill rule - inner rectangle creates a hole
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({250, 50});
 
-  auto shape2 = std::make_shared<ShapePath>();
+  auto shape2 = ShapePath::Make();
   shape2->setPath(concentricPath);
 
   auto fill2 = FillStyle::Make(SolidColor::Make(Color::Blue()));
@@ -874,13 +874,13 @@ TGFX_TEST(VectorLayerTest, TrimPathOffset) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Normal trim (0% to 25%, offset 90 degrees = 0.25 to 0.5)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({28, 80});
 
-  auto ellipse1 = std::make_shared<Ellipse>();
+  auto ellipse1 = Ellipse::Make();
   ellipse1->setSize({120, 120});
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.0f);
   trim1->setEnd(0.25f);
   trim1->setOffset(90.0f);
@@ -890,13 +890,13 @@ TGFX_TEST(VectorLayerTest, TrimPathOffset) {
   group1->setElements({ellipse1, trim1, stroke1});
 
   // Group 2: Wrap-around trim (0% to 25%, offset 315 degrees = 0.875 to 1.125, wraps to 0.125)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({168, 80});
 
-  auto ellipse2 = std::make_shared<Ellipse>();
+  auto ellipse2 = Ellipse::Make();
   ellipse2->setSize({120, 120});
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.0f);
   trim2->setEnd(0.25f);
   trim2->setOffset(315.0f);
@@ -908,7 +908,7 @@ TGFX_TEST(VectorLayerTest, TrimPathOffset) {
   // Group 3: Verify inverted trim segment order using an open polyline.
   // First trim with offset creates inverted mode (start > end after offset), producing two
   // disconnected segments. Second trim reduces from start, revealing which segment comes first.
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({308, 80});
 
   // Open polyline: 4 segments forming an open rectangle shape
@@ -917,19 +917,19 @@ TGFX_TEST(VectorLayerTest, TrimPathOffset) {
   polyline.lineTo(60, -60);
   polyline.lineTo(60, 60);
   polyline.lineTo(-60, 60);
-  auto shapePath3 = std::make_shared<ShapePath>();
+  auto shapePath3 = ShapePath::Make();
   shapePath3->setPath(polyline);
 
   // First trim: 75% length with 180 degree offset on open path triggers inverted mode,
   // producing [stopT, 1] + [0, startT] = two disconnected segments
-  auto trim3a = std::make_shared<TrimPath>();
+  auto trim3a = TrimPath::Make();
   trim3a->setStart(0.0f);
   trim3a->setEnd(0.75f);
   trim3a->setOffset(180.0f);
 
   // Second trim: take last 80%, this will cut from the actual start of the result path,
   // showing which segment is truly first in the inverted output
-  auto trim3b = std::make_shared<TrimPath>();
+  auto trim3b = TrimPath::Make();
   trim3b->setStart(0.2f);
   trim3b->setEnd(1.0f);
   trim3b->setTrimType(TrimPathType::Continuous);
@@ -939,13 +939,13 @@ TGFX_TEST(VectorLayerTest, TrimPathOffset) {
   group3->setElements({shapePath3, trim3a, trim3b, stroke3});
 
   // Group 4: Rectangle wrap-around (to show seamless connection at corner)
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({448, 80});
 
-  auto rect4 = std::make_shared<Rectangle>();
+  auto rect4 = Rectangle::Make();
   rect4->setSize({120, 120});
 
-  auto trim4 = std::make_shared<TrimPath>();
+  auto trim4 = TrimPath::Make();
   trim4->setStart(0.0f);
   trim4->setEnd(0.5f);
   trim4->setOffset(315.0f);  // Wrap around the starting corner
@@ -980,13 +980,13 @@ TGFX_TEST(VectorLayerTest, TrimPathReversedWrapAround) {
 
   // Group 1: Normal reversed trim on ellipse (no wrap-around)
   // start=0.6, end=0.2 means reversed: shows path from 80% to 40% in reverse direction
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({28, 80});
 
-  auto ellipse1 = std::make_shared<Ellipse>();
+  auto ellipse1 = Ellipse::Make();
   ellipse1->setSize({120, 120});
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.6f);
   trim1->setEnd(0.2f);
 
@@ -997,13 +997,13 @@ TGFX_TEST(VectorLayerTest, TrimPathReversedWrapAround) {
   // Group 2: Reversed trim with wrap-around on ellipse
   // start=0.3, end=0.7 with offset=-90 degrees (-0.25) becomes start=0.05, end=0.45
   // Then reversed: start=0.95, end=0.55, which wraps around
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({168, 80});
 
-  auto ellipse2 = std::make_shared<Ellipse>();
+  auto ellipse2 = Ellipse::Make();
   ellipse2->setSize({120, 120});
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.7f);
   trim2->setEnd(0.3f);
   trim2->setOffset(-90.0f);
@@ -1014,13 +1014,13 @@ TGFX_TEST(VectorLayerTest, TrimPathReversedWrapAround) {
 
   // Group 3: Reversed trim on rectangle with wrap-around (tests seamless corner connection)
   // The wrap-around should produce a seamless connection at the corner
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({308, 80});
 
-  auto rect3 = std::make_shared<Rectangle>();
+  auto rect3 = Rectangle::Make();
   rect3->setSize({120, 120});
 
-  auto trim3 = std::make_shared<TrimPath>();
+  auto trim3 = TrimPath::Make();
   trim3->setStart(0.6f);
   trim3->setEnd(0.2f);
   trim3->setOffset(45.0f);  // Offset to make wrap-around cross a corner
@@ -1031,18 +1031,18 @@ TGFX_TEST(VectorLayerTest, TrimPathReversedWrapAround) {
 
   // Group 4: Reversed trim Continuous mode with multiple shapes
   // Tests that reversed trim works correctly when trimming multiple shapes as one
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({448, 80});
 
-  auto rect4a = std::make_shared<Rectangle>();
+  auto rect4a = Rectangle::Make();
   rect4a->setPosition({-30, 0});
   rect4a->setSize({60, 120});
 
-  auto rect4b = std::make_shared<Rectangle>();
+  auto rect4b = Rectangle::Make();
   rect4b->setPosition({30, 0});
   rect4b->setSize({60, 120});
 
-  auto trim4 = std::make_shared<TrimPath>();
+  auto trim4 = TrimPath::Make();
   trim4->setStart(0.7f);
   trim4->setEnd(0.3f);
   trim4->setTrimType(TrimPathType::Continuous);
@@ -1073,22 +1073,22 @@ TGFX_TEST(VectorLayerTest, ComplexComposition) {
   auto displayList = std::make_unique<DisplayList>();
   auto vectorLayer = VectorLayer::Make();
 
-  auto group = std::make_shared<VectorGroup>();
+  auto group = VectorGroup::Make();
   group->setPosition({133, 133});
 
-  auto rect = std::make_shared<Rectangle>();
+  auto rect = Rectangle::Make();
   rect->setSize({160, 32});
 
-  auto roundCorner = std::make_shared<RoundCorner>();
+  auto roundCorner = RoundCorner::Make();
   roundCorner->setRadius(10.0f);
 
-  auto repeater = std::make_shared<Repeater>();
+  auto repeater = Repeater::Make();
   repeater->setCopies(12);
   repeater->setPosition(Point::Zero());
   repeater->setRotation(30.0f);
   repeater->setAnchor({0, 0});
 
-  auto trim = std::make_shared<TrimPath>();
+  auto trim = TrimPath::Make();
   trim->setStart(0.48f);
   trim->setEnd(0.83f);
 
@@ -1123,13 +1123,13 @@ TGFX_TEST(VectorLayerTest, RoundCornerWithScale) {
   // Group 1: RoundCorner without MergePath, with non-uniform scale
   // RoundCorner applies in original coords, then scale stretches the result
   // The radius appears stretched (wider horizontally)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setScale({2.0f, 1.0f});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({100, 100});
 
-  auto roundCorner1 = std::make_shared<RoundCorner>();
+  auto roundCorner1 = RoundCorner::Make();
   roundCorner1->setRadius(30.0f);
 
   auto fill1 = MakeFillStyle(Color::Red());
@@ -1138,19 +1138,19 @@ TGFX_TEST(VectorLayerTest, RoundCornerWithScale) {
   // Group 2: Nested structure to demonstrate MergePath baking matrix before RoundCorner
   // Inner group has scale, MergePath bakes it into the shape, then RoundCorner applies
   // The radius is uniform because it's applied after the scale is already baked in
-  auto outerGroup2 = std::make_shared<VectorGroup>();
+  auto outerGroup2 = VectorGroup::Make();
 
-  auto innerGroup2 = std::make_shared<VectorGroup>();
+  auto innerGroup2 = VectorGroup::Make();
   innerGroup2->setScale({2.0f, 1.0f});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({100, 100});
   innerGroup2->setElements({rect2});
 
-  auto merge2 = std::make_shared<MergePath>();
+  auto merge2 = MergePath::Make();
   merge2->setMode(MergePathOp::Append);
 
-  auto roundCorner2 = std::make_shared<RoundCorner>();
+  auto roundCorner2 = RoundCorner::Make();
   roundCorner2->setRadius(30.0f);
 
   auto fill2 = MakeFillStyle(Color::Blue());
@@ -1200,12 +1200,12 @@ TGFX_TEST(VectorLayerTest, StrokeNestedScale) {
 
   // Group 1: Non-uniform scale at inner group level. Stroke sees accumulated matrix (2,1).
   // Final size: 60*2 x 60*1 = 120x60
-  auto outerGroup1 = std::make_shared<VectorGroup>();
+  auto outerGroup1 = VectorGroup::Make();
 
-  auto innerGroup1 = std::make_shared<VectorGroup>();
+  auto innerGroup1 = VectorGroup::Make();
   innerGroup1->setScale({2.0f, 1.0f});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({60, 60});
   innerGroup1->setElements({rect1});
 
@@ -1216,13 +1216,13 @@ TGFX_TEST(VectorLayerTest, StrokeNestedScale) {
 
   // Group 2: Non-uniform scale at outer group only. Stroke sees the same accumulated matrix as
   // group 1, so the fit region and the rendered stroke must match it visually.
-  auto outerGroup2 = std::make_shared<VectorGroup>();
+  auto outerGroup2 = VectorGroup::Make();
   outerGroup2->setScale({2.0f, 1.0f});
 
-  auto innerGroup2 = std::make_shared<VectorGroup>();
+  auto innerGroup2 = VectorGroup::Make();
   // No scale on inner group
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({60, 60});
   innerGroup2->setElements({rect2});
 
@@ -1235,13 +1235,13 @@ TGFX_TEST(VectorLayerTest, StrokeNestedScale) {
   // coordinate layout (fit region and pattern orientation) is easy to compare visually.
   // Inner: (0.5, 2), Outer: (2, 0.5), Combined: (1, 1)
   // Final size: 60*0.5*2 x 60*2*0.5 = 60x60
-  auto outerGroup3 = std::make_shared<VectorGroup>();
+  auto outerGroup3 = VectorGroup::Make();
   outerGroup3->setScale({2.0f, 0.5f});
 
-  auto innerGroup3 = std::make_shared<VectorGroup>();
+  auto innerGroup3 = VectorGroup::Make();
   innerGroup3->setScale({0.5f, 2.0f});
 
-  auto rect3 = std::make_shared<Rectangle>();
+  auto rect3 = Rectangle::Make();
   rect3->setSize({60, 60});
   innerGroup3->setElements({rect3});
 
@@ -1291,13 +1291,13 @@ TGFX_TEST(VectorLayerTest, TrimPathWithScale) {
   // Rectangle starts from left edge middle (startIndex=2), goes: left-bottom -> bottom -> right
   // 80px = left-bottom(40) + bottom(40), stops at bottom edge
   // Then scale(2,1) stretches horizontally: bottom becomes 80px visually
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setScale({2.0f, 1.0f});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({80, 80});
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.0f);
   trim1->setEnd(0.25f);
 
@@ -1307,19 +1307,19 @@ TGFX_TEST(VectorLayerTest, TrimPathWithScale) {
   // Group 2: Nested structure - inner group has scale, MergePath bakes it
   // Stretched 160x80 rect perimeter = 480px, 25% = 120px
   // 120px = left-bottom(40) + bottom(80), stops further along bottom edge
-  auto outerGroup2 = std::make_shared<VectorGroup>();
+  auto outerGroup2 = VectorGroup::Make();
 
-  auto innerGroup2 = std::make_shared<VectorGroup>();
+  auto innerGroup2 = VectorGroup::Make();
   innerGroup2->setScale({2.0f, 1.0f});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({80, 80});
   innerGroup2->setElements({rect2});
 
-  auto merge2 = std::make_shared<MergePath>();
+  auto merge2 = MergePath::Make();
   merge2->setMode(MergePathOp::Append);
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.0f);
   trim2->setEnd(0.25f);
 
@@ -1359,12 +1359,12 @@ TGFX_TEST(VectorLayerTest, RepeaterWithScale) {
 
   // Group 1: Repeater with non-uniform scale per copy
   // Each copy gets progressively more stretched
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({40, 40});
 
-  auto repeater1 = std::make_shared<Repeater>();
+  auto repeater1 = Repeater::Make();
   repeater1->setCopies(4);
   repeater1->setPosition({100, 0});
   repeater1->setScale({1.3f, 1.0f});  // Non-uniform scale per copy
@@ -1376,13 +1376,13 @@ TGFX_TEST(VectorLayerTest, RepeaterWithScale) {
 
   // Group 2: Repeater inside a non-uniformly scaled group
   // The group scale affects all copies uniformly
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setScale({1.5f, 1.0f});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({40, 40});
 
-  auto repeater2 = std::make_shared<Repeater>();
+  auto repeater2 = Repeater::Make();
   repeater2->setCopies(5);
   repeater2->setPosition({50, 0});
   repeater2->setAnchor({20, 20});
@@ -1425,13 +1425,13 @@ TGFX_TEST(VectorLayerTest, MergePathOps) {
   auto vectorLayer = VectorLayer::Make();
 
   auto createOverlappingShapes = [](float offsetX) {
-    auto group = std::make_shared<VectorGroup>();
+    auto group = VectorGroup::Make();
     group->setPosition({offsetX, 100});
 
-    auto rect = std::make_shared<Rectangle>();
+    auto rect = Rectangle::Make();
     rect->setSize({80, 80});
 
-    auto ellipse = std::make_shared<Ellipse>();
+    auto ellipse = Ellipse::Make();
     ellipse->setPosition({40, 0});
     ellipse->setSize({80, 80});
 
@@ -1440,28 +1440,28 @@ TGFX_TEST(VectorLayerTest, MergePathOps) {
 
   // Group 1: Union (combines both shapes)
   auto [group1, rect1, ellipse1] = createOverlappingShapes(90);
-  auto merge1 = std::make_shared<MergePath>();
+  auto merge1 = MergePath::Make();
   merge1->setMode(MergePathOp::Union);
   auto fill1 = MakeFillStyle(Color::Red());
   group1->setElements({rect1, ellipse1, merge1, fill1});
 
   // Group 2: Intersect (only overlapping area)
   auto [group2, rect2, ellipse2] = createOverlappingShapes(260);
-  auto merge2 = std::make_shared<MergePath>();
+  auto merge2 = MergePath::Make();
   merge2->setMode(MergePathOp::Intersect);
   auto fill2 = MakeFillStyle(Color::Green());
   group2->setElements({rect2, ellipse2, merge2, fill2});
 
   // Group 3: Difference (first minus second)
   auto [group3, rect3, ellipse3] = createOverlappingShapes(430);
-  auto merge3 = std::make_shared<MergePath>();
+  auto merge3 = MergePath::Make();
   merge3->setMode(MergePathOp::Difference);
   auto fill3 = MakeFillStyle(Color::Blue());
   group3->setElements({rect3, ellipse3, merge3, fill3});
 
   // Group 4: XOR (non-overlapping areas)
   auto [group4, rect4, ellipse4] = createOverlappingShapes(600);
-  auto merge4 = std::make_shared<MergePath>();
+  auto merge4 = MergePath::Make();
   merge4->setMode(MergePathOp::XOR);
   auto fill4 = MakeFillStyle(Color::FromRGBA(255, 128, 0, 255));
   group4->setElements({rect4, ellipse4, merge4, fill4});
@@ -1490,10 +1490,10 @@ TGFX_TEST(VectorLayerTest, StrokeDashWithTrim) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Dash only (reference)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({130, 100});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({160, 100});
 
   auto stroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -1503,13 +1503,13 @@ TGFX_TEST(VectorLayerTest, StrokeDashWithTrim) {
   group1->setElements({rect1, stroke1});
 
   // Group 2: Trim then Dash (trim affects the path, then dash is applied)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({340, 100});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({160, 100});
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.0f);
   trim2->setEnd(0.6f);
 
@@ -1544,15 +1544,15 @@ TGFX_TEST(VectorLayerTest, RepeaterEdgeCases) {
 
   // Group 1: Fractional copies (2.5 copies)
   // Should show 2 full copies and 1 half-opacity copy
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({90, 100});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({60, 80});
 
   auto fill1 = MakeFillStyle(Color::Red());
 
-  auto repeater1 = std::make_shared<Repeater>();
+  auto repeater1 = Repeater::Make();
   repeater1->setCopies(2.5f);
   repeater1->setPosition({70, 0});
 
@@ -1560,15 +1560,15 @@ TGFX_TEST(VectorLayerTest, RepeaterEdgeCases) {
 
   // Group 2: Repeater with offset and alpha gradient
   // 4 copies with alpha from 1.0 to 0.3
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({340, 100});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({60, 80});
 
   auto fill2 = MakeFillStyle(Color::Blue());
 
-  auto repeater2 = std::make_shared<Repeater>();
+  auto repeater2 = Repeater::Make();
   repeater2->setCopies(4.0f);
   repeater2->setPosition({70, 0});
   repeater2->setStartAlpha(1.0f);
@@ -1600,39 +1600,39 @@ TGFX_TEST(VectorLayerTest, ChainedModifiers) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Rectangle only (reference)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({100, 100});
 
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({120, 100});
 
   auto stroke1 = MakeStrokeStyle(Color::Red(), 6.0f);
   group1->setElements({rect1, stroke1});
 
   // Group 2: RoundCorner then Stroke
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({270, 100});
 
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({120, 100});
 
-  auto round2 = std::make_shared<RoundCorner>();
+  auto round2 = RoundCorner::Make();
   round2->setRadius(20.0f);
 
   auto stroke2 = MakeStrokeStyle(Color::Green(), 6.0f);
   group2->setElements({rect2, round2, stroke2});
 
   // Group 3: RoundCorner then TrimPath then Stroke
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({440, 100});
 
-  auto rect3 = std::make_shared<Rectangle>();
+  auto rect3 = Rectangle::Make();
   rect3->setSize({120, 100});
 
-  auto round3 = std::make_shared<RoundCorner>();
+  auto round3 = RoundCorner::Make();
   round3->setRadius(20.0f);
 
-  auto trim3 = std::make_shared<TrimPath>();
+  auto trim3 = TrimPath::Make();
   trim3->setStart(0.0f);
   trim3->setEnd(0.6f);
 
@@ -1641,17 +1641,17 @@ TGFX_TEST(VectorLayerTest, ChainedModifiers) {
 
   // Group 4: TrimPath then RoundCorner then Stroke
   // Note: RoundCorner after TrimPath may have different effect
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({610, 100});
 
-  auto rect4 = std::make_shared<Rectangle>();
+  auto rect4 = Rectangle::Make();
   rect4->setSize({120, 100});
 
-  auto trim4 = std::make_shared<TrimPath>();
+  auto trim4 = TrimPath::Make();
   trim4->setStart(0.0f);
   trim4->setEnd(0.6f);
 
-  auto round4 = std::make_shared<RoundCorner>();
+  auto round4 = RoundCorner::Make();
   round4->setRadius(20.0f);
 
   auto stroke4 = MakeStrokeStyle(Color::FromRGBA(255, 128, 0, 255), 6.0f);
@@ -1681,10 +1681,10 @@ TGFX_TEST(VectorLayerTest, PolystarRotation) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Star without rotation
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({100, 100});
 
-  auto star1 = std::make_shared<Polystar>();
+  auto star1 = Polystar::Make();
   star1->setPolystarType(PolystarType::Star);
   star1->setPointCount(5);
   star1->setOuterRadius(60);
@@ -1695,10 +1695,10 @@ TGFX_TEST(VectorLayerTest, PolystarRotation) {
   group1->setElements({star1, fill1});
 
   // Group 2: Star with 36 degree rotation (one point up)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({240, 100});
 
-  auto star2 = std::make_shared<Polystar>();
+  auto star2 = Polystar::Make();
   star2->setPolystarType(PolystarType::Star);
   star2->setPointCount(5);
   star2->setOuterRadius(60);
@@ -1709,10 +1709,10 @@ TGFX_TEST(VectorLayerTest, PolystarRotation) {
   group2->setElements({star2, fill2});
 
   // Group 3: Polygon with rotation
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({380, 100});
 
-  auto polygon3 = std::make_shared<Polystar>();
+  auto polygon3 = Polystar::Make();
   polygon3->setPolystarType(PolystarType::Polygon);
   polygon3->setPointCount(6);
   polygon3->setOuterRadius(60);
@@ -1751,10 +1751,10 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
 
   // Row 1: Different line caps
   // Group 1: Butt cap
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({100, 80});
 
-  auto shape1 = std::make_shared<ShapePath>();
+  auto shape1 = ShapePath::Make();
   shape1->setPath(openPath);
 
   auto stroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -1765,10 +1765,10 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
   group1->setElements({shape1, stroke1});
 
   // Group 2: Round cap
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({250, 80});
 
-  auto shape2 = std::make_shared<ShapePath>();
+  auto shape2 = ShapePath::Make();
   shape2->setPath(openPath);
 
   auto stroke2 = StrokeStyle::Make(SolidColor::Make(Color::Green()));
@@ -1779,10 +1779,10 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
   group2->setElements({shape2, stroke2});
 
   // Group 3: Square cap
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({400, 80});
 
-  auto shape3 = std::make_shared<ShapePath>();
+  auto shape3 = ShapePath::Make();
   shape3->setPath(openPath);
 
   auto stroke3 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
@@ -1794,10 +1794,10 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
 
   // Row 2: Different line joins on closed path
   // Group 4: Miter join
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({100, 210});
 
-  auto rect4 = std::make_shared<Rectangle>();
+  auto rect4 = Rectangle::Make();
   rect4->setSize({80, 80});
 
   auto stroke4 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -1808,10 +1808,10 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
   group4->setElements({rect4, stroke4});
 
   // Group 5: Round join
-  auto group5 = std::make_shared<VectorGroup>();
+  auto group5 = VectorGroup::Make();
   group5->setPosition({250, 210});
 
-  auto rect5 = std::make_shared<Rectangle>();
+  auto rect5 = Rectangle::Make();
   rect5->setSize({80, 80});
 
   auto stroke5 = StrokeStyle::Make(SolidColor::Make(Color::Green()));
@@ -1821,10 +1821,10 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
   group5->setElements({rect5, stroke5});
 
   // Group 6: Bevel join
-  auto group6 = std::make_shared<VectorGroup>();
+  auto group6 = VectorGroup::Make();
   group6->setPosition({400, 210});
 
-  auto rect6 = std::make_shared<Rectangle>();
+  auto rect6 = Rectangle::Make();
   rect6->setSize({80, 80});
 
   auto stroke6 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
@@ -1834,7 +1834,7 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
   group6->setElements({rect6, stroke6});
 
   // Group 7: Sharp angle with miter limit
-  auto group7 = std::make_shared<VectorGroup>();
+  auto group7 = VectorGroup::Make();
   group7->setPosition({550, 80});
 
   Path sharpPath = {};
@@ -1842,7 +1842,7 @@ TGFX_TEST(VectorLayerTest, StrokeJoinCap) {
   sharpPath.lineTo(0, -40);
   sharpPath.lineTo(40, 30);
 
-  auto shape7 = std::make_shared<ShapePath>();
+  auto shape7 = ShapePath::Make();
   shape7->setPath(sharpPath);
 
   auto stroke7 = StrokeStyle::Make(SolidColor::Make(Color::FromRGBA(255, 128, 0, 255)));
@@ -1936,7 +1936,7 @@ TGFX_TEST(VectorLayerTest, TextWithGroup) {
   Font font(typeface, 32.0f);
 
   // Group 1: Rotated text
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({50, 76});
   group1->setRotation(15.0f);
 
@@ -1947,7 +1947,7 @@ TGFX_TEST(VectorLayerTest, TextWithGroup) {
   group1->setElements({textSpan1, fill1});
 
   // Group 2: Scaled text
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({250, 76});
   group2->setScale({2.0f, 1.0f});
 
@@ -1958,7 +1958,7 @@ TGFX_TEST(VectorLayerTest, TextWithGroup) {
   group2->setElements({textSpan2, fill2});
 
   // Group 3: Skewed text with alpha
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({50, 176});
   group3->setSkew(20.0f);
   group3->setAlpha(0.6f);
@@ -1999,7 +1999,7 @@ TGFX_TEST(VectorLayerTest, TextStyles) {
   font.setFauxBold(true);
 
   // Group 1: Fill only
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({46, 60});
 
   auto blob1 = TextBlob::MakeFrom("Fill", font);
@@ -2009,7 +2009,7 @@ TGFX_TEST(VectorLayerTest, TextStyles) {
   group1->setElements({textSpan1, fill1});
 
   // Group 2: Stroke only
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({141, 60});
 
   auto blob2 = TextBlob::MakeFrom("Stroke", font);
@@ -2019,7 +2019,7 @@ TGFX_TEST(VectorLayerTest, TextStyles) {
   group2->setElements({textSpan2, stroke2});
 
   // Group 3: Fill and stroke
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({46, 120});
 
   auto blob3 = TextBlob::MakeFrom("Fill+Stroke", font);
@@ -2030,7 +2030,7 @@ TGFX_TEST(VectorLayerTest, TextStyles) {
   group3->setElements({textSpan3, fill3, stroke3});
 
   // Group 4: Dash stroke
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({46, 180});
 
   auto blob4 = TextBlob::MakeFrom("Dash", font);
@@ -2071,20 +2071,20 @@ TGFX_TEST(VectorLayerTest, TextWithPathModifiers) {
   font.setFauxBold(true);
 
   // Group 1: Text with RoundCorner
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({50, 91});
 
   auto blob1 = TextBlob::MakeFrom("Round", font);
   auto textSpan1 = Text::Make(blob1);
 
-  auto roundCorner = std::make_shared<RoundCorner>();
+  auto roundCorner = RoundCorner::Make();
   roundCorner->setRadius(5.0f);
 
   auto fill1 = MakeFillStyle(Color::Blue());
   group1->setElements({textSpan1, roundCorner, fill1});
 
   // Group 2: Text with MergePath (text with emoji, emoji should be discarded after merge)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({50, 171});
 
   auto blob2a = TextBlob::MakeFrom("AB🐼", font);
@@ -2094,20 +2094,20 @@ TGFX_TEST(VectorLayerTest, TextWithPathModifiers) {
   auto textSpan2b = Text::Make(blob2b);
   textSpan2b->setPosition({100, 0});
 
-  auto mergePath = std::make_shared<MergePath>();
+  auto mergePath = MergePath::Make();
   mergePath->setMode(MergePathOp::Union);
 
   auto fill2 = MakeFillStyle(Color::Red());
   group2->setElements({textSpan2a, textSpan2b, mergePath, fill2});
 
   // Group 3: Text with TrimPath
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({250, 171});
 
   auto blob3 = TextBlob::MakeFrom("Trim", font);
   auto textSpan3 = Text::Make(blob3);
 
-  auto trimPath = std::make_shared<TrimPath>();
+  auto trimPath = TrimPath::Make();
   trimPath->setStart(0.2f);
   trimPath->setEnd(0.8f);
 
@@ -2143,7 +2143,7 @@ TGFX_TEST(VectorLayerTest, TextEdgeCases) {
   Font font(typeface, 32.0f);
 
   // Group 1: Null Text::Make (should return nullptr for null textBlob)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({47, 26});
 
   auto emptySpan = Text::Make(nullptr);  // Should return nullptr
@@ -2153,7 +2153,7 @@ TGFX_TEST(VectorLayerTest, TextEdgeCases) {
   group1->setElements({fill1});  // emptySpan is nullptr, don't add it
 
   // Group 2: Disabled Text (should not render)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({47, 76});
 
   auto blob2 = TextBlob::MakeFrom("Disabled", font);
@@ -2169,11 +2169,11 @@ TGFX_TEST(VectorLayerTest, TextEdgeCases) {
   group2->setElements({disabledSpan, enabledSpan, fill2});
 
   // Group 3: Nested groups with text (transform accumulation)
-  auto outerGroup = std::make_shared<VectorGroup>();
+  auto outerGroup = VectorGroup::Make();
   outerGroup->setPosition({47, 136});
   outerGroup->setScale({1.0f, 1.0f});
 
-  auto innerGroup = std::make_shared<VectorGroup>();
+  auto innerGroup = VectorGroup::Make();
   innerGroup->setRotation(10.0f);
 
   auto blob3 = TextBlob::MakeFrom("Nested", font);
@@ -2212,13 +2212,13 @@ TGFX_TEST(VectorLayerTest, TextWithRepeater) {
   Font font(typeface, 24.0f);
 
   // Text with Repeater
-  auto group = std::make_shared<VectorGroup>();
+  auto group = VectorGroup::Make();
   group->setPosition({50, 68});
 
   auto blob = TextBlob::MakeFrom("ABC", font);
   auto textSpan = Text::Make(blob);
 
-  auto repeater = std::make_shared<Repeater>();
+  auto repeater = Repeater::Make();
   repeater->setCopies(5);
   repeater->setPosition({60, 25});
   repeater->setStartAlpha(1.0f);
@@ -2262,7 +2262,7 @@ TGFX_TEST(VectorLayerTest, TextEmoji) {
   Font emojiFont(emojiTypeface, 32.0f);
 
   // Group 1: Mixed text and emoji with fill
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({50, 80});
 
   auto blob1 = TextBlob::MakeFrom("Hello ", textFont);
@@ -2280,7 +2280,7 @@ TGFX_TEST(VectorLayerTest, TextEmoji) {
   group1->setElements({textSpan1, emojiSpan1, textSpan1b, fill1});
 
   // Group 2: Emoji with stroke (emoji won't show stroke, but text will)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({50, 150});
 
   auto blob2 = TextBlob::MakeFrom("Stroke: ", textFont);
@@ -2295,7 +2295,7 @@ TGFX_TEST(VectorLayerTest, TextEmoji) {
   group2->setElements({textSpan2, emojiSpan2, fill2, stroke2});
 
   // Group 3: Emoji with TrimPath (emoji will be lost, only text path remains)
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({50, 200});
 
   auto blob3 = TextBlob::MakeFrom("Trim: ", textFont);
@@ -2305,7 +2305,7 @@ TGFX_TEST(VectorLayerTest, TextEmoji) {
   auto emojiSpan3 = Text::Make(emojiBlob3);
   emojiSpan3->setPosition({86, 0});
 
-  auto trim3 = std::make_shared<TrimPath>();
+  auto trim3 = TrimPath::Make();
   trim3->setStart(0.0f);
   trim3->setEnd(0.6f);
 
@@ -2313,7 +2313,7 @@ TGFX_TEST(VectorLayerTest, TextEmoji) {
   group3->setElements({textSpan3, emojiSpan3, trim3, stroke3});
 
   // Group 4: Pure emoji row
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({50, 260});
 
   auto emojiBlob4 = TextBlob::MakeFrom("😀🤩🥳🎊🎁", emojiFont);
@@ -2365,7 +2365,7 @@ TGFX_TEST(VectorLayerTest, RichText) {
   ASSERT_TRUE(inlineImage != nullptr);
 
   // === Row 1: [image] "TGFX Rich Text Demo" ===
-  auto imageRect = std::make_shared<Rectangle>();
+  auto imageRect = Rectangle::Make();
   imageRect->setPosition({82, 82});
   imageRect->setSize({64, 64});
 
@@ -2378,10 +2378,10 @@ TGFX_TEST(VectorLayerTest, RichText) {
   imagePattern->setMatrix(imageMatrix);
   auto imageFill = FillStyle::Make(imagePattern);
 
-  auto imageGroup = std::make_shared<VectorGroup>();
+  auto imageGroup = VectorGroup::Make();
   imageGroup->setElements({imageRect, imageFill});
 
-  auto row1 = std::make_shared<VectorGroup>();
+  auto row1 = VectorGroup::Make();
   row1->setPosition({127, 107});
 
   auto tgfxSpan = Text::Make(TextBlob::MakeFrom("TGFX", titleFont));
@@ -2390,19 +2390,19 @@ TGFX_TEST(VectorLayerTest, RichText) {
       {0, 0}, {155, 0}, {Color::FromRGBA(255, 0, 0, 255), Color::FromRGBA(0, 0, 255, 255)});
   titleGradient->setFitsToGeometry(false);
   auto tgfxFill = FillStyle::Make(titleGradient);
-  auto tgfxGroup = std::make_shared<VectorGroup>();
+  auto tgfxGroup = VectorGroup::Make();
   tgfxGroup->setElements({tgfxSpan, tgfxFill});
 
   auto demoSpan = Text::Make(TextBlob::MakeFrom(" Rich Text Demo", titleFont));
   demoSpan->setPosition({155, 0});
   auto blackFill = MakeFillStyle(Color::Black());
-  auto demoGroup = std::make_shared<VectorGroup>();
+  auto demoGroup = VectorGroup::Make();
   demoGroup->setElements({demoSpan, blackFill});
 
   row1->setElements({tgfxGroup, demoGroup});
 
   // === Row 2: "Supports bold italic 描边 and E=mc²" ===
-  auto row2 = std::make_shared<VectorGroup>();
+  auto row2 = VectorGroup::Make();
   row2->setPosition({50, 183});
 
   // "Supports " - black
@@ -2413,7 +2413,7 @@ TGFX_TEST(VectorLayerTest, RichText) {
   boldSpan->setPosition({199, 0});
 
   auto blueFill = MakeFillStyle(Color::Blue());
-  auto boldGroup = std::make_shared<VectorGroup>();
+  auto boldGroup = VectorGroup::Make();
   boldGroup->setElements({boldSpan, blueFill});
 
   // "italic" - red
@@ -2421,7 +2421,7 @@ TGFX_TEST(VectorLayerTest, RichText) {
   italicSpan->setPosition({303, 0});
 
   auto redFill = MakeFillStyle(Color::Red());
-  auto italicGroup = std::make_shared<VectorGroup>();
+  auto italicGroup = VectorGroup::Make();
   italicGroup->setElements({italicSpan, redFill});
 
   // "描边" - black fill + green stroke
@@ -2429,7 +2429,7 @@ TGFX_TEST(VectorLayerTest, RichText) {
   strokeSpan->setPosition({414, 0});
 
   auto greenStroke = MakeStrokeStyle(Color::Green(), 2.0f);
-  auto strokeGroup = std::make_shared<VectorGroup>();
+  auto strokeGroup = VectorGroup::Make();
   strokeGroup->setElements({strokeSpan, blackFill, greenStroke});
 
   // " and E=mc" - black
@@ -2444,7 +2444,7 @@ TGFX_TEST(VectorLayerTest, RichText) {
       {supportsSpan, andSpan, superscriptSpan, blackFill, boldGroup, italicGroup, strokeGroup});
 
   // === Row 3: "Visit tgfx.org for more information ℹ️" ===
-  auto row3 = std::make_shared<VectorGroup>();
+  auto row3 = VectorGroup::Make();
   row3->setPosition({50, 250});
 
   // "Visit " - black
@@ -2454,11 +2454,11 @@ TGFX_TEST(VectorLayerTest, RichText) {
   auto linkSpan = Text::Make(TextBlob::MakeFrom("tgfx.org", normalFont));
   linkSpan->setPosition({97, 0});
 
-  auto underline = std::make_shared<Rectangle>();
+  auto underline = Rectangle::Make();
   underline->setPosition({177, 16});
   underline->setSize({159, 3});
 
-  auto linkGroup = std::make_shared<VectorGroup>();
+  auto linkGroup = VectorGroup::Make();
   linkGroup->setElements({linkSpan, underline, blueFill});
 
   // " for more information " - black
@@ -2517,24 +2517,24 @@ TGFX_TEST(VectorLayerTest, SolidColor) {
   solidRed->setColor(Color::Red());
 
   // Group 1: Default SolidColor (black)
-  auto group1 = std::make_shared<VectorGroup>();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto group1 = VectorGroup::Make();
+  auto rect1 = Rectangle::Make();
   rect1->setPosition({100, 100});
   rect1->setSize({100, 100});
   auto fill1 = FillStyle::Make(solidDefault);
   group1->setElements({rect1, fill1});
 
   // Group 2: SolidColor with specific color
-  auto group2 = std::make_shared<VectorGroup>();
-  auto rect2 = std::make_shared<Rectangle>();
+  auto group2 = VectorGroup::Make();
+  auto rect2 = Rectangle::Make();
   rect2->setPosition({240, 100});
   rect2->setSize({100, 100});
   auto fill2 = FillStyle::Make(solidRed);
   group2->setElements({rect2, fill2});
 
   // Group 3: SolidColor with alpha
-  auto group3 = std::make_shared<VectorGroup>();
-  auto rect3 = std::make_shared<Rectangle>();
+  auto group3 = VectorGroup::Make();
+  auto rect3 = Rectangle::Make();
   rect3->setPosition({380, 100});
   rect3->setSize({100, 100});
   auto fill3 = FillStyle::Make(SolidColor::Make(Color::FromRGBA(0, 0, 255, 128)));
@@ -2566,8 +2566,8 @@ TGFX_TEST(VectorLayerTest, Gradient) {
 
   // Row 1 (fitsToGeometry default true): four gradient types each mapped to their own rect.
   // Linear gradient
-  auto group1 = std::make_shared<VectorGroup>();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto group1 = VectorGroup::Make();
+  auto rect1 = Rectangle::Make();
   rect1->setPosition({110, 110});
   rect1->setSize({120, 120});
   auto linear = Gradient::MakeLinear({0, 0.5f}, {1, 0.5f}, colors);
@@ -2581,8 +2581,8 @@ TGFX_TEST(VectorLayerTest, Gradient) {
   group1->setElements({rect1, fill1});
 
   // Radial gradient
-  auto group2 = std::make_shared<VectorGroup>();
-  auto rect2 = std::make_shared<Rectangle>();
+  auto group2 = VectorGroup::Make();
+  auto rect2 = Rectangle::Make();
   rect2->setPosition({260, 110});
   rect2->setSize({120, 120});
   auto radial = Gradient::MakeRadial({0.5f, 0.5f}, 0.71f, colors);
@@ -2595,8 +2595,8 @@ TGFX_TEST(VectorLayerTest, Gradient) {
   group2->setElements({rect2, fill2});
 
   // Conic gradient
-  auto group3 = std::make_shared<VectorGroup>();
-  auto rect3 = std::make_shared<Rectangle>();
+  auto group3 = VectorGroup::Make();
+  auto rect3 = Rectangle::Make();
   rect3->setPosition({410, 110});
   rect3->setSize({120, 120});
   auto conic = Gradient::MakeConic({0.5f, 0.5f}, 0, 360, colors);
@@ -2611,8 +2611,8 @@ TGFX_TEST(VectorLayerTest, Gradient) {
   group3->setElements({rect3, fill3});
 
   // Diamond gradient
-  auto group4 = std::make_shared<VectorGroup>();
-  auto rect4 = std::make_shared<Rectangle>();
+  auto group4 = VectorGroup::Make();
+  auto rect4 = Rectangle::Make();
   rect4->setPosition({560, 110});
   rect4->setSize({120, 120});
   auto diamond = Gradient::MakeDiamond({0.5f, 0.5f}, 0.71f, colors);
@@ -2711,8 +2711,8 @@ TGFX_TEST(VectorLayerTest, GradientEdgeCases) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Empty colors (invisible fill, with stroke to show rect bounds)
-  auto group1 = std::make_shared<VectorGroup>();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto group1 = VectorGroup::Make();
+  auto rect1 = Rectangle::Make();
   rect1->setPosition({101, 101});
   rect1->setSize({100, 100});
   auto emptyGradient = Gradient::MakeLinear({0, 0.5f}, {1, 0.5f}, {});
@@ -2722,8 +2722,8 @@ TGFX_TEST(VectorLayerTest, GradientEdgeCases) {
   group1->setElements({rect1, fill1, stroke1});
 
   // Group 2: Single color
-  auto group2 = std::make_shared<VectorGroup>();
-  auto rect2 = std::make_shared<Rectangle>();
+  auto group2 = VectorGroup::Make();
+  auto rect2 = Rectangle::Make();
   rect2->setPosition({241, 101});
   rect2->setSize({100, 100});
   auto singleGradient = Gradient::MakeLinear({0, 0.5f}, {1, 0.5f}, {Color::Red()});
@@ -2732,8 +2732,8 @@ TGFX_TEST(VectorLayerTest, GradientEdgeCases) {
   group2->setElements({rect2, fill2});
 
   // Group 3: With rotation matrix (gradient rotated 45 degrees around center)
-  auto group3 = std::make_shared<VectorGroup>();
-  auto rect3 = std::make_shared<Rectangle>();
+  auto group3 = VectorGroup::Make();
+  auto rect3 = Rectangle::Make();
   rect3->setPosition({381, 101});
   rect3->setSize({100, 100});
   // Create a gradient from top-left to bottom-right of the rect
@@ -2773,8 +2773,8 @@ TGFX_TEST(VectorLayerTest, ImagePattern) {
 
   // Row 1 (ScaleMode::None): three tile modes anchored to the layer origin.
   // Group 1: Clamp tile mode - rect larger than image to show edge clamping
-  auto group1 = std::make_shared<VectorGroup>();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto group1 = VectorGroup::Make();
+  auto rect1 = Rectangle::Make();
   rect1->setPosition({100, 100});
   rect1->setSize({100, 100});  // Rect is 100x100, larger than 50x50 image
   auto pattern1 = ImagePattern::Make(image, TileMode::Clamp, TileMode::Clamp);
@@ -2791,8 +2791,8 @@ TGFX_TEST(VectorLayerTest, ImagePattern) {
   group1->setElements({rect1, fill1});
 
   // Group 2: Repeat tile mode - small scale to show tiling
-  auto group2 = std::make_shared<VectorGroup>();
-  auto rect2 = std::make_shared<Rectangle>();
+  auto group2 = VectorGroup::Make();
+  auto rect2 = Rectangle::Make();
   rect2->setPosition({240, 100});
   rect2->setSize({100, 100});
   auto pattern2 = ImagePattern::Make(image2, TileMode::Repeat, TileMode::Repeat);
@@ -2804,8 +2804,8 @@ TGFX_TEST(VectorLayerTest, ImagePattern) {
   group2->setElements({rect2, fill2});
 
   // Group 3: Mirror tile mode with rotation
-  auto group3 = std::make_shared<VectorGroup>();
-  auto rect3 = std::make_shared<Rectangle>();
+  auto group3 = VectorGroup::Make();
+  auto rect3 = Rectangle::Make();
   rect3->setPosition({380, 100});
   rect3->setSize({100, 100});
   auto pattern3 = ImagePattern::Make(image2, TileMode::Mirror, TileMode::Mirror);
@@ -3003,8 +3003,8 @@ TGFX_TEST(VectorLayerTest, ColorSourceAdvanced) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: SolidColor stroke
-  auto group1 = std::make_shared<VectorGroup>();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto group1 = VectorGroup::Make();
+  auto rect1 = Rectangle::Make();
   rect1->setPosition({104, 104});
   rect1->setSize({100, 100});
   auto stroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -3012,8 +3012,8 @@ TGFX_TEST(VectorLayerTest, ColorSourceAdvanced) {
   group1->setElements({rect1, stroke1});
 
   // Group 2: Gradient stroke
-  auto group2 = std::make_shared<VectorGroup>();
-  auto rect2 = std::make_shared<Rectangle>();
+  auto group2 = VectorGroup::Make();
+  auto rect2 = Rectangle::Make();
   rect2->setPosition({244, 104});
   rect2->setSize({100, 100});
   auto strokeGradient = Gradient::MakeLinear({0, 0}, {1, 1}, {Color::Blue(), Color::Green()});
@@ -3024,8 +3024,8 @@ TGFX_TEST(VectorLayerTest, ColorSourceAdvanced) {
   // Group 3: Shared ColorSource (two shapes share the same gradient)
   auto sharedGradient = Gradient::MakeRadial(
       {0.5f, 0.5f}, 0.7f, {Color::FromRGBA(255, 255, 0, 255), Color::FromRGBA(255, 0, 255, 255)});
-  auto group3 = std::make_shared<VectorGroup>();
-  auto rect3 = std::make_shared<Rectangle>();
+  auto group3 = VectorGroup::Make();
+  auto rect3 = Rectangle::Make();
   rect3->setPosition({384, 104});
   rect3->setSize({100, 100});
   auto fill3 = FillStyle::Make(sharedGradient);
@@ -3123,12 +3123,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   // ==================== Column 1: Basic TextPath options ====================
 
   // Group 1: Start alignment, perpendicular to path
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({98, 143});
 
   auto textSpan1 = Text::Make(TextBlob::MakeFrom("Start Aligned", font));
 
-  auto textPath1 = std::make_shared<TextPath>();
+  auto textPath1 = TextPath::Make();
   textPath1->setPath(curvePath);
   textPath1->setPerpendicular(true);
 
@@ -3136,13 +3136,13 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group1->setElements({textSpan1, textPath1, fill1});
 
   // Group 2: Center alignment using firstMargin
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({98, 243});
 
   auto textBlob2 = TextBlob::MakeFrom("Center Aligned", font);
   auto textSpan2 = Text::Make(textBlob2);
 
-  auto textPath2 = std::make_shared<TextPath>();
+  auto textPath2 = TextPath::Make();
   textPath2->setPath(curvePath);
   textPath2->setPerpendicular(true);
   // Center text on path using firstMargin
@@ -3154,12 +3154,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group2->setElements({textSpan2, textPath2, fill2});
 
   // Group 3: Not perpendicular to path (text stays upright)
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({98, 343});
 
   auto textSpan3 = Text::Make(TextBlob::MakeFrom("Not Perpendicular", font));
 
-  auto textPath3 = std::make_shared<TextPath>();
+  auto textPath3 = TextPath::Make();
   textPath3->setPath(curvePath);
   textPath3->setPerpendicular(false);
 
@@ -3167,12 +3167,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group3->setElements({textSpan3, textPath3, fill3});
 
   // Group 4: Reversed path direction
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({98, 443});
 
   auto textSpan4 = Text::Make(TextBlob::MakeFrom("Reversed Path", font));
 
-  auto textPath4 = std::make_shared<TextPath>();
+  auto textPath4 = TextPath::Make();
   textPath4->setPath(curvePath);
   textPath4->setPerpendicular(true);
   textPath4->setReversed(true);
@@ -3181,12 +3181,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group4->setElements({textSpan4, textPath4, fill4});
 
   // Group 5: Force alignment without margins
-  auto group5 = std::make_shared<VectorGroup>();
+  auto group5 = VectorGroup::Make();
   group5->setPosition({98, 543});
 
   auto textSpan5 = Text::Make(TextBlob::MakeFrom("Force Alignment", font));
 
-  auto textPath5 = std::make_shared<TextPath>();
+  auto textPath5 = TextPath::Make();
   textPath5->setPath(curvePath);
   textPath5->setForceAlignment(true);
   textPath5->setPerpendicular(true);
@@ -3195,12 +3195,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group5->setElements({textSpan5, textPath5, fill5});
 
   // Group 6: Force alignment with margins
-  auto group6 = std::make_shared<VectorGroup>();
+  auto group6 = VectorGroup::Make();
   group6->setPosition({98, 643});
 
   auto textSpan6 = Text::Make(TextBlob::MakeFrom("Force+Margin", font));
 
-  auto textPath6 = std::make_shared<TextPath>();
+  auto textPath6 = TextPath::Make();
   textPath6->setPath(curvePath);
   textPath6->setFirstMargin(60);
   textPath6->setLastMargin(-60);
@@ -3218,16 +3218,16 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   largerCurvePath.cubicTo(100, -200, 300, 200, 400, 0);  // More extreme curve
 
   // Group 7: Two consecutive TextPaths - second applies on top of first
-  auto group7 = std::make_shared<VectorGroup>();
+  auto group7 = VectorGroup::Make();
   group7->setPosition({588, 193});
 
   auto textSpan7 = Text::Make(TextBlob::MakeFrom("Second Override", font));
 
-  auto textPathFirst = std::make_shared<TextPath>();
+  auto textPathFirst = TextPath::Make();
   textPathFirst->setPath(curvePath);
   textPathFirst->setPerpendicular(true);
 
-  auto textPathSecond = std::make_shared<TextPath>();
+  auto textPathSecond = TextPath::Make();
   textPathSecond->setPath(largerCurvePath);
   textPathSecond->setPerpendicular(true);
 
@@ -3235,17 +3235,17 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group7->setElements({textSpan7, textPathFirst, textPathSecond, fill7});
 
   // Group 8: Inner group transform overridden by TextPath
-  auto group8 = std::make_shared<VectorGroup>();
+  auto group8 = VectorGroup::Make();
   group8->setPosition({588, 293});
 
-  auto innerGroup8 = std::make_shared<VectorGroup>();
+  auto innerGroup8 = VectorGroup::Make();
   innerGroup8->setScale({1.5f, 0.8f});
 
   auto textSpan8 = Text::Make(TextBlob::MakeFrom("Group Override", font));
 
   innerGroup8->setElements({textSpan8});
 
-  auto textPath8 = std::make_shared<TextPath>();
+  auto textPath8 = TextPath::Make();
   textPath8->setPath(curvePath);
   textPath8->setPerpendicular(true);
 
@@ -3258,12 +3258,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   shortPath.moveTo(140, 0);
   shortPath.cubicTo(180, -60, 240, 60, 280, 0);
 
-  auto group9 = std::make_shared<VectorGroup>();
+  auto group9 = VectorGroup::Make();
   group9->setPosition({588, 413});
 
   auto textSpan9 = Text::Make(TextBlob::MakeFrom("Path Extension Test", font));
 
-  auto textPath9 = std::make_shared<TextPath>();
+  auto textPath9 = TextPath::Make();
   textPath9->setPath(shortPath);
   textPath9->setPerpendicular(true);
 
@@ -3277,12 +3277,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   closedPath.cubicTo(100, 40, 100, -40, 200, -40);
   closedPath.close();
 
-  auto group10 = std::make_shared<VectorGroup>();
+  auto group10 = VectorGroup::Make();
   group10->setPosition({588, 513});
 
   auto textSpan10 = Text::Make(TextBlob::MakeFrom("Closed Path Text Wrap", font));
 
-  auto textPath10 = std::make_shared<TextPath>();
+  auto textPath10 = TextPath::Make();
   textPath10->setPath(closedPath);
   textPath10->setFirstMargin(-80.0f);  // Negative margin to wrap around the closed path
   textPath10->setPerpendicular(true);
@@ -3291,13 +3291,13 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group10->setElements({textSpan10, textPath10, fill10});
 
   // Group 11: Multiple Text elements with nested transforms
-  auto group11 = std::make_shared<VectorGroup>();
+  auto group11 = VectorGroup::Make();
   group11->setPosition({448, 633});
 
-  auto middleGroup11 = std::make_shared<VectorGroup>();
+  auto middleGroup11 = VectorGroup::Make();
   middleGroup11->setScale({1.3f, 1.3f});
 
-  auto innerGroup11 = std::make_shared<VectorGroup>();
+  auto innerGroup11 = VectorGroup::Make();
   innerGroup11->setPosition({0, 8});
   innerGroup11->setSkew(-20.0f);
 
@@ -3310,7 +3310,7 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   auto spaceWidth = font.getAdvance(font.getGlyphID(' '), false);
   textSpan11b->setPosition({std::round(textBlob11a->getTightBounds().right + spaceWidth), 0});
 
-  auto textPath11 = std::make_shared<TextPath>();
+  auto textPath11 = TextPath::Make();
   textPath11->setPath(curvePath);
   textPath11->setPerpendicular(true);
   auto textWidth11 = std::round(textBlob11a->getTightBounds().right + spaceWidth) +
@@ -3325,7 +3325,7 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   innerGroup11->setElements({textSpan11a, textSpan11b, textPath11, fill11});
   middleGroup11->setElements({innerGroup11});
 
-  auto rotationGroup11 = std::make_shared<VectorGroup>();
+  auto rotationGroup11 = VectorGroup::Make();
   rotationGroup11->setAnchor({350, 104});
   rotationGroup11->setPosition({350, 104});
   rotationGroup11->setRotation(15.0f);
@@ -3336,12 +3336,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   // ==================== Row 6: Edge cases and special text layout ====================
 
   // Group 12: Negative spacing - firstMargin exceeds pathLength + lastMargin
-  auto group12 = std::make_shared<VectorGroup>();
+  auto group12 = VectorGroup::Make();
   group12->setPosition({98, 743});
 
   auto textSpan12 = Text::Make(TextBlob::MakeFrom("Negative Spacing", font));
 
-  auto textPath12 = std::make_shared<TextPath>();
+  auto textPath12 = TextPath::Make();
   textPath12->setPath(curvePath);
   textPath12->setFirstMargin(400);  // Exceeds path end
   textPath12->setLastMargin(-350);  // Path length ~380, so 400 > 380 + (-350) = 30
@@ -3352,7 +3352,7 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group12->setElements({textSpan12, textPath12, fill12});
 
   // Group 13: Multi-line text with line spacing preserved, centered on path
-  auto group13 = std::make_shared<VectorGroup>();
+  auto group13 = VectorGroup::Make();
   group13->setPosition({98, 843});
 
   auto textBlob13a = TextBlob::MakeFrom("Multiple", font);
@@ -3365,7 +3365,7 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   textSpan13a->setPosition({centerOffset13, 0});
   textSpan13b->setPosition({0, lineSpacing13});
 
-  auto innerGroup13 = std::make_shared<VectorGroup>();
+  auto innerGroup13 = VectorGroup::Make();
   innerGroup13->setElements({textSpan13a, textSpan13b});
 
   auto textPath13 = TextPath::Make();
@@ -3380,7 +3380,7 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group13->setElements({innerGroup13, textPath13, fill13});
 
   // Group 14: Vertical text with 90° rotation (Latin rotated, CJK upright)
-  auto group14 = std::make_shared<VectorGroup>();
+  auto group14 = VectorGroup::Make();
   group14->setPosition({588, 843});
 
   std::string verticalText = "Vertical 文本";
@@ -3432,7 +3432,7 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   for (const auto& span : textSpans14) {
     elements14.push_back(span);
   }
-  auto innerGroup14 = std::make_shared<VectorGroup>();
+  auto innerGroup14 = VectorGroup::Make();
   innerGroup14->setElements(elements14);
 
   auto textPath14 = TextPath::Make();
@@ -3445,12 +3445,12 @@ TGFX_TEST(VectorLayerTest, TextPath) {
   group14->setElements({innerGroup14, textPath14, fill14});
 
   // Group 15: Reversed path with force alignment
-  auto group15 = std::make_shared<VectorGroup>();
+  auto group15 = VectorGroup::Make();
   group15->setPosition({588, 743});
 
   auto textSpan15 = Text::Make(TextBlob::MakeFrom("Reversed+Force", font));
 
-  auto textPath15 = std::make_shared<TextPath>();
+  auto textPath15 = TextPath::Make();
   textPath15->setPath(curvePath);
   textPath15->setReversed(true);
   textPath15->setForceAlignment(true);
@@ -3473,14 +3473,14 @@ TGFX_TEST(VectorLayerTest, TextPath) {
 
   // Column 1 helper paths
   std::vector<std::pair<float, Color>> pathPositions1 = {
-      {143, Color::Blue()},
-      {243, Color::Red()},
-      {343, Color{1.0f, 0.5f, 0.0f, 1.0f}},  // Orange
-      {443, Color{0.5f, 0.0f, 0.5f, 1.0f}},  // Purple
-      {543, Color{0.0f, 0.5f, 0.5f, 1.0f}},  // Teal (Force Alignment)
-      {643, Color{0.8f, 0.2f, 0.2f, 1.0f}},  // Dark red (Force+Margin)
-      {743, Color{0.2f, 0.2f, 0.8f, 1.0f}},  // Dark blue (Negative Spacing)
-      {843, Color::Green()},                 // Multi-line centered
+      {143.f, Color::Blue()},
+      {243.f, Color::Red()},
+      {343.f, Color{1.0f, 0.5f, 0.0f, 1.0f}},  // Orange
+      {443.f, Color{0.5f, 0.0f, 0.5f, 1.0f}},  // Purple
+      {543.f, Color{0.0f, 0.5f, 0.5f, 1.0f}},  // Teal (Force Alignment)
+      {643.f, Color{0.8f, 0.2f, 0.2f, 1.0f}},  // Dark red (Force+Margin)
+      {743.f, Color{0.2f, 0.2f, 0.8f, 1.0f}},  // Dark blue (Negative Spacing)
+      {843.f, Color::Green()},                 // Multi-line centered
   };
 
   for (const auto& [y, color] : pathPositions1) {
@@ -3581,16 +3581,16 @@ TGFX_TEST(VectorLayerTest, TextPathWithTrimPath) {
   // Group 1: TextPath then TrimPath
   // Text is first laid out along the path (glyphs positioned on curve),
   // then TrimPath trims each glyph shape (Separate mode)
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({68, 170});
 
   auto textSpan1 = Text::Make(TextBlob::MakeFrom("TextPath+TrimPath", font));
 
-  auto textPath1 = std::make_shared<TextPath>();
+  auto textPath1 = TextPath::Make();
   textPath1->setPath(curvePath);
   textPath1->setPerpendicular(true);
 
-  auto trim1 = std::make_shared<TrimPath>();
+  auto trim1 = TrimPath::Make();
   trim1->setStart(0.0f);
   trim1->setEnd(0.95f);
   trim1->setTrimType(TrimPathType::Separate);
@@ -3602,18 +3602,18 @@ TGFX_TEST(VectorLayerTest, TextPathWithTrimPath) {
   // TrimPath runs first, converts text to shapes (at original position) and trims from 5% to 100%.
   // TextPath then runs but finds no text to layout (already converted to shapes by TrimPath).
   // Result: text is trimmed at original position, not laid out along path.
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({68, 290});
 
   auto textSpan2 = Text::Make(TextBlob::MakeFrom("TrimPath+TextPath", font));
   textSpan2->setPosition({110, -20});
 
-  auto trim2 = std::make_shared<TrimPath>();
+  auto trim2 = TrimPath::Make();
   trim2->setStart(0.05f);
   trim2->setEnd(1.0f);
   trim2->setTrimType(TrimPathType::Separate);
 
-  auto textPath2 = std::make_shared<TextPath>();
+  auto textPath2 = TextPath::Make();
   textPath2->setPath(curvePath);
   textPath2->setPerpendicular(true);
 
@@ -3681,60 +3681,60 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   float rowHeight = 75;
 
   // Row 1: Position
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({col1X, 86});
   auto textSpan1 = Text::Make(TextBlob::MakeFrom("Position", font));
   auto selector1 = std::make_shared<RangeSelector>();
   selector1->setShape(SelectorShape::RampUp);
-  auto modifier1 = std::make_shared<TextModifier>();
+  auto modifier1 = TextModifier::Make();
   modifier1->setSelectors({selector1});
   modifier1->setPosition({0, -20});
   group1->setElements({textSpan1, modifier1, MakeFillStyle(Color::Blue())});
   groups.push_back(group1);
 
   // Row 2: Scale (non-uniform)
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({col1X, 86 + rowHeight});
   auto textSpan2 = Text::Make(TextBlob::MakeFrom("Scale", font));
   auto selector2 = std::make_shared<RangeSelector>();
   selector2->setShape(SelectorShape::Triangle);
-  auto modifier2 = std::make_shared<TextModifier>();
+  auto modifier2 = TextModifier::Make();
   modifier2->setSelectors({selector2});
   modifier2->setScale({2.0f, 0.5f});
   group2->setElements({textSpan2, modifier2, MakeFillStyle(Color::Red())});
   groups.push_back(group2);
 
   // Row 3: Rotation
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({col1X, 86 + rowHeight * 2});
   auto textSpan3 = Text::Make(TextBlob::MakeFrom("Rotation", font));
   auto selector3 = std::make_shared<RangeSelector>();
   selector3->setShape(SelectorShape::Square);
-  auto modifier3 = std::make_shared<TextModifier>();
+  auto modifier3 = TextModifier::Make();
   modifier3->setSelectors({selector3});
   modifier3->setRotation(45);
   group3->setElements({textSpan3, modifier3, MakeFillStyle(Color::Green())});
   groups.push_back(group3);
 
   // Row 4: Alpha (intermediate value 0.5)
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({col1X, 86 + rowHeight * 3});
   auto textSpan4 = Text::Make(TextBlob::MakeFrom("Alpha", font));
   auto selector4 = std::make_shared<RangeSelector>();
   selector4->setShape(SelectorShape::RampDown);
-  auto modifier4 = std::make_shared<TextModifier>();
+  auto modifier4 = TextModifier::Make();
   modifier4->setSelectors({selector4});
   modifier4->setAlpha(0.5f);
   group4->setElements({textSpan4, modifier4, MakeFillStyle(Color::Black())});
   groups.push_back(group4);
 
   // Row 5: Skew
-  auto group5 = std::make_shared<VectorGroup>();
+  auto group5 = VectorGroup::Make();
   group5->setPosition({col1X, 86 + rowHeight * 4});
   auto textSpan5 = Text::Make(TextBlob::MakeFrom("Skew", font));
   auto selector5 = std::make_shared<RangeSelector>();
   selector5->setShape(SelectorShape::Triangle);
-  auto modifier5 = std::make_shared<TextModifier>();
+  auto modifier5 = TextModifier::Make();
   modifier5->setSelectors({selector5});
   modifier5->setSkew(30);
   modifier5->setSkewAxis(45);
@@ -3742,12 +3742,12 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   groups.push_back(group5);
 
   // Row 6: AnchorPoint
-  auto group6 = std::make_shared<VectorGroup>();
+  auto group6 = VectorGroup::Make();
   group6->setPosition({col1X, 86 + rowHeight * 5});
   auto textSpan6 = Text::Make(TextBlob::MakeFrom("AnchorPoint", font));
   auto selector6 = std::make_shared<RangeSelector>();
   selector6->setShape(SelectorShape::RampUp);
-  auto modifier6 = std::make_shared<TextModifier>();
+  auto modifier6 = TextModifier::Make();
   modifier6->setSelectors({selector6});
   modifier6->setAnchor({0, 15});
   modifier6->setRotation(30);
@@ -3758,48 +3758,48 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   float col2X = 244;
 
   // Row 1: FillColor
-  auto group7 = std::make_shared<VectorGroup>();
+  auto group7 = VectorGroup::Make();
   group7->setPosition({col2X, 86});
   auto textSpan7 = Text::Make(TextBlob::MakeFrom("FillColor", boldFont));
   auto selector7 = std::make_shared<RangeSelector>();
   selector7->setShape(SelectorShape::RampDown);
-  auto modifier7 = std::make_shared<TextModifier>();
+  auto modifier7 = TextModifier::Make();
   modifier7->setSelectors({selector7});
   modifier7->setFillColor(Color::Red());
   group7->setElements({textSpan7, modifier7, MakeFillStyle(Color::Blue())});
   groups.push_back(group7);
 
   // Row 2: StrokeColor
-  auto group8 = std::make_shared<VectorGroup>();
+  auto group8 = VectorGroup::Make();
   group8->setPosition({col2X, 86 + rowHeight});
   auto textSpan8 = Text::Make(TextBlob::MakeFrom("StrokeColor", boldFont));
   auto selector8 = std::make_shared<RangeSelector>();
   selector8->setShape(SelectorShape::Triangle);
-  auto modifier8 = std::make_shared<TextModifier>();
+  auto modifier8 = TextModifier::Make();
   modifier8->setSelectors({selector8});
   modifier8->setStrokeColor(Color::Red());
   group8->setElements({textSpan8, modifier8, MakeStrokeStyle(Color::Blue(), 2)});
   groups.push_back(group8);
 
   // Row 3: StrokeWidth
-  auto group9 = std::make_shared<VectorGroup>();
+  auto group9 = VectorGroup::Make();
   group9->setPosition({col2X, 86 + rowHeight * 2});
   auto textSpan9 = Text::Make(TextBlob::MakeFrom("StrokeWidth", boldFont));
   auto selector9 = std::make_shared<RangeSelector>();
   selector9->setShape(SelectorShape::RampUp);
-  auto modifier9 = std::make_shared<TextModifier>();
+  auto modifier9 = TextModifier::Make();
   modifier9->setSelectors({selector9});
-  modifier9->setStrokeWidth(6);
+  modifier9->setStrokeWidth(6.f);
   group9->setElements({textSpan9, modifier9, MakeStrokeStyle(Color::Green(), 1)});
   groups.push_back(group9);
 
   // Row 4: Fill+Stroke
-  auto group10 = std::make_shared<VectorGroup>();
+  auto group10 = VectorGroup::Make();
   group10->setPosition({col2X, 86 + rowHeight * 3});
   auto textSpan10 = Text::Make(TextBlob::MakeFrom("Fill+Stroke", boldFont));
   auto selector10 = std::make_shared<RangeSelector>();
   selector10->setShape(SelectorShape::RampUp);
-  auto modifier10 = std::make_shared<TextModifier>();
+  auto modifier10 = TextModifier::Make();
   modifier10->setSelectors({selector10});
   modifier10->setFillColor(Color::Red());
   modifier10->setStrokeColor(Color::Green());
@@ -3808,7 +3808,7 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   groups.push_back(group10);
 
   // Row 5: MultiSpan
-  auto group11 = std::make_shared<VectorGroup>();
+  auto group11 = VectorGroup::Make();
   group11->setPosition({col2X, 86 + rowHeight * 4});
   auto textSpanA = Text::Make(TextBlob::MakeFrom("AB", font));
   auto textSpanB = Text::Make(TextBlob::MakeFrom("CD", font));
@@ -3817,7 +3817,7 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   textSpanC->setPosition({110, 0});
   auto selector11 = std::make_shared<RangeSelector>();
   selector11->setShape(SelectorShape::RampUp);
-  auto modifier11 = std::make_shared<TextModifier>();
+  auto modifier11 = TextModifier::Make();
   modifier11->setSelectors({selector11});
   modifier11->setPosition({0, -20});
   modifier11->setFillColor(Color::Red());
@@ -3825,19 +3825,19 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   groups.push_back(group11);
 
   // Row 6: Multiple Modifiers stacking
-  auto group12 = std::make_shared<VectorGroup>();
+  auto group12 = VectorGroup::Make();
   group12->setPosition({col2X, 86 + rowHeight * 5});
   auto textSpan12 = Text::Make(TextBlob::MakeFrom("MultiMod", font));
   auto selectorA = std::make_shared<RangeSelector>();
   selectorA->setStart(0.0f);
   selectorA->setEnd(0.5f);
-  auto modifierA = std::make_shared<TextModifier>();
+  auto modifierA = TextModifier::Make();
   modifierA->setSelectors({selectorA});
   modifierA->setPosition({0, -10});
   auto selectorB = std::make_shared<RangeSelector>();
   selectorB->setStart(0.5f);
   selectorB->setEnd(1.0f);
-  auto modifierB = std::make_shared<TextModifier>();
+  auto modifierB = TextModifier::Make();
   modifierB->setSelectors({selectorB});
   modifierB->setRotation(15);
   group12->setElements(
@@ -3852,12 +3852,12 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
       {SelectorShape::Round, "Round"},       {SelectorShape::Smooth, "Smooth"}};
 
   for (size_t i = 0; i < shapes.size(); i++) {
-    auto group = std::make_shared<VectorGroup>();
+    auto group = VectorGroup::Make();
     group->setPosition({col3X, 86 + rowHeight * static_cast<float>(i)});
     auto textSpan = Text::Make(TextBlob::MakeFrom(shapes[i].second, font));
     auto selector = std::make_shared<RangeSelector>();
     selector->setShape(shapes[i].first);
-    auto modifier = std::make_shared<TextModifier>();
+    auto modifier = TextModifier::Make();
     modifier->setSelectors({selector});
     modifier->setPosition({0, -15});
     group->setElements({textSpan, modifier, MakeFillStyle(Color::Blue())});
@@ -3868,81 +3868,81 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   float col4X = 680;
 
   // Row 1: EaseIn (Triangle + EaseIn)
-  auto groupEL = std::make_shared<VectorGroup>();
+  auto groupEL = VectorGroup::Make();
   groupEL->setPosition({col4X, 86});
   auto textSpanEL = Text::Make(TextBlob::MakeFrom("EaseIn", font));
   auto selectorEL = std::make_shared<RangeSelector>();
   selectorEL->setShape(SelectorShape::Triangle);
   selectorEL->setEaseIn(0.8f);
-  auto modifierEL = std::make_shared<TextModifier>();
+  auto modifierEL = TextModifier::Make();
   modifierEL->setSelectors({selectorEL});
   modifierEL->setPosition({0, -15});
   groupEL->setElements({textSpanEL, modifierEL, MakeFillStyle(Color::Blue())});
   groups.push_back(groupEL);
 
   // Row 2: EaseOut (Triangle + EaseOut)
-  auto groupEH = std::make_shared<VectorGroup>();
+  auto groupEH = VectorGroup::Make();
   groupEH->setPosition({col4X, 86 + rowHeight});
   auto textSpanEH = Text::Make(TextBlob::MakeFrom("EaseOut", font));
   auto selectorEH = std::make_shared<RangeSelector>();
   selectorEH->setShape(SelectorShape::Triangle);
   selectorEH->setEaseOut(0.8f);
-  auto modifierEH = std::make_shared<TextModifier>();
+  auto modifierEH = TextModifier::Make();
   modifierEH->setSelectors({selectorEH});
   modifierEH->setPosition({0, -15});
   groupEH->setElements({textSpanEH, modifierEH, MakeFillStyle(Color::Red())});
   groups.push_back(groupEH);
 
   // Row 3: EaseBoth (Triangle + EaseOut + EaseIn)
-  auto groupEB = std::make_shared<VectorGroup>();
+  auto groupEB = VectorGroup::Make();
   groupEB->setPosition({col4X, 86 + rowHeight * 2});
   auto textSpanEB = Text::Make(TextBlob::MakeFrom("EaseBoth", font));
   auto selectorEB = std::make_shared<RangeSelector>();
   selectorEB->setShape(SelectorShape::Triangle);
   selectorEB->setEaseOut(0.6f);
   selectorEB->setEaseIn(0.6f);
-  auto modifierEB = std::make_shared<TextModifier>();
+  auto modifierEB = TextModifier::Make();
   modifierEB->setSelectors({selectorEB});
   modifierEB->setPosition({0, -15});
   groupEB->setElements({textSpanEB, modifierEB, MakeFillStyle(Color::Green())});
   groups.push_back(groupEB);
 
   // Row 4: Unit (Index)
-  auto groupUnit = std::make_shared<VectorGroup>();
+  auto groupUnit = VectorGroup::Make();
   groupUnit->setPosition({col4X, 86 + rowHeight * 3});
   auto textSpanUnit = Text::Make(TextBlob::MakeFrom("ABCDEFGH", font));
   auto selectorUnit = std::make_shared<RangeSelector>();
   selectorUnit->setUnit(SelectorUnit::Index);
   selectorUnit->setStart(2);
   selectorUnit->setEnd(6);
-  auto modifierUnit = std::make_shared<TextModifier>();
+  auto modifierUnit = TextModifier::Make();
   modifierUnit->setSelectors({selectorUnit});
   modifierUnit->setFillColor(Color::Red());
   groupUnit->setElements({textSpanUnit, modifierUnit, MakeFillStyle(Color::Blue())});
   groups.push_back(groupUnit);
 
   // Row 5: Negative Offset
-  auto groupOff = std::make_shared<VectorGroup>();
+  auto groupOff = VectorGroup::Make();
   groupOff->setPosition({col4X, 86 + rowHeight * 4});
   auto textSpanOff = Text::Make(TextBlob::MakeFrom("NegOffset", font));
   auto selectorOff = std::make_shared<RangeSelector>();
   selectorOff->setStart(0.5f);
   selectorOff->setEnd(1.0f);
   selectorOff->setOffset(-0.3f);
-  auto modifierOff = std::make_shared<TextModifier>();
+  auto modifierOff = TextModifier::Make();
   modifierOff->setSelectors({selectorOff});
   modifierOff->setFillColor(Color::Green());
   groupOff->setElements({textSpanOff, modifierOff, MakeFillStyle(Color::Blue())});
   groups.push_back(groupOff);
 
   // Row 6: Reversed (Start > End)
-  auto groupRev = std::make_shared<VectorGroup>();
+  auto groupRev = VectorGroup::Make();
   groupRev->setPosition({col4X, 86 + rowHeight * 5});
   auto textSpanRev = Text::Make(TextBlob::MakeFrom("Reversed", font));
   auto selectorRev = std::make_shared<RangeSelector>();
   selectorRev->setStart(0.7f);
   selectorRev->setEnd(0.3f);
-  auto modifierRev = std::make_shared<TextModifier>();
+  auto modifierRev = TextModifier::Make();
   modifierRev->setSelectors({selectorRev});
   modifierRev->setFillColor(Color::FromRGBA(255, 128, 0, 255));
   groupRev->setElements({textSpanRev, modifierRev, MakeFillStyle(Color::Blue())});
@@ -3952,14 +3952,14 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   float col5X = 910;
 
   // Row 1: Random
-  auto groupRnd = std::make_shared<VectorGroup>();
+  auto groupRnd = VectorGroup::Make();
   groupRnd->setPosition({col5X, 86});
   auto textSpanRnd = Text::Make(TextBlob::MakeFrom("Random", font));
   auto selectorRnd = std::make_shared<RangeSelector>();
   selectorRnd->setShape(SelectorShape::RampUp);
   selectorRnd->setRandomOrder(true);
   selectorRnd->setRandomSeed(12345);
-  auto modifierRnd = std::make_shared<TextModifier>();
+  auto modifierRnd = TextModifier::Make();
   modifierRnd->setSelectors({selectorRnd});
   modifierRnd->setPosition({0, -12});
   groupRnd->setElements(
@@ -3967,35 +3967,35 @@ TGFX_TEST(VectorLayerTest, TextModifier) {
   groups.push_back(groupRnd);
 
   // Row 2: Empty selector
-  auto groupEmpty = std::make_shared<VectorGroup>();
+  auto groupEmpty = VectorGroup::Make();
   groupEmpty->setPosition({col5X, 86 + rowHeight});
   auto textSpanEmpty = Text::Make(TextBlob::MakeFrom("Empty", font));
-  auto modifierEmpty = std::make_shared<TextModifier>();
+  auto modifierEmpty = TextModifier::Make();
   modifierEmpty->setPosition({0, -10});
   groupEmpty->setElements({textSpanEmpty, modifierEmpty, MakeFillStyle(Color::Black())});
   groups.push_back(groupEmpty);
 
   // Row 3: Start == End boundary
-  auto groupSE = std::make_shared<VectorGroup>();
+  auto groupSE = VectorGroup::Make();
   groupSE->setPosition({col5X, 86 + rowHeight * 2});
   auto textSpanSE = Text::Make(TextBlob::MakeFrom("StartEnd", font));
   auto selectorSE = std::make_shared<RangeSelector>();
   selectorSE->setStart(0.5f);
   selectorSE->setEnd(0.5f);
-  auto modifierSE = std::make_shared<TextModifier>();
+  auto modifierSE = TextModifier::Make();
   modifierSE->setSelectors({selectorSE});
   modifierSE->setFillColor(Color::Red());
   groupSE->setElements({textSpanSE, modifierSE, MakeFillStyle(Color::Black())});
   groups.push_back(groupSE);
 
   // Row 4: First selector uses Subtract mode
-  auto groupSub = std::make_shared<VectorGroup>();
+  auto groupSub = VectorGroup::Make();
   groupSub->setPosition({col5X, 86 + rowHeight * 3});
   auto textSpanSub = Text::Make(TextBlob::MakeFrom("SubFirst", font));
   auto selectorSub = std::make_shared<RangeSelector>();
   selectorSub->setMode(SelectorMode::Subtract);
   selectorSub->setShape(SelectorShape::Triangle);
-  auto modifierSub = std::make_shared<TextModifier>();
+  auto modifierSub = TextModifier::Make();
   modifierSub->setSelectors({selectorSub});
   modifierSub->setPosition({0, -15});
   groupSub->setElements(
@@ -4043,11 +4043,11 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
 
   // Helper to create a baseline indicator line
   auto makeBaseline = [](float width) {
-    auto group = std::make_shared<VectorGroup>();
+    auto group = VectorGroup::Make();
     Path linePath = {};
     linePath.moveTo(0, 0);
     linePath.lineTo(width, 0);
-    auto shapePath = std::make_shared<ShapePath>();
+    auto shapePath = ShapePath::Make();
     shapePath->setPath(linePath);
     auto stroke = StrokeStyle::Make(SolidColor::Make(Color{0.8f, 0.8f, 0.8f}));
     group->setElements({shapePath, stroke});
@@ -4068,7 +4068,7 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
     baseline->setPosition({col1X, y});
     groups.push_back(baseline);
 
-    auto group = std::make_shared<VectorGroup>();
+    auto group = VectorGroup::Make();
     group->setPosition({col1X, y});
     auto textSpan = Text::Make(TextBlob::MakeFrom(modes[i].second, font));
 
@@ -4088,7 +4088,7 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
     selector2->setWeight(0.4f);
     selector2->setMode(modes[i].first);
 
-    auto modifier = std::make_shared<TextModifier>();
+    auto modifier = TextModifier::Make();
     modifier->setSelectors({selector1, selector2});
     modifier->setPosition({0, -20});
 
@@ -4111,7 +4111,7 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
     baseline->setPosition({col2X, y});
     groups.push_back(baseline);
 
-    auto group = std::make_shared<VectorGroup>();
+    auto group = VectorGroup::Make();
     group->setPosition({col2X, y});
     auto textSpan = Text::Make(TextBlob::MakeFrom(weights[i].second, font));
 
@@ -4119,7 +4119,7 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
     selector->setShape(SelectorShape::Triangle);
     selector->setWeight(weights[i].first);
 
-    auto modifier = std::make_shared<TextModifier>();
+    auto modifier = TextModifier::Make();
     modifier->setSelectors({selector});
     modifier->setPosition({0, -20});
 
@@ -4135,7 +4135,7 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
     baseline->setPosition({col2X, y});
     groups.push_back(baseline);
 
-    auto group = std::make_shared<VectorGroup>();
+    auto group = VectorGroup::Make();
     group->setPosition({col2X, y});
     auto textSpan = Text::Make(TextBlob::MakeFrom("ThreeSels", font));
 
@@ -4162,7 +4162,7 @@ TGFX_TEST(VectorLayerTest, TextSelector) {
     selector3->setWeight(0.5f);
     selector3->setMode(SelectorMode::Add);
 
-    auto modifier = std::make_shared<TextModifier>();
+    auto modifier = TextModifier::Make();
     modifier->setSelectors({selector1, selector2, selector3});
     modifier->setPosition({0, -20});
 
@@ -4202,8 +4202,8 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   auto refStroke = StrokeStyle::Make(SolidColor::Make(Color::Black()));
 
   // Row 1: Rectangle with Center/Inside/Outside stroke
-  auto rectGroup1 = std::make_shared<VectorGroup>();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rectGroup1 = VectorGroup::Make();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({100, 100});
   auto rectFill1 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto rectStroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -4211,9 +4211,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   rectStroke1->setStrokeAlign(StrokeAlign::Center);
   rectGroup1->setElements({rect1, rectFill1, rectStroke1, refStroke});
 
-  auto rectGroup2 = std::make_shared<VectorGroup>();
+  auto rectGroup2 = VectorGroup::Make();
   rectGroup2->setPosition({150, 0});
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({100, 100});
   auto rectFill2 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto rectStroke2 = StrokeStyle::Make(SolidColor::Make(Color::Green()));
@@ -4221,9 +4221,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   rectStroke2->setStrokeAlign(StrokeAlign::Inside);
   rectGroup2->setElements({rect2, rectFill2, rectStroke2, refStroke});
 
-  auto rectGroup3 = std::make_shared<VectorGroup>();
+  auto rectGroup3 = VectorGroup::Make();
   rectGroup3->setPosition({300, 0});
-  auto rect3 = std::make_shared<Rectangle>();
+  auto rect3 = Rectangle::Make();
   rect3->setSize({100, 100});
   auto rectFill3 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto rectStroke3 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
@@ -4232,9 +4232,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   rectGroup3->setElements({rect3, rectFill3, rectStroke3, refStroke});
 
   // Row 2: Ellipse with Center/Inside/Outside stroke
-  auto ellipseGroup1 = std::make_shared<VectorGroup>();
+  auto ellipseGroup1 = VectorGroup::Make();
   ellipseGroup1->setPosition({0, 130});
-  auto ellipse1 = std::make_shared<Ellipse>();
+  auto ellipse1 = Ellipse::Make();
   ellipse1->setSize({100, 70});
   auto ellipseFill1 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto ellipseStroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -4242,9 +4242,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   ellipseStroke1->setStrokeAlign(StrokeAlign::Center);
   ellipseGroup1->setElements({ellipse1, ellipseFill1, ellipseStroke1, refStroke});
 
-  auto ellipseGroup2 = std::make_shared<VectorGroup>();
+  auto ellipseGroup2 = VectorGroup::Make();
   ellipseGroup2->setPosition({150, 130});
-  auto ellipse2 = std::make_shared<Ellipse>();
+  auto ellipse2 = Ellipse::Make();
   ellipse2->setSize({100, 70});
   auto ellipseFill2 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto ellipseStroke2 = StrokeStyle::Make(SolidColor::Make(Color::Green()));
@@ -4252,9 +4252,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   ellipseStroke2->setStrokeAlign(StrokeAlign::Inside);
   ellipseGroup2->setElements({ellipse2, ellipseFill2, ellipseStroke2, refStroke});
 
-  auto ellipseGroup3 = std::make_shared<VectorGroup>();
+  auto ellipseGroup3 = VectorGroup::Make();
   ellipseGroup3->setPosition({300, 130});
-  auto ellipse3 = std::make_shared<Ellipse>();
+  auto ellipse3 = Ellipse::Make();
   ellipse3->setSize({100, 70});
   auto ellipseFill3 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto ellipseStroke3 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
@@ -4263,7 +4263,7 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   ellipseGroup3->setElements({ellipse3, ellipseFill3, ellipseStroke3, refStroke});
 
   // Row 3: Text with Center/Inside/Outside stroke
-  auto textGroup1 = std::make_shared<VectorGroup>();
+  auto textGroup1 = VectorGroup::Make();
   textGroup1->setPosition({-20, 230});
   auto textSpan1 = Text::Make(TextBlob::MakeFrom("Aa", font));
   auto textFill1 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
@@ -4272,7 +4272,7 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   textStroke1->setStrokeAlign(StrokeAlign::Center);
   textGroup1->setElements({textSpan1, textFill1, textStroke1, refStroke});
 
-  auto textGroup2 = std::make_shared<VectorGroup>();
+  auto textGroup2 = VectorGroup::Make();
   textGroup2->setPosition({130, 230});
   auto textSpan2 = Text::Make(TextBlob::MakeFrom("Aa", font));
   auto textFill2 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
@@ -4281,7 +4281,7 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   textStroke2->setStrokeAlign(StrokeAlign::Inside);
   textGroup2->setElements({textSpan2, textFill2, textStroke2, refStroke});
 
-  auto textGroup3 = std::make_shared<VectorGroup>();
+  auto textGroup3 = VectorGroup::Make();
   textGroup3->setPosition({280, 230});
   auto textSpan3 = Text::Make(TextBlob::MakeFrom("Aa", font));
   auto textFill3 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
@@ -4291,9 +4291,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   textGroup3->setElements({textSpan3, textFill3, textStroke3, refStroke});
 
   // Row 4: Rectangle with dash and Center/Inside/Outside stroke
-  auto dashGroup1 = std::make_shared<VectorGroup>();
+  auto dashGroup1 = VectorGroup::Make();
   dashGroup1->setPosition({0, 310});
-  auto dashRect1 = std::make_shared<Rectangle>();
+  auto dashRect1 = Rectangle::Make();
   dashRect1->setSize({100, 100});
   auto dashFill1 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto dashStroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
@@ -4302,9 +4302,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   dashStroke1->setStrokeAlign(StrokeAlign::Center);
   dashGroup1->setElements({dashRect1, dashFill1, dashStroke1, refStroke});
 
-  auto dashGroup2 = std::make_shared<VectorGroup>();
+  auto dashGroup2 = VectorGroup::Make();
   dashGroup2->setPosition({150, 310});
-  auto dashRect2 = std::make_shared<Rectangle>();
+  auto dashRect2 = Rectangle::Make();
   dashRect2->setSize({100, 100});
   auto dashFill2 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto dashStroke2 = StrokeStyle::Make(SolidColor::Make(Color::Green()));
@@ -4313,9 +4313,9 @@ TGFX_TEST(VectorLayerTest, StrokeAlign) {
   dashStroke2->setStrokeAlign(StrokeAlign::Inside);
   dashGroup2->setElements({dashRect2, dashFill2, dashStroke2, refStroke});
 
-  auto dashGroup3 = std::make_shared<VectorGroup>();
+  auto dashGroup3 = VectorGroup::Make();
   dashGroup3->setPosition({300, 310});
-  auto dashRect3 = std::make_shared<Rectangle>();
+  auto dashRect3 = Rectangle::Make();
   dashRect3->setSize({100, 100});
   auto dashFill3 = MakeFillStyle(Color::FromRGBA(200, 200, 200, 255));
   auto dashStroke3 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
@@ -4357,7 +4357,7 @@ TGFX_TEST(VectorLayerTest, LayerPlacement) {
 
   // Test 1: Fill with Background (default) - child layer should be on top
   auto vectorLayer1 = VectorLayer::Make();
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({80, 80});
   rect1->setPosition({40, 40});
   auto fill1 = MakeFillStyle(Color::Red());
@@ -4375,7 +4375,7 @@ TGFX_TEST(VectorLayerTest, LayerPlacement) {
   // Test 2: Fill with Foreground - fill should be on top of child layer
   auto vectorLayer2 = VectorLayer::Make();
   vectorLayer2->setPosition({120, 0});
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({80, 80});
   rect2->setPosition({40, 40});
   auto fill2 = MakeFillStyle(Color::Red());
@@ -4392,7 +4392,7 @@ TGFX_TEST(VectorLayerTest, LayerPlacement) {
   // Test 3: Stroke with Background (default)
   auto vectorLayer3 = VectorLayer::Make();
   vectorLayer3->setPosition({240, 0});
-  auto rect3 = std::make_shared<Rectangle>();
+  auto rect3 = Rectangle::Make();
   rect3->setSize({60, 60});
   rect3->setPosition({40, 40});
   auto stroke3 = MakeStrokeStyle(Color::Green(), 20);
@@ -4409,7 +4409,7 @@ TGFX_TEST(VectorLayerTest, LayerPlacement) {
   // Test 4: Stroke with Foreground - stroke should be on top of child layer
   auto vectorLayer4 = VectorLayer::Make();
   vectorLayer4->setPosition({360, 0});
-  auto rect4 = std::make_shared<Rectangle>();
+  auto rect4 = Rectangle::Make();
   rect4->setSize({60, 60});
   rect4->setPosition({40, 40});
   auto stroke4 = MakeStrokeStyle(Color::Green(), 20);
@@ -4480,7 +4480,7 @@ TGFX_TEST(VectorLayerTest, TextAnchors) {
   }
 
   // Left: No anchor - rotate 2nd character around default center
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({50, 80});
   auto textSpan1 = Text::Make(textBlob);
   auto selector1 = std::make_shared<RangeSelector>();
@@ -4496,7 +4496,7 @@ TGFX_TEST(VectorLayerTest, TextAnchors) {
   // This tests that TextModifier anchor adds to glyph anchor
   std::vector<Point> modifierAnchorOffsets(glyphCount, Point::Zero());
   modifierAnchorOffsets[1] = {0, -20};  // Initial anchor offset on 'G'
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({220, 80});
   auto textSpan2 = Text::Make(textBlob, modifierAnchorOffsets);
   auto selector2 = std::make_shared<RangeSelector>();
@@ -4520,10 +4520,10 @@ TGFX_TEST(VectorLayerTest, TextAnchors) {
   float centerMargin = std::round((curveLength - textWidth) / 2);
 
   // Left: No anchor offset, centered on curve
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({50, 200});
   auto textSpan3 = Text::Make(textBlob);
-  auto textPath3 = std::make_shared<TextPath>();
+  auto textPath3 = TextPath::Make();
   textPath3->setPath(curvePath);
   textPath3->setPerpendicular(true);
   textPath3->setFirstMargin(centerMargin);
@@ -4532,12 +4532,12 @@ TGFX_TEST(VectorLayerTest, TextAnchors) {
 
   // Right: Create a separate TextBlob positioned at y=14 (aligned to anchor y=-14)
   // This tests that different initial positions with matching anchor offsets produce the same result
-  auto group4 = std::make_shared<VectorGroup>();
+  auto group4 = VectorGroup::Make();
   group4->setPosition({220, 200});
   std::vector<Point> pathAnchorOffsets(glyphCount, {0, -14});  // Anchor is 14px above glyph origin
   auto textSpan4WithAnchor = Text::Make(textBlob, pathAnchorOffsets);
   textSpan4WithAnchor->setPosition({0, 14});
-  auto textPath4 = std::make_shared<TextPath>();
+  auto textPath4 = TextPath::Make();
   textPath4->setPath(curvePath);
   textPath4->setPerpendicular(true);
   textPath4->setFirstMargin(centerMargin);
@@ -4586,9 +4586,9 @@ TGFX_TEST(VectorLayerTest, StrokeDashAdaptive) {
   auto vectorLayer = VectorLayer::Make();
 
   // Group 1: Normal dash (not adaptive) on a rectangle
-  auto group1 = std::make_shared<VectorGroup>();
+  auto group1 = VectorGroup::Make();
   group1->setPosition({200, 75});
-  auto rect1 = std::make_shared<Rectangle>();
+  auto rect1 = Rectangle::Make();
   rect1->setSize({300, 100});
   auto stroke1 = StrokeStyle::Make(SolidColor::Make(Color::Red()));
   stroke1->setStrokeWidth(4.0f);
@@ -4597,9 +4597,9 @@ TGFX_TEST(VectorLayerTest, StrokeDashAdaptive) {
   group1->setElements({rect1, stroke1});
 
   // Group 2: Adaptive dash on the same rectangle
-  auto group2 = std::make_shared<VectorGroup>();
+  auto group2 = VectorGroup::Make();
   group2->setPosition({200, 200});
-  auto rect2 = std::make_shared<Rectangle>();
+  auto rect2 = Rectangle::Make();
   rect2->setSize({300, 100});
   auto stroke2 = StrokeStyle::Make(SolidColor::Make(Color::Blue()));
   stroke2->setStrokeWidth(4.0f);
@@ -4609,9 +4609,9 @@ TGFX_TEST(VectorLayerTest, StrokeDashAdaptive) {
   group2->setElements({rect2, stroke2});
 
   // Group 3: Adaptive dash on an ellipse
-  auto group3 = std::make_shared<VectorGroup>();
+  auto group3 = VectorGroup::Make();
   group3->setPosition({200, 375});
-  auto ellipse3 = std::make_shared<Ellipse>();
+  auto ellipse3 = Ellipse::Make();
   ellipse3->setSize({300, 100});
   auto stroke3 = StrokeStyle::Make(SolidColor::Make(Color::Green()));
   stroke3->setStrokeWidth(4.0f);

--- a/test/src/utils/ProjectPath.cpp
+++ b/test/src/utils/ProjectPath.cpp
@@ -26,16 +26,16 @@ static std::string GetRootPath() {
 #else
   std::filesystem::path filePath = __FILE__;
   auto dir = filePath.parent_path().string();
-  return std::filesystem::path(dir + "/../../..").lexically_normal();
+  return std::filesystem::path(dir + "/../../..").lexically_normal().string();
 #endif
 }
 std::string ProjectPath::Absolute(const std::string& relativePath) {
   std::filesystem::path path = relativePath;
   if (path.is_absolute()) {
-    return path;
+    return path.string();
   }
   static const std::string rootPath = GetRootPath() + "/";
-  return std::filesystem::path(rootPath + relativePath).lexically_normal();
+  return std::filesystem::path(rootPath + relativePath).lexically_normal().string();
 }
 
 }  // namespace tgfx

--- a/test/src/utils/TestUtils.cpp
+++ b/test/src/utils/TestUtils.cpp
@@ -36,11 +36,9 @@ std::shared_ptr<ImageCodec> MakeImageCodec(const std::string& path) {
   return ImageCodec::MakeFrom(ProjectPath::Absolute(path));
 }
 
-TGFX_PRIVATE_ACCESS(
-std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path) {
+TGFX_PRIVATE_ACCESS(std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path) {
   return ImageCodec::MakeNativeCodec(ProjectPath::Absolute(path));
-}
-)
+})
 
 std::shared_ptr<Image> MakeImage(const std::string& path) {
   return Image::MakeFromFile(ProjectPath::Absolute(path));

--- a/test/src/utils/TestUtils.cpp
+++ b/test/src/utils/TestUtils.cpp
@@ -17,7 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "TestUtils.h"
-#include <dirent.h>
+#include <filesystem>
 #include <fstream>
 #include "ProjectPath.h"
 #include "core/utils/Log.h"
@@ -36,9 +36,11 @@ std::shared_ptr<ImageCodec> MakeImageCodec(const std::string& path) {
   return ImageCodec::MakeFrom(ProjectPath::Absolute(path));
 }
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
 std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path) {
   return ImageCodec::MakeNativeCodec(ProjectPath::Absolute(path));
 }
+#endif
 
 std::shared_ptr<Image> MakeImage(const std::string& path) {
   return Image::MakeFromFile(ProjectPath::Absolute(path));

--- a/test/src/utils/TestUtils.cpp
+++ b/test/src/utils/TestUtils.cpp
@@ -36,11 +36,11 @@ std::shared_ptr<ImageCodec> MakeImageCodec(const std::string& path) {
   return ImageCodec::MakeFrom(ProjectPath::Absolute(path));
 }
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
+TGFX_PRIVATE_ACCESS(
 std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path) {
   return ImageCodec::MakeNativeCodec(ProjectPath::Absolute(path));
 }
-#endif
+)
 
 std::shared_ptr<Image> MakeImage(const std::string& path) {
   return Image::MakeFromFile(ProjectPath::Absolute(path));

--- a/test/src/utils/TestUtils.h
+++ b/test/src/utils/TestUtils.h
@@ -32,11 +32,17 @@
 
 namespace tgfx {
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
+#define TGFX_TEST_PRIVATE(suite, name) TGFX_TEST(suite, name)
+#define TGFX_PRIVATE_ACCESS(...) __VA_ARGS__
+#else
+#define TGFX_TEST_PRIVATE(suite, name) static void Disabled_##suite##_##name()
+#define TGFX_PRIVATE_ACCESS(...) /* skipped on MSVC */
+#endif
+
 std::shared_ptr<ImageCodec> MakeImageCodec(const std::string& path);
 
-#ifdef TGFX_TEST_ACCESS_PRIVATE
-std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path);
-#endif
+TGFX_PRIVATE_ACCESS(std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path);)
 
 std::shared_ptr<Image> MakeImage(const std::string& path);
 

--- a/test/src/utils/TestUtils.h
+++ b/test/src/utils/TestUtils.h
@@ -34,7 +34,9 @@ namespace tgfx {
 
 std::shared_ptr<ImageCodec> MakeImageCodec(const std::string& path);
 
+#ifdef TGFX_TEST_ACCESS_PRIVATE
 std::shared_ptr<ImageCodec> MakeNativeCodec(const std::string& path);
+#endif
 
 std::shared_ptr<Image> MakeImage(const std::string& path);
 


### PR DESCRIPTION
修复测试代码在 Windows MSVC 编译器下的编译和运行问题。

主要变更：
- 新增 TGFX_TEST_PRIVATE 和 TGFX_PRIVATE_ACCESS 两个便捷宏（定义在 TestUtils.h），将所有测试文件中对私有成员的访问统一收敛到宏中，MSVC 下自动跳过这些测试用例
- 将测试中直接使用私有 API 构造 Surface 的方式替换为公开 API（createTexture + Surface::MakeFrom）
- 修复 SVGExportTest 中 Windows CRLF 换行符导致的基准文件比对失败
- 修复 CMakeLists.txt 和 ProjectPath.cpp 中与 Windows 相关的构建配置
- 新增 codeformat.bat 供 Windows 环境下运行代码格式化