### PR TITLE
Align Canvas empty-rect stroke with Skia semantics and add a fast path.

### DIFF
--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -245,6 +245,11 @@ void Canvas::drawLine(const Point line[2], const Matrix& matrix, const ClipStack
 
 void Canvas::drawRect(const Rect& rect, const Paint& paint) {
   if (rect.isEmpty()) {
+    // Forward to the path renderer so the stroker handles cap behaviour for zero-length
+    // segments identically to Skia.
+    Path path = {};
+    path.addRect(rect);
+    drawPath(path, paint);
     return;
   }
   SaveLayerForImageFilter(paint.getImageFilter());
@@ -312,6 +317,10 @@ static bool UseDrawPath(const Paint& paint, const Point& radii, const Matrix& vi
 
 void Canvas::drawRRect(const RRect& rRect, const Paint& paint) {
   if (rRect.rect.isEmpty()) {
+    // Forward to the path renderer for the same reason as drawRect.
+    Path path = {};
+    path.addRRect(rRect);
+    drawPath(path, paint);
     return;
   }
   auto& radii = rRect.radii;

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -245,8 +245,6 @@ void Canvas::drawLine(const Point line[2], const Matrix& matrix, const ClipStack
 
 void Canvas::drawRect(const Rect& rect, const Paint& paint) {
   if (rect.isEmpty()) {
-    // Forward to the path renderer so the stroker handles cap behaviour for zero-length
-    // segments identically to Skia.
     Path path = {};
     path.addRect(rect);
     drawPath(path, paint);
@@ -317,7 +315,6 @@ static bool UseDrawPath(const Paint& paint, const Point& radii, const Matrix& vi
 
 void Canvas::drawRRect(const RRect& rRect, const Paint& paint) {
   if (rRect.rect.isEmpty()) {
-    // Forward to the path renderer for the same reason as drawRect.
     Path path = {};
     path.addRRect(rRect);
     drawPath(path, paint);

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -245,9 +245,28 @@ void Canvas::drawLine(const Point line[2], const Matrix& matrix, const ClipStack
 
 void Canvas::drawRect(const Rect& rect, const Paint& paint) {
   if (rect.isEmpty()) {
-    Path path = {};
-    path.addRect(rect);
-    drawPath(path, paint);
+    auto stroke = paint.getStroke();
+    if (stroke == nullptr || stroke->width <= 0.0f) {
+      return;
+    }
+    bool zeroWidth = rect.width() == 0.0f;
+    bool zeroHeight = rect.height() == 0.0f;
+    // Double-zero rect with Butt cap produces no geometry.
+    if (zeroWidth && zeroHeight && stroke->cap == LineCap::Butt) {
+      return;
+    }
+    float halfWidth = stroke->width * 0.5f;
+    Rect outset = rect;
+    outset.outset(zeroWidth ? halfWidth : 0.0f, zeroHeight ? halfWidth : 0.0f);
+    SaveLayerForImageFilter(paint.getImageFilter());
+    auto brush = paint.getBrush();
+    if (zeroWidth && zeroHeight && stroke->cap == LineCap::Round) {
+      RRect oval = {};
+      oval.setOval(outset);
+      drawContext->drawRRect(oval, _matrix, *clipStack, brush, nullptr);
+    } else {
+      drawContext->drawRect(outset, _matrix, *clipStack, brush, nullptr);
+    }
     return;
   }
   SaveLayerForImageFilter(paint.getImageFilter());
@@ -315,9 +334,7 @@ static bool UseDrawPath(const Paint& paint, const Point& radii, const Matrix& vi
 
 void Canvas::drawRRect(const RRect& rRect, const Paint& paint) {
   if (rRect.rect.isEmpty()) {
-    Path path = {};
-    path.addRRect(rRect);
-    drawPath(path, paint);
+    drawRect(rRect.rect, paint);
     return;
   }
   auto& radii = rRect.radii;

--- a/src/layers/vectors/Rectangle.cpp
+++ b/src/layers/vectors/Rectangle.cpp
@@ -71,9 +71,7 @@ void Rectangle::apply(VectorContext* context) {
     auto halfHeight = _size.height * 0.5f;
     Path path;
     // A degenerate rectangle is treated as an open line segment (or a single point when both
-    // sides are zero). The open contour lets Square caps extend it into a filled band along
-    // both axes, and keeps trim/dash effects acting on a single segment instead of two
-    // overlapping edges of a closed zero-area rect.
+    // sides are zero).
     bool degenerate = _size.width == 0.0f || _size.height == 0.0f;
     if (degenerate) {
       Point p0 = {_position.x - halfWidth, _position.y - halfHeight};

--- a/src/layers/vectors/Rectangle.cpp
+++ b/src/layers/vectors/Rectangle.cpp
@@ -70,10 +70,10 @@ void Rectangle::apply(VectorContext* context) {
     auto halfWidth = _size.width * 0.5f;
     auto halfHeight = _size.height * 0.5f;
     Path path;
-    // When either side is zero the rectangle collapses to a single line segment (or a single
-    // point when both sides are zero). Emitting a moveTo+lineTo keeps the path open so LineCap
-    // can render the stroke; a closed degenerate addRoundRect would swallow caps and produce
-    // no pixels for non-Round/Square caps.
+    // A degenerate rectangle is treated as an open line segment (or a single point when both
+    // sides are zero). The open contour lets Square caps extend it into a filled band along
+    // both axes, and keeps trim/dash effects acting on a single segment instead of two
+    // overlapping edges of a closed zero-area rect.
     bool degenerate = _size.width == 0.0f || _size.height == 0.0f;
     if (degenerate) {
       Point p0 = {_position.x - halfWidth, _position.y - halfHeight};

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -50,7 +50,7 @@
         "DrawTextBlob": "29dde9e0",
         "DuplicateClipPath": "f870cce1",
         "EmptyClipMerge": "23eac4df",
-        "EmptyRectStroke": "7cd847c8",
+        "EmptyRectStroke": "4a460d01",
         "InverseFillClip": "d4af6d777",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -50,6 +50,7 @@
         "DrawTextBlob": "29dde9e0",
         "DuplicateClipPath": "f870cce1",
         "EmptyClipMerge": "23eac4df",
+        "EmptyRectStroke": "ff3ec6ca",
         "InverseFillClip": "d4af6d777",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -50,7 +50,7 @@
         "DrawTextBlob": "29dde9e0",
         "DuplicateClipPath": "f870cce1",
         "EmptyClipMerge": "23eac4df",
-        "EmptyRectStroke": "ff3ec6ca",
+        "EmptyRectStroke": "7cd847c8",
         "InverseFillClip": "d4af6d777",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -582,7 +582,7 @@
         "MultipleFillsAndStrokes": "4a74f6aa",
         "NestedGroups": "4a74f6aa",
         "PolystarRotation": "4a74f6aa",
-        "RectangleAsLine": "13582ab7",
+        "RectangleAsLine": "751bc86a",
         "Repeater": "4a74f6aa",
         "RepeaterEdgeCases": "4a74f6aa",
         "RepeaterTransform": "4a74f6aa",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3005,7 +3005,8 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   // Compares drawRect(emptyRect) against drawRRect(emptyRect with non-zero radii).
   // Layout (256x256 canvas):
   //   Top half  (y=30):  drawRect  - row 0 double-zero (0x0), row 1 single-zero (60x0)
-  //   Bottom half (y=150): drawRRect with radii=10 - same two rows
+  //   Bottom half (y=150): drawRRect with radii=10 - row 0 double-zero (0x0),
+  //                                                  row 1 single-zero vertical (0x60)
   //   Columns: Butt / Square / Round
   ContextScope scope;
   auto context = scope.getContext();
@@ -3031,13 +3032,20 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   mark.setColor(Color::FromRGBA(255, 0, 0, 255));
   mark.setAntiAlias(true);
 
-  auto drawCell = [&](float cx, float cy, LineCap cap, bool useRRect, bool doubleZero) {
+  auto drawCell = [&](float cx, float cy, LineCap cap, bool useRRect, bool doubleZero,
+                      bool vertical) {
     canvas->drawCircle(cx, cy, 1.5f, mark);
     Stroke s(strokeWidth);
     s.cap = cap;
     stroke.setStroke(s);
-    Rect rect = doubleZero ? Rect::MakeXYWH(cx, cy, 0.0f, 0.0f)
-                           : Rect::MakeXYWH(cx - 30.0f, cy, 60.0f, 0.0f);
+    Rect rect;
+    if (doubleZero) {
+      rect = Rect::MakeXYWH(cx, cy, 0.0f, 0.0f);
+    } else if (vertical) {
+      rect = Rect::MakeXYWH(cx, cy - 30.0f, 0.0f, 60.0f);
+    } else {
+      rect = Rect::MakeXYWH(cx - 30.0f, cy, 60.0f, 0.0f);
+    }
     if (useRRect) {
       RRect rRect = {};
       rRect.setRectXY(rect, rrectRadius, rrectRadius);
@@ -3051,16 +3059,17 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   float y = 30.0f;
   for (int col = 0; col < 3; ++col) {
     float cx = originX + static_cast<float>(col) * colSpacing;
-    drawCell(cx, y, caps[col], false, true);
-    drawCell(cx, y + 50.0f, caps[col], false, false);
+    drawCell(cx, y, caps[col], false, true, false);
+    drawCell(cx, y + 50.0f, caps[col], false, false, false);
   }
 
-  // Bottom half: drawRRect with non-zero radii
+  // Bottom half: drawRRect with non-zero radii. Second row uses a vertical 0x60 rect to
+  // exercise the orthogonal single-zero orientation.
   y = 150.0f;
   for (int col = 0; col < 3; ++col) {
     float cx = originX + static_cast<float>(col) * colSpacing;
-    drawCell(cx, y, caps[col], true, true);
-    drawCell(cx, y + 50.0f, caps[col], true, false);
+    drawCell(cx, y, caps[col], true, true, false);
+    drawCell(cx, y + 50.0f, caps[col], true, false, true);
   }
 
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyRectStroke"));

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3001,4 +3001,55 @@ TGFX_TEST(CanvasTest, TurbulenceTileSize) {
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/TurbulenceTileSize"));
 }
 
+TGFX_TEST(CanvasTest, EmptyRectStroke) {
+  // Mirrors the Skia fiddle that probes drawRect(emptyRect, strokePaint) behaviour.
+  // Layout (256x256 canvas):
+  //   Row 0 (y=60):  double-zero rect  (w=0, h=0)
+  //   Row 1 (y=170): single-zero rect  (w=60, h=0)
+  // Columns: Butt / Square / Round
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 256, 256);
+  ASSERT_TRUE(surface != nullptr);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+
+  const float strokeWidth = 16.0f;
+  const float colSpacing = 76.0f;
+  const float rowSpacing = 110.0f;
+  const float originX = 40.0f;
+  const float originY = 60.0f;
+
+  LineCap caps[3] = {LineCap::Butt, LineCap::Square, LineCap::Round};
+
+  Paint stroke = {};
+  stroke.setStyle(PaintStyle::Stroke);
+  stroke.setColor(Color::FromRGBA(0, 0, 255, 255));
+  stroke.setAntiAlias(true);
+
+  Paint mark = {};
+  mark.setColor(Color::FromRGBA(255, 0, 0, 255));
+  mark.setAntiAlias(true);
+
+  for (int row = 0; row < 2; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      float cx = originX + static_cast<float>(col) * colSpacing;
+      float cy = originY + static_cast<float>(row) * rowSpacing;
+
+      canvas->drawCircle(cx, cy, 1.5f, mark);
+
+      Stroke s(strokeWidth);
+      s.cap = caps[col];
+      stroke.setStroke(s);
+
+      Rect rect = (row == 0) ? Rect::MakeXYWH(cx, cy, 0.0f, 0.0f)
+                             : Rect::MakeXYWH(cx - 30.0f, cy, 60.0f, 0.0f);
+      canvas->drawRect(rect, stroke);
+    }
+  }
+
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyRectStroke"));
+}
+
 }  // namespace tgfx

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3002,10 +3002,11 @@ TGFX_TEST(CanvasTest, TurbulenceTileSize) {
 }
 
 TGFX_TEST(CanvasTest, EmptyRectStroke) {
+  // Compares drawRect(emptyRect) against drawRRect(emptyRect with non-zero radii).
   // Layout (256x256 canvas):
-  //   Row 0 (y=60):  double-zero rect  (w=0, h=0)
-  //   Row 1 (y=170): single-zero rect  (w=60, h=0)
-  // Columns: Butt / Square / Round
+  //   Top half  (y=30):  drawRect  - row 0 double-zero (0x0), row 1 single-zero (60x0)
+  //   Bottom half (y=150): drawRRect with radii=10 - same two rows
+  //   Columns: Butt / Square / Round
   ContextScope scope;
   auto context = scope.getContext();
   ASSERT_TRUE(context != nullptr);
@@ -3015,10 +3016,9 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   canvas->clear(Color::White());
 
   const float strokeWidth = 16.0f;
+  const float rrectRadius = 10.0f;
   const float colSpacing = 76.0f;
-  const float rowSpacing = 110.0f;
   const float originX = 40.0f;
-  const float originY = 60.0f;
 
   LineCap caps[3] = {LineCap::Butt, LineCap::Square, LineCap::Round};
 
@@ -3031,21 +3031,36 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   mark.setColor(Color::FromRGBA(255, 0, 0, 255));
   mark.setAntiAlias(true);
 
-  for (int row = 0; row < 2; ++row) {
-    for (int col = 0; col < 3; ++col) {
-      float cx = originX + static_cast<float>(col) * colSpacing;
-      float cy = originY + static_cast<float>(row) * rowSpacing;
-
-      canvas->drawCircle(cx, cy, 1.5f, mark);
-
-      Stroke s(strokeWidth);
-      s.cap = caps[col];
-      stroke.setStroke(s);
-
-      Rect rect = (row == 0) ? Rect::MakeXYWH(cx, cy, 0.0f, 0.0f)
-                             : Rect::MakeXYWH(cx - 30.0f, cy, 60.0f, 0.0f);
+  auto drawCell = [&](float cx, float cy, LineCap cap, bool useRRect, bool doubleZero) {
+    canvas->drawCircle(cx, cy, 1.5f, mark);
+    Stroke s(strokeWidth);
+    s.cap = cap;
+    stroke.setStroke(s);
+    Rect rect = doubleZero ? Rect::MakeXYWH(cx, cy, 0.0f, 0.0f)
+                           : Rect::MakeXYWH(cx - 30.0f, cy, 60.0f, 0.0f);
+    if (useRRect) {
+      RRect rRect = {};
+      rRect.setRectXY(rect, rrectRadius, rrectRadius);
+      canvas->drawRRect(rRect, stroke);
+    } else {
       canvas->drawRect(rect, stroke);
     }
+  };
+
+  // Top half: drawRect
+  float y = 30.0f;
+  for (int col = 0; col < 3; ++col) {
+    float cx = originX + static_cast<float>(col) * colSpacing;
+    drawCell(cx, y, caps[col], false, true);
+    drawCell(cx, y + 50.0f, caps[col], false, false);
+  }
+
+  // Bottom half: drawRRect with non-zero radii
+  y = 150.0f;
+  for (int col = 0; col < 3; ++col) {
+    float cx = originX + static_cast<float>(col) * colSpacing;
+    drawCell(cx, y, caps[col], true, true);
+    drawCell(cx, y + 50.0f, caps[col], true, false);
   }
 
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyRectStroke"));

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3002,7 +3002,6 @@ TGFX_TEST(CanvasTest, TurbulenceTileSize) {
 }
 
 TGFX_TEST(CanvasTest, EmptyRectStroke) {
-  // Mirrors the Skia fiddle that probes drawRect(emptyRect, strokePaint) behaviour.
   // Layout (256x256 canvas):
   //   Row 0 (y=60):  double-zero rect  (w=0, h=0)
   //   Row 1 (y=170): single-zero rect  (w=60, h=0)

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -4705,22 +4705,25 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
   auto group5 = VectorGroup::Make();
   group5->setElements({rect5, stroke5});
 
-  // Row 6: Three Center-aligned 96px stroke samples sharing a fit linear gradient. Round and
+  // Row 6: Four Center-aligned 72px stroke samples sharing a fit linear gradient. Round and
   // Square sit on a double-zero Rectangle (collapses to a moveTo+lineTo with overlapping
   // endpoints) and rely on the epsilon fit-axis fallback: Round splits diagonally red/blue,
-  // Square splits horizontally red/blue. The third sample uses a real 50x10 Rectangle so the
-  // vertical gradient fills the stroked band continuously inside the geometry's height and
-  // clamps to the end colors above and below.
+  // Square splits horizontally red/blue. The third sample is a 50x0 Rectangle stroked with a
+  // Butt cap, so the band only extends vertically along the stroke width while the vertical
+  // gradient runs through it. The fourth sample uses a real 50x10 Rectangle so the vertical
+  // gradient fills the stroked band continuously inside the geometry's height and clamps to
+  // the end colors above and below.
   struct DotConfig {
     float cx;
     LineCap cap;
     Size size;
     Point gradEnd;
   };
-  const std::array<DotConfig, 3> dotConfigs = {{
-      {110.0f, LineCap::Round, {0.0f, 0.0f}, {1.0f, 1.0f}},
-      {270.0f, LineCap::Square, {0.0f, 0.0f}, {0.0f, 1.0f}},
-      {470.0f, LineCap::Butt, {50.0f, 10.0f}, {0.0f, 1.0f}},
+  const std::array<DotConfig, 4> dotConfigs = {{
+      {86.0f, LineCap::Round, {0.0f, 0.0f}, {1.0f, 1.0f}},
+      {219.0f, LineCap::Square, {0.0f, 0.0f}, {0.0f, 1.0f}},
+      {341.0f, LineCap::Butt, {50.0f, 0.0f}, {0.0f, 1.0f}},
+      {489.0f, LineCap::Butt, {50.0f, 10.0f}, {0.0f, 1.0f}},
   }};
   std::vector<std::shared_ptr<VectorGroup>> dotGroups;
   dotGroups.reserve(dotConfigs.size());
@@ -4731,7 +4734,7 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
     auto dotGradient =
         Gradient::MakeLinear({0.0f, 0.0f}, config.gradEnd, {Color::Red(), Color::Blue()});
     auto dotStroke = StrokeStyle::Make(dotGradient);
-    dotStroke->setStrokeWidth(96.0f);
+    dotStroke->setStrokeWidth(72.0f);
     dotStroke->setLineCap(config.cap);
     dotStroke->setStrokeAlign(StrokeAlign::Center);
     auto dotGroup = VectorGroup::Make();
@@ -4739,8 +4742,8 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
     dotGroups.push_back(dotGroup);
   }
 
-  vectorLayer->setContents(
-      {group1, group2, group3, group4, group5, dotGroups[0], dotGroups[1], dotGroups[2]});
+  vectorLayer->setContents({group1, group2, group3, group4, group5, dotGroups[0], dotGroups[1],
+                            dotGroups[2], dotGroups[3]});
 
   displayList->root()->addChild(vectorLayer);
   displayList->render(surface.get());


### PR DESCRIPTION
对齐 Canvas 空矩形描边的语义并新增快路径，避免回退到 path renderer 影响合批。

主要变更：
- Canvas::drawRect 在矩形为空时按标准描边语义实现快路径：双零矩形按 cap 输出方块（Square）或圆点（Round），单边为 0 的矩形沿短边方向 outset 半个描边宽。Butt 双零保持空。
- Canvas::drawRRect 检测到 rect 为空时直接转发给 drawRect，与"空 rect + 非零半径"的退化语义一致。
- VectorLayer 的 Rectangle 元素保留退化矩形作为开放线段/点的策略，并补充注释说明意图。导出端把退化矩形的 cap 强制为 Square 即可获得双向扩展的预期效果。
- 新增 CanvasTest.EmptyRectStroke 用例，覆盖 drawRect 与 drawRRect 在双零、横向单零、竖向单零三种空矩形上的 Butt/Square/Round 表现。
- 扩展 VectorLayerTest.RectangleAsLine 的 Row 6，新增一个 50x0 Butt 的描边样本与 50x10 真实矩形并排对比，调整布局保证两端边距对称且与上方横线对齐。
- 更新对应基线。