### PR TITLE
Remove definite-assignment assertions from static fields in ScalerContext.

### DIFF
--- a/web/src/core/scaler-context.ts
+++ b/web/src/core/scaler-context.ts
@@ -27,8 +27,8 @@ export class ScalerContext {
     // from every constructor, guaranteeing both fields are set before any
     // instance method can reach them. Callers must not touch these before an
     // instance has been constructed.
-    public static canvas!: HTMLCanvasElement | OffscreenCanvas;
-    public static context!: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    public static canvas: HTMLCanvasElement | OffscreenCanvas;
+    public static context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
     private static hasMeasureBoundsAPI: boolean | undefined = undefined;
 
     public static getLineCap(cap: ctor): CanvasLineCap {


### PR DESCRIPTION
## 问题

#1415 中为 `ScalerContext.canvas` 和 `ScalerContext.context` 添加了 `!` definite-assignment assertion，但项目 `tsconfig.json` 使用 `target: ES2020`，此时 `useDefineForClassFields` 默认为 `false`，静态字段上的 `!` 断言会触发 TS1255 编译错误。

## 修改

移除两个静态字段上的 `!` 断言。字段的初始化保证已由注释和 `loadCanvas()` 的调用约定说明，无需断言。

## 测试

- [x] `tsc --noEmit` 无报错