### PR TITLE
Set exact=1 for WebP lossless encoding to preserve RGB under transparent pixels

### DIFF
--- a/src/core/codecs/webp/WebpCodec.cpp
+++ b/src/core/codecs/webp/WebpCodec.cpp
@@ -186,6 +186,7 @@ std::shared_ptr<Data> WebpCodec::Encode(const Pixmap& pixmap, int quality) {
   if (isLossless) {
     webp_config.lossless = 1;
     webp_config.method = 1;
+    webp_config.exact = 1;
     pic.use_argb = 1;
   } else {
     webp_config.lossless = 0;


### PR DESCRIPTION
WebP lossless 编码默认 exact=0，编码器会修改 alpha=0 像素的 RGB 为邻居预测值以优化压缩率。VP8L 空间预测编码在解码时从邻居像素恢复出非零 RGB，导致解码后出现 alpha=0 但 RGB≠0 的脏像素，违反 premultiplied alpha 约束。

设置 exact=1 后，编码器保留原始像素值不做修改，解码结果正确。

对文件大小的影响：348 个含透明像素的测试 WebP 文件对比，总体仅增加 0.34%，72% 的文件大小完全不变。450 个截图测试全部通过。