### PR TITLE
Guard MaskContext path extraction against runaway PathOp::Union cost.

### DIFF
--- a/src/layers/MaskContext.cpp
+++ b/src/layers/MaskContext.cpp
@@ -30,6 +30,15 @@ namespace tgfx {
  */
 static constexpr size_t MaxMaskPathDrawCount = 30;
 
+/**
+ * Hard cap on the verb count of the accumulated mask path. PathOp::Union cost is dominated by the
+ * size of its left operand, so when the running mask grows past this size each additional Union
+ * gets prohibitively expensive — drawCount alone cannot bound it because a single record may
+ * contribute thousands of verbs (dense SVG paths, stroke-applied curves, etc). Once exceeded,
+ * abort path extraction so the caller falls back to the MaskFilter shader path.
+ */
+static constexpr int MaxAccumulatedMaskVerbs = 2000;
+
 bool MaskContext::GetMaskPath(const std::shared_ptr<Picture>& picture, Path* result) {
   if (picture == nullptr || result == nullptr) {
     return false;
@@ -72,6 +81,20 @@ bool MaskContext::finish(Path* result) {
       return false;
     }
     record.path.transform(record.matrix);
+    // Pre-Union circuit breaker: PathOp::Union cost is dominated by the combined verb count of
+    // both operands, and grows super-linearly. Cut off BEFORE paying the next Union when the
+    // projected size already exceeds the cap. The caller falls back to the MaskFilter shader
+    // path, which scales much better with complex masks.
+    auto projected = maskPath.countVerbs() + record.path.countVerbs();
+    if (record.clip.state() == ClipState::Complex ||
+        record.clip.state() == ClipState::Rect) {
+      // Complex / partial-rect clip will run an extra Intersect on the clip path, which inflates
+      // the right operand. Account for the clip path verbs too.
+      projected += record.clip.getClipPath().countVerbs();
+    }
+    if (projected > MaxAccumulatedMaskVerbs) {
+      return false;
+    }
     switch (record.clip.state()) {
       case ClipState::Empty:
         // Already filtered out in addPath().
@@ -177,6 +200,12 @@ void MaskContext::drawTextBlob(std::shared_ptr<TextBlob>, const Matrix&, const C
 void MaskContext::drawPicture(std::shared_ptr<Picture> picture, const Matrix& matrix,
                               const ClipStack& clip) {
   if (_aborted || picture == nullptr) {
+    return;
+  }
+  // Apply the same drawCount budget as the top-level entry: nested pictures with too many ops
+  // would otherwise bypass the outer guard and blow up the union accumulation in finish().
+  if (picture->drawCount > MaxMaskPathDrawCount) {
+    _aborted = true;
     return;
   }
   MaskContext subContext;

--- a/src/layers/MaskContext.cpp
+++ b/src/layers/MaskContext.cpp
@@ -86,8 +86,7 @@ bool MaskContext::finish(Path* result) {
     // projected size already exceeds the cap. The caller falls back to the MaskFilter shader
     // path, which scales much better with complex masks.
     auto projected = maskPath.countVerbs() + record.path.countVerbs();
-    if (record.clip.state() == ClipState::Complex ||
-        record.clip.state() == ClipState::Rect) {
+    if (record.clip.state() == ClipState::Complex || record.clip.state() == ClipState::Rect) {
       // Complex / partial-rect clip will run an extra Intersect on the clip path, which inflates
       // the right operand. Account for the clip path verbs too.
       projected += record.clip.getClipPath().countVerbs();

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -1714,6 +1714,83 @@ TGFX_TEST(CanvasTest, PictureMaskPath) {
   EXPECT_EQ(colorOutside, Color::Transparent());
 }
 
+/**
+ * Verifies the complexity guards in MaskContext that protect against runaway PathOp::Union cost
+ * when the source picture is too large or contains very dense paths. All three guards must abort
+ * extraction so callers can fall back to the MaskFilter shader path.
+ */
+TGFX_TEST(CanvasTest, PictureMaskPathComplexAbort) {
+  auto getMaskPath = [](const std::shared_ptr<Picture>& picture, Path* maskPath) -> bool {
+    return MaskContext::GetMaskPath(picture, maskPath);
+  };
+  Paint paint = {};
+  paint.setColor(Color::Black());
+
+  // Guard 1: drawCount budget at the top level. 31 draws exceeds the 30-op cap.
+  {
+    PictureRecorder recorder = {};
+    auto* canvas = recorder.beginRecording();
+    for (int i = 0; i < 31; ++i) {
+      canvas->drawRect(Rect::MakeXYWH(static_cast<float>(i), 0.f, 1.f, 1.f), paint);
+    }
+    auto picture = recorder.finishRecordingAsPicture();
+    ASSERT_TRUE(picture != nullptr);
+    Path maskPath = {};
+    EXPECT_FALSE(getMaskPath(picture, &maskPath));
+  }
+
+  // Guard 2: accumulated-verb circuit breaker. A single drawPath with thousands of segments
+  // stays under the drawCount budget but blows past the projected-verb cap before Union runs.
+  {
+    Path densePath = {};
+    densePath.moveTo(0.f, 0.f);
+    for (int i = 1; i < 4000; ++i) {
+      densePath.lineTo(static_cast<float>(i), static_cast<float>(i & 1));
+    }
+    densePath.close();
+    PictureRecorder recorder = {};
+    auto* canvas = recorder.beginRecording();
+    canvas->drawPath(densePath, paint);
+    auto picture = recorder.finishRecordingAsPicture();
+    ASSERT_TRUE(picture != nullptr);
+    TGFX_PRIVATE_ACCESS(EXPECT_LE(picture->drawCount, 30u));
+    Path maskPath = {};
+    EXPECT_FALSE(getMaskPath(picture, &maskPath));
+  }
+
+  // Guard 3: drawCount budget propagates into nested pictures. A small outer picture that
+  // embeds an oversized inner picture must abort, otherwise the inner replay would bypass the
+  // top-level cap.
+  {
+    PictureRecorder innerRecorder = {};
+    auto* innerCanvas = innerRecorder.beginRecording();
+    for (int i = 0; i < 31; ++i) {
+      innerCanvas->drawRect(Rect::MakeXYWH(static_cast<float>(i), 0.f, 1.f, 1.f), paint);
+    }
+    auto innerPicture = innerRecorder.finishRecordingAsPicture();
+    ASSERT_TRUE(innerPicture != nullptr);
+
+    PictureRecorder outerRecorder = {};
+    auto* outerCanvas = outerRecorder.beginRecording();
+    outerCanvas->drawPicture(innerPicture);
+    auto outerPicture = outerRecorder.finishRecordingAsPicture();
+    ASSERT_TRUE(outerPicture != nullptr);
+    Path maskPath = {};
+    EXPECT_FALSE(getMaskPath(outerPicture, &maskPath));
+  }
+
+  // Sanity: a small simple picture still succeeds, ensuring the new guards don't over-trigger.
+  {
+    PictureRecorder recorder = {};
+    auto* canvas = recorder.beginRecording();
+    canvas->drawRect(Rect::MakeWH(50.f, 50.f), paint);
+    auto picture = recorder.finishRecordingAsPicture();
+    ASSERT_TRUE(picture != nullptr);
+    Path maskPath = {};
+    EXPECT_TRUE(getMaskPath(picture, &maskPath));
+  }
+}
+
 TGFX_TEST(CanvasTest, DrawImage) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
在 MaskContext 路径提取阶段加入复杂度保护，避免 PathOp::Union 因累计 mask 路径过大而出现超线性成本。

变更内容：
1. 新增累计 verb 数量上限 MaxAccumulatedMaskVerbs (2000)，在每次 Union 之前预测合并后的规模，超过则提前 abort，让上层退化到 MaskFilter shader 路径。
2. 复杂/Rect clip 会引入额外的 Intersect 操作，在预测 verb 数时一并计入 clip path 的 verb 数。
3. drawPicture 中对嵌套 picture 同样应用 MaxMaskPathDrawCount 预算，防止内层 picture 绕过顶层守卫。
4. 新增测试 CanvasTest.PictureMaskPathComplexAbort 覆盖三个守卫的 abort 路径，并保留一个简单 picture 的成功用例，确保新守卫不会过度触发。