### PR TITLE
Stop collapsing zero-extent Rectangle into a line segment or point.

### DIFF
--- a/src/layers/vectors/Gradient.cpp
+++ b/src/layers/vectors/Gradient.cpp
@@ -92,14 +92,14 @@ std::shared_ptr<Shader> Gradient::getShader() const {
 
 Matrix Gradient::getFitMatrix(const Rect& bounds) const {
   DEBUG_ASSERT(_fitsToGeometry);
-  // Replace zero-width/height axes with a sub-pixel epsilon so the resulting matrix stays
-  // invertible. The 1e-3 px transition band is far below any sampling grid (GPUs sample at
-  // 1/16 px or coarser), so a zero-extent axis still renders as a clean Clamp split between
-  // the first and last colors of the gradient instead of degenerating to a constant fill.
-  // 1/epsilon = 1e3 stays well within fp32 precision for the inverse used during shading.
-  constexpr float kMinScale = 1e-3f;
-  float sx = std::max(bounds.width(), kMinScale);
-  float sy = std::max(bounds.height(), kMinScale);
+  // Clamp zero or sub-pixel bounds axes to the 1/16 px GPU sub-pixel grid. Below this
+  // floor, 1/sx blows up shader-space coordinates and (tu + tv) suffers catastrophic
+  // cancellation, producing stair-step artifacts along the split. 1/16 px is still
+  // narrow enough to read as a hard Clamp split between the first and last colors on a
+  // collapsed axis.
+  constexpr float MinFitScale = 1.0f / 16.0f;
+  float sx = std::max(bounds.width(), MinFitScale);
+  float sy = std::max(bounds.height(), MinFitScale);
   auto matrix = Matrix::MakeScale(sx, sy);
   matrix.postTranslate(bounds.left, bounds.top);
   return matrix;

--- a/src/layers/vectors/Rectangle.cpp
+++ b/src/layers/vectors/Rectangle.cpp
@@ -67,32 +67,22 @@ void Rectangle::setReversed(bool value) {
 void Rectangle::apply(VectorContext* context) {
   DEBUG_ASSERT(context != nullptr);
   if (_cachedShape == nullptr) {
-    auto halfWidth = _size.width * 0.5f;
-    auto halfHeight = _size.height * 0.5f;
+    // Replace zero-extent axes with a sub-pixel epsilon so a Rectangle with one or both
+    // sides collapsed to zero stays a closed area shape. The value sits just above the
+    // engine-wide FLOAT_NEARLY_ZERO (1/4096 ~ 2.44e-4) so stroker and path utility code
+    // keep treating the axis as non-zero, yet remains far below any sampling grid (GPUs
+    // sample at 1/16 px or coarser), so the geometry still reads as a line or point
+    // visually while the stroker can expand symmetrically on both sides and trim, dash,
+    // and inside/outside align all keep their well-defined area semantics.
+    constexpr float MinExtent = 5e-4f;
+    auto width = std::max(_size.width, MinExtent);
+    auto height = std::max(_size.height, MinExtent);
+    auto halfWidth = width * 0.5f;
+    auto halfHeight = height * 0.5f;
+    auto radius = std::min({_roundness, halfWidth, halfHeight});
+    auto rect = Rect::MakeXYWH(_position.x - halfWidth, _position.y - halfHeight, width, height);
     Path path;
-    // A degenerate rectangle is treated as an open line segment (or a single point when both
-    // sides are zero).
-    bool degenerate = _size.width == 0.0f || _size.height == 0.0f;
-    if (degenerate) {
-      Point p0 = {_position.x - halfWidth, _position.y - halfHeight};
-      Point p1 = {_position.x + halfWidth, _position.y + halfHeight};
-      if (_reversed) {
-        std::swap(p0, p1);
-      }
-      path.moveTo(p0);
-      path.lineTo(p1);
-    } else {
-      auto radius = _roundness;
-      if (radius > halfWidth) {
-        radius = halfWidth;
-      }
-      if (radius > halfHeight) {
-        radius = halfHeight;
-      }
-      auto rect = Rect::MakeXYWH(_position.x - halfWidth, _position.y - halfHeight, _size.width,
-                                 _size.height);
-      path.addRoundRect(rect, radius, radius, _reversed, 2);
-    }
+    path.addRoundRect(rect, radius, radius, _reversed, 2);
     _cachedShape = Shape::MakeFrom(path);
   }
   if (_cachedShape) {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -582,7 +582,7 @@
         "MultipleFillsAndStrokes": "4a74f6aa",
         "NestedGroups": "4a74f6aa",
         "PolystarRotation": "4a74f6aa",
-        "RectangleAsLine": "751bc86a",
+        "RectangleAsLine": "bf38f4c3",
         "Repeater": "4a74f6aa",
         "RepeaterEdgeCases": "4a74f6aa",
         "RepeaterTransform": "4a74f6aa",

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -4627,11 +4627,7 @@ TGFX_TEST(VectorLayerTest, StrokeDashAdaptive) {
 }
 
 /**
- * Test Rectangle collapsing to a line segment when one side is zero: horizontal stroke,
- * trimmed (forward and reversed) segments, along-axis fit gradients that prove the stroke
- * fit bounds expand only perpendicular to the segment (not along it), and a double-zero
- * Rectangle that must keep its area-shape semantics (round-cap stroked dot with a
- * symmetric two-axis fit gradient).
+ * Test Rectangle collapsing to a sub-pixel band when one side is zero.
  */
 TGFX_TEST(VectorLayerTest, RectangleAsLine) {
   ContextScope scope;
@@ -4644,7 +4640,6 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
   auto displayList = std::make_unique<DisplayList>();
   auto vectorLayer = VectorLayer::Make();
 
-  // Row 1: Horizontal degenerate Rectangle with solid red stroke.
   auto rect1 = Rectangle::Make();
   rect1->setPosition({300, 54});
   rect1->setSize({500, 0});
@@ -4652,35 +4647,17 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
   auto group1 = VectorGroup::Make();
   group1->setElements({rect1, stroke1});
 
-  // Row 2: Horizontal degenerate Rectangle trimmed to the first half, stroked green.
   auto rect2 = Rectangle::Make();
-  rect2->setPosition({175, 150});
-  rect2->setSize({250, 0});
+  rect2->setPosition({300, 150});
+  rect2->setSize({500, 0});
   auto trim2 = TrimPath::Make();
   trim2->setStart(0.0f);
   trim2->setEnd(0.5f);
   auto stroke2 = MakeStrokeStyle(Color::Green(), 8.0f);
+  stroke2->setDashes({20.0f, 20.0f});
   auto group2 = VectorGroup::Make();
   group2->setElements({rect2, trim2, stroke2});
 
-  // Row 3: Reversed horizontal degenerate Rectangle with the same trim; the opposite half
-  // should be drawn.
-  auto rect3 = Rectangle::Make();
-  rect3->setPosition({425, 150});
-  rect3->setSize({250, 0});
-  rect3->setReversed(true);
-  auto trim3 = TrimPath::Make();
-  trim3->setStart(0.0f);
-  trim3->setEnd(0.5f);
-  auto stroke3 = MakeStrokeStyle(Color::FromRGBA(255, 128, 0, 255), 8.0f);
-  auto group3 = VectorGroup::Make();
-  group3->setElements({rect3, trim3, stroke3});
-
-  // Row 4: Center-aligned stroke with an along-segment fit gradient. The fit bounds come from
-  // the path geometry (a horizontal zero-height segment) so the gradient runs from red (left)
-  // to blue (right) across the full stroked length and the perpendicular axis falls into the
-  // epsilon fallback. A regression that padded the fit bounds by stroke width would inset both
-  // ends in fit space, washing the endpoints toward purple.
   auto rect4 = Rectangle::Make();
   rect4->setPosition({300, 258});
   rect4->setSize({500, 0});
@@ -4691,13 +4668,9 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
   auto group4 = VectorGroup::Make();
   group4->setElements({rect4, stroke4});
 
-  // Row 5: Outside-aligned stroke with a perpendicular fit gradient. The fit bounds collapse
-  // along y so the epsilon fallback turns the perpendicular axis into a sharp red/blue split:
-  // the upper half of the Outside band is pure red and the lower half is pure blue, with no
-  // horizontal padding from the fit.
   auto rect5 = Rectangle::Make();
   rect5->setPosition({300, 354});
-  rect5->setSize({500, 0});
+  rect5->setSize({476, 0});
   auto gradient5 = Gradient::MakeLinear({0.5f, 0.0f}, {0.5f, 1.0f}, {Color::Red(), Color::Blue()});
   auto stroke5 = StrokeStyle::Make(gradient5);
   stroke5->setStrokeWidth(24.0f);
@@ -4705,25 +4678,18 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
   auto group5 = VectorGroup::Make();
   group5->setElements({rect5, stroke5});
 
-  // Row 6: Four Center-aligned 72px stroke samples sharing a fit linear gradient. Round and
-  // Square sit on a double-zero Rectangle (collapses to a moveTo+lineTo with overlapping
-  // endpoints) and rely on the epsilon fit-axis fallback: Round splits diagonally red/blue,
-  // Square splits horizontally red/blue. The third sample is a 50x0 Rectangle stroked with a
-  // Butt cap, so the band only extends vertically along the stroke width while the vertical
-  // gradient runs through it. The fourth sample uses a real 50x10 Rectangle so the vertical
-  // gradient fills the stroked band continuously inside the geometry's height and clamps to
-  // the end colors above and below.
   struct DotConfig {
     float cx;
     LineCap cap;
     Size size;
     Point gradEnd;
+    StrokeAlign align;
   };
   const std::array<DotConfig, 4> dotConfigs = {{
-      {86.0f, LineCap::Round, {0.0f, 0.0f}, {1.0f, 1.0f}},
-      {219.0f, LineCap::Square, {0.0f, 0.0f}, {0.0f, 1.0f}},
-      {341.0f, LineCap::Butt, {50.0f, 0.0f}, {0.0f, 1.0f}},
-      {489.0f, LineCap::Butt, {50.0f, 10.0f}, {0.0f, 1.0f}},
+      {76.0f, LineCap::Round, {0.0f, 0.0f}, {1.0f, 1.0f}, StrokeAlign::Center},
+      {224.0f, LineCap::Square, {0.0f, 0.0f}, {0.0f, 1.0f}, StrokeAlign::Outside},
+      {373.0f, LineCap::Butt, {50.0f, 0.0f}, {0.0f, 1.0f}, StrokeAlign::Center},
+      {523.0f, LineCap::Butt, {50.0f, 10.0f}, {0.0f, 1.0f}, StrokeAlign::Center},
   }};
   std::vector<std::shared_ptr<VectorGroup>> dotGroups;
   dotGroups.reserve(dotConfigs.size());
@@ -4734,16 +4700,16 @@ TGFX_TEST(VectorLayerTest, RectangleAsLine) {
     auto dotGradient =
         Gradient::MakeLinear({0.0f, 0.0f}, config.gradEnd, {Color::Red(), Color::Blue()});
     auto dotStroke = StrokeStyle::Make(dotGradient);
-    dotStroke->setStrokeWidth(72.0f);
+    dotStroke->setStrokeWidth(48.0f);
     dotStroke->setLineCap(config.cap);
-    dotStroke->setStrokeAlign(StrokeAlign::Center);
+    dotStroke->setStrokeAlign(config.align);
     auto dotGroup = VectorGroup::Make();
     dotGroup->setElements({dotRect, dotStroke});
     dotGroups.push_back(dotGroup);
   }
 
-  vectorLayer->setContents({group1, group2, group3, group4, group5, dotGroups[0], dotGroups[1],
-                            dotGroups[2], dotGroups[3]});
+  vectorLayer->setContents(
+      {group1, group2, group4, group5, dotGroups[0], dotGroups[1], dotGroups[2], dotGroups[3]});
 
   displayList->root()->addChild(vectorLayer);
   displayList->render(surface.get());


### PR DESCRIPTION
修复 Rectangle 图层在宽或高为 0 时被退化为线段或点导致的渲染异常，保留原始零面积矩形以支持 dashed stroke 和 Outside 对齐的正确绘制。

同时将 Gradient 的 fit scale 向下取整到 1/16 像素精度，避免亚像素边界的数值抖动。

RectangleAsLine 测试用例已更新以覆盖 dashed stroke 和 Outside 对齐场景，并同步刷新对应截图基准。