### PR TITLE
Fix false context-lost on EGL drivers returning out-of-spec graphics reset status.

### DIFF
--- a/src/gpu/opengl/GLDefines.h
+++ b/src/gpu/opengl/GLDefines.h
@@ -168,6 +168,11 @@ namespace tgfx {
 #define GL_CONTEXT_LOST 0x300E
 #define GL_INVALID_INDEX 0xFFFFFFFF
 
+// GraphicsResetStatus (KHR_robustness / EXT_robustness)
+#define GL_GUILTY_CONTEXT_RESET 0x8253
+#define GL_INNOCENT_CONTEXT_RESET 0x8254
+#define GL_UNKNOWN_CONTEXT_RESET 0x8255
+
 // FrontFaceDirection
 #define GL_CW 0x0900
 #define GL_CCW 0x0901

--- a/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/src/gpu/opengl/egl/EGLDevice.cpp
@@ -37,6 +37,18 @@
 #define EGL_LOSE_CONTEXT_ON_RESET_EXT 0x31BF
 #endif
 
+#ifndef GL_GUILTY_CONTEXT_RESET
+#define GL_GUILTY_CONTEXT_RESET 0x8253
+#endif
+
+#ifndef GL_INNOCENT_CONTEXT_RESET
+#define GL_INNOCENT_CONTEXT_RESET 0x8254
+#endif
+
+#ifndef GL_UNKNOWN_CONTEXT_RESET
+#define GL_UNKNOWN_CONTEXT_RESET 0x8255
+#endif
+
 namespace tgfx {
 static std::vector<EGLint> GetValidAttributes(const std::vector<EGLint>& attributes) {
   if (!attributes.empty() && attributes.back() == EGL_NONE) {
@@ -333,13 +345,22 @@ bool EGLDevice::checkGraphicsResetStatus() {
     return false;
   }
   auto status = getGraphicsResetStatus();
-  if (status != GL_NO_ERROR) {
-    graphicsResetStatus = status;
-    LOGE("EGLDevice::checkGraphicsResetStatus() GPU reset detected: status=0x%x", status);
-    handleContextLost();
-    return true;
+  if (status == GL_NO_ERROR) {
+    return false;
   }
-  return false;
+  // The GL_KHR_robustness/GL_EXT_robustness spec restricts the return value to one of the four
+  // constants below. Some drivers (notably Android emulator GPU stubs) return out-of-spec values
+  // such as uninitialized memory, which would otherwise trigger a false context-lost. Treat any
+  // non-spec value as no reset to avoid taking down all contexts on broken drivers.
+  if (status != GL_GUILTY_CONTEXT_RESET && status != GL_INNOCENT_CONTEXT_RESET &&
+      status != GL_UNKNOWN_CONTEXT_RESET) {
+    LOGE("EGLDevice::checkGraphicsResetStatus() ignored out-of-spec status=0x%x", status);
+    return false;
+  }
+  graphicsResetStatus = status;
+  LOGE("EGLDevice::checkGraphicsResetStatus() GPU reset detected: status=0x%x", status);
+  handleContextLost();
+  return true;
 }
 
 bool EGLDevice::recreateSurfaceIfNeeded(EGLNativeWindowType nativeWindow) {

--- a/src/gpu/opengl/egl/EGLDevice.cpp
+++ b/src/gpu/opengl/egl/EGLDevice.cpp
@@ -37,18 +37,6 @@
 #define EGL_LOSE_CONTEXT_ON_RESET_EXT 0x31BF
 #endif
 
-#ifndef GL_GUILTY_CONTEXT_RESET
-#define GL_GUILTY_CONTEXT_RESET 0x8253
-#endif
-
-#ifndef GL_INNOCENT_CONTEXT_RESET
-#define GL_INNOCENT_CONTEXT_RESET 0x8254
-#endif
-
-#ifndef GL_UNKNOWN_CONTEXT_RESET
-#define GL_UNKNOWN_CONTEXT_RESET 0x8255
-#endif
-
 namespace tgfx {
 static std::vector<EGLint> GetValidAttributes(const std::vector<EGLint>& attributes) {
   if (!attributes.empty() && attributes.back() == EGL_NONE) {


### PR DESCRIPTION
部分 EGL 驱动（如 Android 模拟器 GPU stub）在 glGetGraphicsResetStatus 中会返回未初始化内存等不在规范范围内的值，导致 EGLDevice 误判为 GPU 复位并触发全局 context lost。

本次修改在 EGLDevice::checkGraphicsResetStatus 中加入白名单校验，仅当返回值为 GL_GUILTY_CONTEXT_RESET、GL_INNOCENT_CONTEXT_RESET、GL_UNKNOWN_CONTEXT_RESET 三种规范状态之一时才认定为复位，其他非规范值打日志后忽略，避免在异常驱动上误杀全部 context。

同时把这三个新增的 robustness 状态宏从 EGLDevice.cpp 迁移到 src/gpu/opengl/GLDefines.h，与 GL_NO_ERROR、GL_CONTEXT_LOST 等同族常量集中维护，方便后续其他平台 Device 复用。