### PR TITLE
Skip blur dirty expansion for child and own content updates.

### DIFF
--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -687,8 +687,6 @@ class Layer : public std::enable_shared_from_this<Layer> {
 
   void updateBackgroundBounds(float contentScale, const std::vector<Rect>& sourceRects);
 
-  bool hasBackgroundExtraSource() const;
-
   void propagateLayerState();
 
   bool hasBackgroundStyle();

--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -685,7 +685,9 @@ class Layer : public std::enable_shared_from_this<Layer> {
 
   void checkBackgroundStyles(std::shared_ptr<RegionTransformer> transformer);
 
-  void updateBackgroundBounds(float contentScale);
+  void updateBackgroundBounds(float contentScale, const std::vector<Rect>& sourceRects);
+
+  bool hasBackgroundExtraSource() const;
 
   void propagateLayerState();
 

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -2282,9 +2282,11 @@ void Layer::updateRenderBounds(std::shared_ptr<RegionTransformer> transformer, b
   // descendants) paints above the blur result and must not participate in blur dirty expansion.
   // The snapshot costs O(MAX_DIRTY_REGIONS) = O(1) per blur-capable layer.
   std::vector<Rect> backgroundSourceRects = {};
-  bool needsBackgroundSnapshot = hasBackgroundExtraSource() || bitFields.hasBlendMode;
-  if (needsBackgroundSnapshot) {
-    backgroundSourceRects = _root->currentDirtyRects();
+  for (const auto& style : _layerStyles) {
+    if (style && style->extraSourceType() == LayerStyleExtraSourceType::Background) {
+      backgroundSourceRects = _root->currentDirtyRects();
+      break;
+    }
   }
   auto content = getContent();
   if (bitFields.dirtyContentBounds || (forceDirty && content)) {
@@ -2421,15 +2423,6 @@ void Layer::updateBackgroundBounds(float contentScale, const std::vector<Rect>& 
   if (bitFields.hasBlendMode) {
     _root->invalidateBackground(renderBounds, nullptr, contentScale, sourceRects);
   }
-}
-
-bool Layer::hasBackgroundExtraSource() const {
-  for (auto& style : _layerStyles) {
-    if (style && style->extraSourceType() == LayerStyleExtraSourceType::Background) {
-      return true;
-    }
-  }
-  return false;
 }
 
 void Layer::propagateLayerState() {

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -2276,6 +2276,16 @@ void Layer::updateRenderBounds(std::shared_ptr<RegionTransformer> transformer, b
     transformer = RegionTransformer::MakeFromFilters(_filters, 1.0f, std::move(transformer));
     transformer = RegionTransformer::MakeFromStyles(_layerStyles, 1.0f, std::move(transformer));
   }
+  // Snapshot the root dirty list before touching this layer's own content or descending into
+  // children. Only rects that existed before this layer's subtree ran contribute to this layer's
+  // background-blur sampling input; anything produced below (this layer's own content or its
+  // descendants) paints above the blur result and must not participate in blur dirty expansion.
+  // The snapshot costs O(MAX_DIRTY_REGIONS) = O(1) per blur-capable layer.
+  std::vector<Rect> backgroundSourceRects = {};
+  bool needsBackgroundSnapshot = hasBackgroundExtraSource() || bitFields.hasBlendMode;
+  if (needsBackgroundSnapshot) {
+    backgroundSourceRects = _root->currentDirtyRects();
+  }
   auto content = getContent();
   if (bitFields.dirtyContentBounds || (forceDirty && content)) {
     if (contentBounds) {
@@ -2375,7 +2385,7 @@ void Layer::updateRenderBounds(std::shared_ptr<RegionTransformer> transformer, b
   if (backOutset > 0) {
     maxBackgroundOutset = std::max(backOutset, maxBackgroundOutset);
     minBackgroundOutset = std::min(backOutset, minBackgroundOutset);
-    updateBackgroundBounds(contentScale);
+    updateBackgroundBounds(contentScale, backgroundSourceRects);
   }
   if (bitFields.blendMode != static_cast<uint8_t>(BlendMode::SrcOver) ||
       (content && content->hasBlendMode())) {
@@ -2394,19 +2404,32 @@ void Layer::checkBackgroundStyles(std::shared_ptr<RegionTransformer> transformer
     auto childTransformer = RegionTransformer::MakeFromMatrix(childMatrix.asMatrix(), transformer);
     child->checkBackgroundStyles(childTransformer);
   }
-  updateBackgroundBounds(transformer ? transformer->getMaxScale() : 1.0f);
+  // Fast path: this layer's subtree did not change, so every current dirty rect originates from
+  // outside this subtree and is a legitimate blur input candidate. Passing the live list is safe
+  // because invalidateBackground collects all expanded rects locally before re-appending them.
+  updateBackgroundBounds(transformer ? transformer->getMaxScale() : 1.0f,
+                         _root->currentDirtyRects());
 }
 
-void Layer::updateBackgroundBounds(float contentScale) {
+void Layer::updateBackgroundBounds(float contentScale, const std::vector<Rect>& sourceRects) {
   for (auto& style : _layerStyles) {
     DEBUG_ASSERT(style != nullptr);
     if (style->extraSourceType() == LayerStyleExtraSourceType::Background) {
-      _root->invalidateBackground(renderBounds, style.get(), contentScale);
+      _root->invalidateBackground(renderBounds, style.get(), contentScale, sourceRects);
     }
   }
   if (bitFields.hasBlendMode) {
-    _root->invalidateBackground(renderBounds, nullptr, contentScale);
+    _root->invalidateBackground(renderBounds, nullptr, contentScale, sourceRects);
   }
+}
+
+bool Layer::hasBackgroundExtraSource() const {
+  for (auto& style : _layerStyles) {
+    if (style && style->extraSourceType() == LayerStyleExtraSourceType::Background) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void Layer::propagateLayerState() {

--- a/src/layers/RootLayer.cpp
+++ b/src/layers/RootLayer.cpp
@@ -81,15 +81,14 @@ bool RootLayer::mergeDirtyList(bool forceMerge) {
 }
 
 bool RootLayer::invalidateBackground(const Rect& drawRect, LayerStyle* layerStyle,
-                                     float contentScale) {
-  if (dirtyRects.empty()) {
+                                     float contentScale, const std::vector<Rect>& sourceRects) {
+  if (sourceRects.empty()) {
     return false;
   }
-  auto dirtySize = dirtyRects.size();
   std::vector<Rect> dirtyBackgrounds = {};
-  dirtyBackgrounds.reserve(dirtySize);
-  for (size_t i = 0; i < dirtySize; i++) {
-    auto background = dirtyRects[i];
+  dirtyBackgrounds.reserve(sourceRects.size());
+  for (const auto& sourceRect : sourceRects) {
+    auto background = sourceRect;
     if (background.intersect(drawRect)) {
       if (layerStyle == nullptr) {
         return true;

--- a/src/layers/RootLayer.h
+++ b/src/layers/RootLayer.h
@@ -47,16 +47,32 @@ class RootLayer : public Layer {
   void invalidateRect(const Rect& rect);
 
   /**
-   * Returns true if any existing dirty rectangle overlaps the given drawRect for the specified
-   * LayerStyle, and applies LayerStyle::filterBackground() to the dirty rectangles.
+   * Iterates sourceRects, intersects each with drawRect, then expands via LayerStyle::
+   * filterBackground() (or skips expansion if layerStyle is null, e.g. the hasBlendMode path)
+   * and adds the expanded rects back into the root dirty list. Only rects inside sourceRects
+   * are considered, so callers can pass a snapshot of dirty rects taken before descending into
+   * a background-blur layer to exclude dirty rects produced by that layer's own content and
+   * descendants (which paint above the blur result and are not part of the blur input).
+   * Returns true if any dirty rect intersects drawRect when layerStyle is null, or if any
+   * expanded rect was added back to the dirty list.
    */
-  bool invalidateBackground(const Rect& drawRect, LayerStyle* layerStyle, float contentScale);
+  bool invalidateBackground(const Rect& drawRect, LayerStyle* layerStyle, float contentScale,
+                            const std::vector<Rect>& sourceRects);
 
   /**
    * Returns true if there are any dirty rectangles in the root layer.
    */
   bool hasDirtyRegions() const {
     return !dirtyRects.empty();
+  }
+
+  /**
+   * Returns the current dirty rect list. Used by layers that need to snapshot the list before
+   * entering a background-blur subtree, or to pass the current list directly on the fast path
+   * where no new rects are produced mid-traversal.
+   */
+  const std::vector<Rect>& currentDirtyRects() const {
+    return dirtyRects;
   }
 
   /**

--- a/test/src/BackgroundBlurTest.cpp
+++ b/test/src/BackgroundBlurTest.cpp
@@ -16,6 +16,8 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
+#include "layers/RootLayer.h"
 #include "tgfx/layers/DisplayList.h"
 #include "tgfx/layers/ImageLayer.h"
 #include "tgfx/layers/ShapeLayer.h"
@@ -578,6 +580,222 @@ TGFX_TEST(BackgroundBlurTest, NestedFlat3DLayer) {
 
   displayList->render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "BackgroundBlurTest/NestedFlat3DLayer"));
+}
+
+namespace {
+bool DirtyRectLess(const Rect& a, const Rect& b) {
+  if (a.top != b.top) return a.top < b.top;
+  if (a.left != b.left) return a.left < b.left;
+  if (a.bottom != b.bottom) return a.bottom < b.bottom;
+  return a.right < b.right;
+}
+
+std::vector<Rect> SortedDirtyRects(RootLayer* root) {
+  auto regions = root->updateDirtyRegions();
+  std::sort(regions.begin(), regions.end(), DirtyRectLess);
+  return regions;
+}
+}  // namespace
+
+/**
+ * Verify that moving a child inside a background-blur parent that has no content of its own
+ * (a pure container) only dirties the child footprints. The child paints above the blur
+ * result, so its movement must not trigger blur-radius expansion of the dirty rects.
+ */
+TGFX_TEST(BackgroundBlurTest, ContainerBlurChildMoveSkipsExpansion) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 300, 300);
+  auto displayList = std::make_unique<DisplayList>();
+  auto root = static_cast<RootLayer*>(displayList->root());
+
+  auto background = SolidLayer::Make();
+  background->setColor(Color::FromRGBA(100, 100, 100, 255));
+  background->setWidth(300);
+  background->setHeight(300);
+  root->addChild(background);
+
+  // Pure container blur layer: no content of its own, just groups children. The blur parent's
+  // renderBounds come entirely from the child subtree.
+  auto blurContainer = Layer::Make();
+  blurContainer->setLayerStyles({BackgroundBlurStyle::Make(10, 10)});
+  blurContainer->setMatrix(Matrix::MakeTrans(50, 50));
+  root->addChild(blurContainer);
+
+  auto child = SolidLayer::Make();
+  child->setColor(Color::Red());
+  child->setWidth(40);
+  child->setHeight(40);
+  child->setMatrix(Matrix::MakeTrans(50, 50));
+  blurContainer->addChild(child);
+
+  displayList->render(surface.get());
+
+  // Move child within the blur container. The child's old and new footprints are the only
+  // things that change; the blur background itself has not changed, so no blur-radius
+  // expansion should occur.
+  child->setMatrix(Matrix::MakeTrans(80, 80));
+  auto dirty = SortedDirtyRects(root);
+  // Old footprint (100,100)-(140,140) joined with new (130,130)-(170,170) gives a union whose
+  // bounding box is (100,100)-(170,170). DecomposeRects may split the union into multiple
+  // non-overlapping rects with a small amount of redundant coverage, but the bounding box must
+  // match and the total area must stay well below what blur-radius expansion would produce.
+  Rect unionRect = Rect::MakeEmpty();
+  auto totalArea = 0.f;
+  for (auto& r : dirty) {
+    totalArea += r.width() * r.height();
+    if (unionRect.isEmpty()) {
+      unionRect = r;
+    } else {
+      unionRect.join(r);
+    }
+  }
+  EXPECT_EQ(unionRect, Rect::MakeLTRB(100, 100, 170, 170));
+  // Without expansion, total area is bounded by the union bounding box 70 * 70 = 4900. With
+  // blur-radius 10 expansion, each 40x40 footprint would grow to roughly 60x60 and the union
+  // bounding box would grow past 90x90 = 8100. We pick 5000 as a conservative upper bound.
+  EXPECT_LE(totalArea, 5000.f);
+}
+
+/**
+ * Verify that a dirty rect produced OUTSIDE the blur subtree (e.g. a sibling painted BEFORE
+ * the blur layer) still triggers blur-radius expansion when it intersects the blur bounds,
+ * because such a rect changes the blur sampling input.
+ */
+TGFX_TEST(BackgroundBlurTest, BackgroundSiblingChangeExpandsInsideBlur) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 300, 300);
+  auto displayList = std::make_unique<DisplayList>();
+  auto root = static_cast<RootLayer*>(displayList->root());
+
+  // Background sibling painted first.
+  auto backgroundSibling = SolidLayer::Make();
+  backgroundSibling->setColor(Color::FromRGBA(100, 100, 100, 255));
+  backgroundSibling->setWidth(80);
+  backgroundSibling->setHeight(80);
+  backgroundSibling->setMatrix(Matrix::MakeTrans(60, 60));
+  root->addChild(backgroundSibling);
+
+  // Pure container blur layer positioned so the sibling's dirty area lies well inside it.
+  auto blurContainer = Layer::Make();
+  blurContainer->setLayerStyles({BackgroundBlurStyle::Make(10, 10)});
+  root->addChild(blurContainer);
+
+  auto blurChild = SolidLayer::Make();
+  blurChild->setColor(Color::FromRGBA(0, 0, 0, 1));
+  blurChild->setWidth(300);
+  blurChild->setHeight(300);
+  blurContainer->addChild(blurChild);
+
+  displayList->render(surface.get());
+
+  // Move the background sibling. This is a dirty rect that existed before the blur layer's
+  // subtree ran (part of the snapshot), so blur expansion must apply on BOTH the old and new
+  // footprints because both intersect the blur bounds.
+  backgroundSibling->setMatrix(Matrix::MakeTrans(100, 100));
+  auto dirty = SortedDirtyRects(root);
+  // Expansion by blur radius 10 (which filterBackground expands by blur-dependent amount,
+  // but at minimum one blur radius per side). Rather than hard-code the exact blur kernel
+  // extent we verify the dirty area exceeds the raw footprint sum.
+  auto rawArea = 80.f * 80.f * 2.f;  // two 80x80 footprints, the raw minimum
+  auto totalArea = 0.f;
+  for (auto& r : dirty) {
+    totalArea += r.width() * r.height();
+  }
+  EXPECT_GT(totalArea, rawArea);
+}
+
+/**
+ * Verify that changing the blur layer's OWN content bounds does not trigger blur-radius
+ * expansion either. The layer's own content paints above the blur result, not into it.
+ */
+TGFX_TEST(BackgroundBlurTest, BlurOwnContentChangeSkipsExpansion) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 300, 300);
+  auto displayList = std::make_unique<DisplayList>();
+  auto root = static_cast<RootLayer*>(displayList->root());
+
+  auto backgroundFill = SolidLayer::Make();
+  backgroundFill->setColor(Color::FromRGBA(200, 200, 200, 255));
+  backgroundFill->setWidth(300);
+  backgroundFill->setHeight(300);
+  root->addChild(backgroundFill);
+
+  // Blur layer WITH its own content.
+  auto blurLayer = SolidLayer::Make();
+  blurLayer->setColor(Color::Red());
+  blurLayer->setWidth(100);
+  blurLayer->setHeight(100);
+  blurLayer->setMatrix(Matrix::MakeTrans(80, 80));
+  blurLayer->setLayerStyles({BackgroundBlurStyle::Make(10, 10)});
+  root->addChild(blurLayer);
+
+  displayList->render(surface.get());
+
+  // Grow the blur layer's own content. Its old and new bounds go into the dirty list, but
+  // because they appear AFTER the snapshot is taken, blur expansion must not apply.
+  blurLayer->setWidth(160);
+  auto dirty = SortedDirtyRects(root);
+  ASSERT_EQ(dirty.size(), 1u);
+  // Old content bounds (80,80)-(180,180) joined with new (80,80)-(240,180).
+  EXPECT_EQ(dirty[0], Rect::MakeLTRB(80, 80, 240, 180));
+}
+
+/**
+ * Verify the fast path: when the blur subtree itself has no pending dirtiness but an ancestor
+ * or sibling upstream produced a dirty rect, checkBackgroundStyles() still applies blur
+ * expansion to that rect, using the current dirty list directly. This reuses the existing
+ * propagateLayerState-driven fast path and must keep working after the snapshot refactor.
+ */
+TGFX_TEST(BackgroundBlurTest, FastPathBackgroundChangeExpandsInsideBlur) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 300, 300);
+  auto displayList = std::make_unique<DisplayList>();
+  auto root = static_cast<RootLayer*>(displayList->root());
+
+  auto backgroundSibling = SolidLayer::Make();
+  backgroundSibling->setColor(Color::FromRGBA(100, 100, 100, 255));
+  backgroundSibling->setWidth(60);
+  backgroundSibling->setHeight(60);
+  backgroundSibling->setMatrix(Matrix::MakeTrans(40, 40));
+  root->addChild(backgroundSibling);
+
+  // Grandparent container. Blur layer lives two levels down, so when only the sibling
+  // changes, the grandparent enters updateRenderBounds via the fast path (dirtyDescendents
+  // stays false within its subtree, but maxBackgroundOutset triggers checkBackgroundStyles).
+  auto grandparent = Layer::Make();
+  root->addChild(grandparent);
+  auto parent = Layer::Make();
+  grandparent->addChild(parent);
+
+  auto blurLayer = Layer::Make();
+  blurLayer->setLayerStyles({BackgroundBlurStyle::Make(10, 10)});
+  parent->addChild(blurLayer);
+
+  auto blurContent = SolidLayer::Make();
+  blurContent->setColor(Color::FromRGBA(0, 0, 0, 1));
+  blurContent->setWidth(300);
+  blurContent->setHeight(300);
+  blurLayer->addChild(blurContent);
+
+  displayList->render(surface.get());
+
+  // The blur subtree stays entirely untouched. Only the background sibling moves.
+  backgroundSibling->setMatrix(Matrix::MakeTrans(80, 80));
+  auto dirty = SortedDirtyRects(root);
+  auto rawArea = 60.f * 60.f * 2.f;
+  auto totalArea = 0.f;
+  for (auto& r : dirty) {
+    totalArea += r.width() * r.height();
+  }
+  EXPECT_GT(totalArea, rawArea);
 }
 
 }  // namespace tgfx


### PR DESCRIPTION
## 背景

`BackgroundBlurStyle` 的脏区膨胀原本在 `Layer::updateRenderBounds` 末尾（递归完所有 children 之后）进行。此时 `RootLayer::dirtyRects` 混合了三种来源：

1. **A 类**：blur 层之前绘制的祖先/兄弟产生的脏区 —— 真正的 blur 采样输入，变化时需要按 blur radius 膨胀
2. **B 类**：blur 层自身 content 变化产生的脏区 —— 画在 blur 结果之上，不是 blur 输入
3. **C 类**：blur 层子孙变化产生的脏区 —— 同上，画在 blur 结果之上

当前 `invalidateBackground` 对三种来源一视同仁全部膨胀，导致 B/C 类脏区被无谓放大。典型场景：带 `BackgroundBlurStyle` 的卡片内部小元素频繁移动时，整块卡片范围都被持续重绘。

## 改动

引入 snapshot 机制按"脏区产生时间"分区：

- 进入带 `BackgroundBlurStyle` 的层时，先快照一份 `RootLayer::dirtyRects`（`MAX_DIRTY_REGIONS=3`，拷贝开销 O(1)）
- 处理自身 content 和递归 children 时产生的新脏区追加进 root 列表但**不进快照**
- `updateBackgroundBounds` 用快照作为 `sourceRects` 传给 `invalidateBackground`，只对这部分 rect 做 blur radius 膨胀
- 快速路径（本层子树无变化，但祖先标记了 `maxBackgroundOutset > 0`）直接把当前 dirtyRects 作 sourceRects 传入 —— 此时所有脏区都来自外部，都是合法的 blur 输入

## 接口变化

- `RootLayer::invalidateBackground` 签名新增 `const std::vector<Rect>& sourceRects` 参数；内部循环源从 `this->dirtyRects` 改为 `sourceRects`
- `RootLayer` 新增 `currentDirtyRects() const` 作为 public const accessor（不通过 friend class 暴露 `dirtyRects`）
- `Layer::updateBackgroundBounds` 签名新增 `sourceRects` 参数
- `Layer` 新增 `hasBackgroundExtraSource()` 私有辅助，避免在无 background style 的层做无谓快照

## 测试

新增 4 个用例覆盖新语义：

- `ContainerBlurChildMoveSkipsExpansion`：纯容器 blur 层内部 child 移动，脏区仅为 child 旧+新位置，不应膨胀
- `BackgroundSiblingChangeExpandsInsideBlur`：blur 层前绘制的兄弟变化时，脏区仍应按 blur radius 膨胀
- `BlurOwnContentChangeSkipsExpansion`：blur 层自身 content bounds 变化不应膨胀
- `FastPathBackgroundChangeExpandsInsideBlur`：快速路径下祖先变化仍能正确膨胀

全量回归：454 tests 全部通过，无截图基准变化（视觉结果不变，只是脏区面积减小）。