### PR TITLE
Apply paint when exporting picture images to SVG.

### DIFF
--- a/src/svg/ElementWriter.cpp
+++ b/src/svg/ElementWriter.cpp
@@ -547,21 +547,12 @@ Resources ElementWriter::addResources(const Brush& brush, Context* context,
     addShaderResources(shader, context, &resources);
   }
 
-  if (auto colorFilter = brush.colorFilter) {
-    auto type = Types::Get(colorFilter.get());
-    switch (type) {
-      case Types::ColorFilterType::Blend:
-        addBlendColorFilterResources(static_cast<const ModeColorFilter*>(colorFilter.get()),
-                                     &resources);
-        break;
-      case Types::ColorFilterType::Matrix: {
-        addMatrixColorFilterResources(static_cast<const MatrixColorFilter*>(colorFilter.get()),
-                                      &resources);
-        break;
-      }
-      default:
-        reportUnsupportedElement("Unsupported color filter");
+  if (brush.colorFilter) {
+    auto filterResources = addColorFilterResource(brush.colorFilter);
+    if (filterResources.filter.empty()) {
+      reportUnsupportedElement("Unsupported color filter");
     }
+    resources.filter = filterResources.filter;
   }
 
   if (auto maskFilter = brush.maskFilter) {

--- a/src/svg/ElementWriter.cpp
+++ b/src/svg/ElementWriter.cpp
@@ -289,6 +289,26 @@ Resources ElementWriter::addImageFilterResource(
   return resources;
 }
 
+Resources ElementWriter::addColorFilterResource(const std::shared_ptr<ColorFilter>& colorFilter) {
+  Resources resources;
+  if (!colorFilter) {
+    return resources;
+  }
+  switch (Types::Get(colorFilter.get())) {
+    case Types::ColorFilterType::Blend:
+      addBlendColorFilterResources(static_cast<const ModeColorFilter*>(colorFilter.get()),
+                                   &resources);
+      break;
+    case Types::ColorFilterType::Matrix:
+      addMatrixColorFilterResources(static_cast<const MatrixColorFilter*>(colorFilter.get()),
+                                    &resources);
+      break;
+    default:
+      break;
+  }
+  return resources;
+}
+
 std::string ElementWriter::addImageFilter(const std::shared_ptr<ImageFilter>& imageFilter,
                                           Rect bound,
                                           const std::shared_ptr<SVGCustomWriter>& exportWriter) {

--- a/src/svg/ElementWriter.h
+++ b/src/svg/ElementWriter.h
@@ -78,6 +78,14 @@ class ElementWriter {
   Resources addImageFilterResource(const std::shared_ptr<ImageFilter>& imageFilter, Rect bound,
                                    const std::shared_ptr<SVGCustomWriter>& exportWriter);
 
+  /**
+   * Emits an SVG <filter> resource that reproduces the given color filter and returns its
+   * Resources::filter url. Returns empty Resources::filter when the color filter type cannot be
+   * expressed as a vector SVG filter, in which case the caller must rasterize. Must be called
+   * within a parent <defs> element.
+   */
+  Resources addColorFilterResource(const std::shared_ptr<ColorFilter>& colorFilter);
+
  private:
   Resources addResources(const Brush& brush, Context* context, SVGExportContext* svgContext);
 

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -171,38 +171,32 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     if (brush.nothingToDraw()) {
       return;
     }
-    // SVG has no single attribute that applies "per-element alpha multiply" to a playback stream.
-    // Classify the brush into three buckets so playback can still preserve vector output whenever
-    // possible:
-    //   identity        -> replay directly (current behavior)
-    //   alpha-only < 1  -> wrap in <g opacity=...> then replay
-    //   anything else   -> rasterize the picture image and route through exportPixmap so the
-    //                      brush (shader/colorFilter/maskFilter/blendMode) is fully honored
-    bool brushIsIdentityExceptAlpha = brush.shader == nullptr && brush.maskFilter == nullptr &&
-                                      brush.colorFilter == nullptr &&
-                                      brush.blendMode == BlendMode::SrcOver;
-    if (brushIsIdentityExceptAlpha) {
+    // Honor non-identity brushes on PictureImage: alpha-only goes through <g opacity>
+    // to preserve vectors; any shader/filter/blend forces rasterization via exportPixmap.
+    bool canExportAsVector = brush.shader == nullptr && brush.maskFilter == nullptr &&
+                             brush.colorFilter == nullptr &&
+                             brush.blendMode == BlendMode::SrcOver;
+    if (canExportAsVector) {
       const auto pictureImage = static_cast<const PictureImage*>(image.get());
       auto newMatrix = matrix;
       if (pictureImage->matrix) {
         newMatrix.preConcat(*pictureImage->matrix);
       }
-      if (brush.color.alpha < 1.0f) {
-        // Close any active clip group so the <g opacity> wraps at the right parent level.
-        // Clear the members on exit so subsequent applyClipPath rebuilds the clip group
-        // instead of short-circuiting on a matching currentClipPath.
-        clipGroupElement = nullptr;
-        currentClipPath = {};
-        {
-          ElementWriter opacityGroup("g", xmlWriter, resourceBucket.get());
-          opacityGroup.addAttribute("opacity", brush.color.alpha);
-          drawPicture(pictureImage->picture, newMatrix, clip);
-        }
-        clipGroupElement = nullptr;
-        currentClipPath = {};
-      } else {
+      if (FloatNearlyEqual(brush.color.alpha, 1.0f)) {
+        drawPicture(pictureImage->picture, newMatrix, clip);
+        return;
+      }
+      // Reset clip state around the <g opacity> so nested playback ops rebuild their own
+      // clip groups under the correct parent instead of short-circuiting on currentClipPath.
+      clipGroupElement = nullptr;
+      currentClipPath = {};
+      {
+        ElementWriter opacityGroup("g", xmlWriter, resourceBucket.get());
+        opacityGroup.addAttribute("opacity", brush.color.alpha);
         drawPicture(pictureImage->picture, newMatrix, clip);
       }
+      clipGroupElement = nullptr;
+      currentClipPath = {};
       return;
     }
     auto modifyImage = ConvertImageColorSpace(image, context, _targetColorSpace, _assignColorSpace);

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -53,6 +53,16 @@
 
 namespace tgfx {
 
+namespace {
+// Returns true when the brush carries no effect that requires compositing, so a draw can be
+// emitted as SVG vector elements instead of being rasterized. Only the alpha channel of the
+// brush color can be honored in this mode by wrapping the output in a <g opacity="..."> group.
+bool CanExportAsVector(const Brush& brush) {
+  return brush.shader == nullptr && brush.maskFilter == nullptr && brush.colorFilter == nullptr &&
+         brush.blendMode == BlendMode::SrcOver;
+}
+}  // namespace
+
 SVGExportContext::SVGExportContext(Context* context, const Rect& viewBox,
                                    std::unique_ptr<XMLWriter> inputXmlWriter, uint32_t exportFlags,
                                    std::shared_ptr<SVGCustomWriter> customWriter,
@@ -173,26 +183,38 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     }
     // Honor non-identity brushes on PictureImage: alpha-only goes through <g opacity>
     // to preserve vectors; any shader/filter/blend forces rasterization via exportPixmap.
-    bool canExportAsVector = brush.shader == nullptr && brush.maskFilter == nullptr &&
-                             brush.colorFilter == nullptr && brush.blendMode == BlendMode::SrcOver;
-    if (canExportAsVector) {
+    if (CanExportAsVector(brush)) {
       const auto pictureImage = static_cast<const PictureImage*>(image.get());
       auto newMatrix = matrix;
       if (pictureImage->matrix) {
         newMatrix.preConcat(*pictureImage->matrix);
       }
-      if (FloatNearlyEqual(brush.color.alpha, 1.0f)) {
+      if (brush.color.alpha == 1.0f) {
         drawPicture(pictureImage->picture, newMatrix, clip);
         return;
       }
-      // Reset clip state around the <g opacity> so nested playback ops rebuild their own
-      // clip groups under the correct parent instead of short-circuiting on currentClipPath.
+      // Lift the outer clip to a single <g clip-path> wrapper around <g opacity> so nested
+      // playback ops do not redefine identical clipPath resources. See drawLayer for the same
+      // structure. Inside the opacity group the clip stack is cleared, letting internal draws
+      // rebuild clips only when the picture itself introduces new ones.
+      auto clipPath = clip.getClipPath();
+      auto bound = newMatrix.mapRect(pictureImage->picture->getBounds());
+      bool needsClip = !clipPath.isEmpty() && !clipPath.contains(bound);
+      std::string clipID;
+      if (needsClip) {
+        clipID = defineClipPath(clipPath);
+      }
       clipGroupElement = nullptr;
       currentClipPath = {};
       {
+        std::unique_ptr<ElementWriter> clipElement;
+        if (needsClip) {
+          clipElement = std::make_unique<ElementWriter>("g", xmlWriter, resourceBucket.get());
+          clipElement->addAttribute("clip-path", "url(#" + clipID + ")");
+        }
         ElementWriter opacityGroup("g", xmlWriter, resourceBucket.get());
         opacityGroup.addAttribute("opacity", brush.color.alpha);
-        drawPicture(pictureImage->picture, newMatrix, clip);
+        drawPicture(pictureImage->picture, newMatrix, needsClip ? ClipStack{} : clip);
       }
       clipGroupElement = nullptr;
       currentClipPath = {};

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -185,11 +185,12 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
         blendModeStyle = "mix-blend-mode: " + svgBlendMode;
       }
     }
-    std::string filterUrl;
+    std::shared_ptr<ColorFilter> vectorColorFilter;
     if (canVectorize && brush.colorFilter) {
       auto colorFilterType = Types::Get(brush.colorFilter.get());
-      // Blend ColorFilter is only expressible when its blend mode has an SVG mapping; checking
-      // before opening <defs> avoids an empty <defs></defs> when addColorFilterResource bails out.
+      // Decide expressibility WITHOUT writing <defs> yet; the actual <defs>/<filter> emission is
+      // deferred to exportPictureImageAsVector so it lands AFTER the outer clip wrapper has been
+      // closed and at the same XML level as the brush <g> that consumes it.
       bool expressible =
           colorFilterType == Types::ColorFilterType::Matrix ||
           (colorFilterType == Types::ColorFilterType::Blend &&
@@ -198,9 +199,7 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
       if (!expressible) {
         canVectorize = false;
       } else {
-        ElementWriter defs("defs", xmlWriter, resourceBucket.get(), _targetColorSpace,
-                           _assignColorSpace);
-        filterUrl = defs.addColorFilterResource(brush.colorFilter).filter;
+        vectorColorFilter = brush.colorFilter;
       }
     }
     if (canVectorize) {
@@ -209,7 +208,7 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
       if (pictureImage->matrix) {
         newMatrix.preConcat(*pictureImage->matrix);
       }
-      exportPictureImageAsVector(pictureImage, newMatrix, clip, filterUrl, blendModeStyle,
+      exportPictureImageAsVector(pictureImage, newMatrix, clip, vectorColorFilter, blendModeStyle,
                                  brush.color.alpha);
       return;
     }
@@ -447,25 +446,37 @@ void SVGExportContext::drawPicture(std::shared_ptr<Picture> picture, const Matri
 
 void SVGExportContext::exportPictureImageAsVector(const PictureImage* pictureImage,
                                                   const Matrix& matrix, const ClipStack& clip,
-                                                  const std::string& filterUrl,
+                                                  const std::shared_ptr<ColorFilter>& colorFilter,
                                                   const std::string& blendModeStyle, float alpha) {
   // Skip the wrapper when there is nothing to attach to it.
-  if (filterUrl.empty() && blendModeStyle.empty() && alpha == 1.0f) {
+  if (!colorFilter && blendModeStyle.empty() && alpha == 1.0f) {
     drawPicture(pictureImage->picture, matrix, clip);
     return;
   }
   // Lift the outer clip to a single <g clip-path> wrapping the brush group so nested playback
   // ops do not redefine identical clipPath resources. See drawLayer for the same pattern.
+  // Use the PictureImage's logical output rect (not the raw picture bounds) so the contains()
+  // check matches what is actually painted into the SVG.
   auto clipPath = clip.getClipPath();
-  auto bound = matrix.mapRect(pictureImage->picture->getBounds());
+  auto bound = matrix.mapRect(Rect::MakeWH(static_cast<float>(pictureImage->width()),
+                                           static_cast<float>(pictureImage->height())));
   bool needsClip = !clipPath.isEmpty() && !clipPath.contains(bound);
-  std::string clipID;
-  if (needsClip) {
-    clipID = defineClipPath(clipPath);
-  }
   {
+    // Close any clip wrapper opened by previous draws BEFORE emitting our <clipPath>, <defs>
+    // and brush <g>. Otherwise these resources would be nested inside a stale <g clip-path>
+    // that does not belong to this draw, leaving them at the wrong XML depth.
     clipGroupElement = nullptr;
     currentClipPath = {};
+    std::string clipID;
+    if (needsClip) {
+      clipID = defineClipPath(clipPath);
+    }
+    std::string filterUrl;
+    if (colorFilter) {
+      ElementWriter defs("defs", xmlWriter, resourceBucket.get(), _targetColorSpace,
+                         _assignColorSpace);
+      filterUrl = defs.addColorFilterResource(colorFilter).filter;
+    }
     std::unique_ptr<ElementWriter> clipElement;
     if (needsClip) {
       clipElement = std::make_unique<ElementWriter>("g", xmlWriter, resourceBucket.get());

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -168,12 +168,48 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
   DEBUG_ASSERT(image != nullptr);
   auto type = Types::Get(image.get());
   if (type == Types::ImageType::Picture) {
-    const auto pictureImage = static_cast<const PictureImage*>(image.get());
-    auto newMatrix = matrix;
-    if (pictureImage->matrix) {
-      newMatrix.preConcat(*pictureImage->matrix);
+    if (brush.nothingToDraw()) {
+      return;
     }
-    drawPicture(pictureImage->picture, newMatrix, clip);
+    // SVG has no single attribute that applies "per-element alpha multiply" to a playback stream.
+    // Classify the brush into three buckets so playback can still preserve vector output whenever
+    // possible:
+    //   identity        -> replay directly (current behavior)
+    //   alpha-only < 1  -> wrap in <g opacity=...> then replay
+    //   anything else   -> rasterize the picture image and route through exportPixmap so the
+    //                      brush (shader/colorFilter/maskFilter/blendMode) is fully honored
+    bool brushIsIdentityExceptAlpha = brush.shader == nullptr && brush.maskFilter == nullptr &&
+                                      brush.colorFilter == nullptr &&
+                                      brush.blendMode == BlendMode::SrcOver;
+    if (brushIsIdentityExceptAlpha) {
+      const auto pictureImage = static_cast<const PictureImage*>(image.get());
+      auto newMatrix = matrix;
+      if (pictureImage->matrix) {
+        newMatrix.preConcat(*pictureImage->matrix);
+      }
+      if (brush.color.alpha < 1.0f) {
+        // Close any active clip group so the <g opacity> wraps at the right parent level.
+        // Clear the members on exit so subsequent applyClipPath rebuilds the clip group
+        // instead of short-circuiting on a matching currentClipPath.
+        clipGroupElement = nullptr;
+        currentClipPath = {};
+        {
+          ElementWriter opacityGroup("g", xmlWriter, resourceBucket.get());
+          opacityGroup.addAttribute("opacity", brush.color.alpha);
+          drawPicture(pictureImage->picture, newMatrix, clip);
+        }
+        clipGroupElement = nullptr;
+        currentClipPath = {};
+      } else {
+        drawPicture(pictureImage->picture, newMatrix, clip);
+      }
+      return;
+    }
+    auto modifyImage = ConvertImageColorSpace(image, context, _targetColorSpace, _assignColorSpace);
+    Bitmap bitmap = ImageExportToBitmap(context, modifyImage);
+    if (!bitmap.isEmpty()) {
+      exportPixmap(Pixmap(bitmap), matrix, brush);
+    }
   } else if (type == Types::ImageType::Filter) {
     const auto filterImage = static_cast<const FilterImage*>(image.get());
     auto filter = filterImage->filter;

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -188,16 +188,19 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     std::string filterUrl;
     if (canVectorize && brush.colorFilter) {
       auto colorFilterType = Types::Get(brush.colorFilter.get());
-      if (colorFilterType != Types::ColorFilterType::Blend &&
-          colorFilterType != Types::ColorFilterType::Matrix) {
+      // Blend ColorFilter is only expressible when its blend mode has an SVG mapping; checking
+      // before opening <defs> avoids an empty <defs></defs> when addColorFilterResource bails out.
+      bool expressible =
+          colorFilterType == Types::ColorFilterType::Matrix ||
+          (colorFilterType == Types::ColorFilterType::Blend &&
+           !ToSVGBlendMode(static_cast<const ModeColorFilter*>(brush.colorFilter.get())->mode)
+                .empty());
+      if (!expressible) {
         canVectorize = false;
       } else {
         ElementWriter defs("defs", xmlWriter, resourceBucket.get(), _targetColorSpace,
                            _assignColorSpace);
         filterUrl = defs.addColorFilterResource(brush.colorFilter).filter;
-        if (filterUrl.empty()) {
-          canVectorize = false;
-        }
       }
     }
     if (canVectorize) {

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -53,16 +53,6 @@
 
 namespace tgfx {
 
-namespace {
-// Returns true when the brush carries no effect that requires compositing, so a draw can be
-// emitted as SVG vector elements instead of being rasterized. Only the alpha channel of the
-// brush color can be honored in this mode by wrapping the output in a <g opacity="..."> group.
-bool CanExportAsVector(const Brush& brush) {
-  return brush.shader == nullptr && brush.maskFilter == nullptr && brush.colorFilter == nullptr &&
-         brush.blendMode == BlendMode::SrcOver;
-}
-}  // namespace
-
 SVGExportContext::SVGExportContext(Context* context, const Rect& viewBox,
                                    std::unique_ptr<XMLWriter> inputXmlWriter, uint32_t exportFlags,
                                    std::shared_ptr<SVGCustomWriter> customWriter,
@@ -181,43 +171,37 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     if (brush.nothingToDraw()) {
       return;
     }
-    // Honor non-identity brushes on PictureImage: alpha-only goes through <g opacity>
-    // to preserve vectors; any shader/filter/blend forces rasterization via exportPixmap.
-    if (CanExportAsVector(brush)) {
+    // Keep PictureImage vectorized when the brush only carries effects SVG <g> can express:
+    // alpha as opacity, Blend/Matrix colorFilter as a <filter> resource, and a separable blend
+    // mode as mix-blend-mode. Anything else (shader, maskFilter, Porter-Duff blend without an
+    // SVG mapping, or unsupported colorFilter subtype) rasterizes.
+    bool canVectorize = brush.shader == nullptr && brush.maskFilter == nullptr;
+    std::string blendModeStyle;
+    if (canVectorize && brush.blendMode != BlendMode::SrcOver) {
+      auto svgBlendMode = ToSVGBlendMode(brush.blendMode);
+      if (svgBlendMode.empty() || svgBlendMode == "normal") {
+        canVectorize = false;
+      } else {
+        blendModeStyle = "mix-blend-mode:" + svgBlendMode;
+      }
+    }
+    std::string filterUrl;
+    if (canVectorize && brush.colorFilter) {
+      ElementWriter defs("defs", xmlWriter, resourceBucket.get(), _targetColorSpace,
+                         _assignColorSpace);
+      filterUrl = defs.addColorFilterResource(brush.colorFilter).filter;
+      if (filterUrl.empty()) {
+        canVectorize = false;
+      }
+    }
+    if (canVectorize) {
       const auto pictureImage = static_cast<const PictureImage*>(image.get());
       auto newMatrix = matrix;
       if (pictureImage->matrix) {
         newMatrix.preConcat(*pictureImage->matrix);
       }
-      if (brush.color.alpha == 1.0f) {
-        drawPicture(pictureImage->picture, newMatrix, clip);
-        return;
-      }
-      // Lift the outer clip to a single <g clip-path> wrapper around <g opacity> so nested
-      // playback ops do not redefine identical clipPath resources. See drawLayer for the same
-      // structure. Inside the opacity group the clip stack is cleared, letting internal draws
-      // rebuild clips only when the picture itself introduces new ones.
-      auto clipPath = clip.getClipPath();
-      auto bound = newMatrix.mapRect(pictureImage->picture->getBounds());
-      bool needsClip = !clipPath.isEmpty() && !clipPath.contains(bound);
-      std::string clipID;
-      if (needsClip) {
-        clipID = defineClipPath(clipPath);
-      }
-      clipGroupElement = nullptr;
-      currentClipPath = {};
-      {
-        std::unique_ptr<ElementWriter> clipElement;
-        if (needsClip) {
-          clipElement = std::make_unique<ElementWriter>("g", xmlWriter, resourceBucket.get());
-          clipElement->addAttribute("clip-path", "url(#" + clipID + ")");
-        }
-        ElementWriter opacityGroup("g", xmlWriter, resourceBucket.get());
-        opacityGroup.addAttribute("opacity", brush.color.alpha);
-        drawPicture(pictureImage->picture, newMatrix, needsClip ? ClipStack{} : clip);
-      }
-      clipGroupElement = nullptr;
-      currentClipPath = {};
+      exportPictureImageAsVector(pictureImage, newMatrix, clip, filterUrl, blendModeStyle,
+                                 brush.color.alpha);
       return;
     }
     auto modifyImage = ConvertImageColorSpace(image, context, _targetColorSpace, _assignColorSpace);
@@ -449,6 +433,48 @@ void SVGExportContext::drawPicture(std::shared_ptr<Picture> picture, const Matri
                                    const ClipStack& clip) {
   DEBUG_ASSERT(picture != nullptr);
   picture->playback(this, matrix, clip);
+}
+
+void SVGExportContext::exportPictureImageAsVector(const PictureImage* pictureImage,
+                                                  const Matrix& matrix, const ClipStack& clip,
+                                                  const std::string& filterUrl,
+                                                  const std::string& blendModeStyle, float alpha) {
+  // Skip the wrapper when there is nothing to attach to it.
+  if (filterUrl.empty() && blendModeStyle.empty() && alpha == 1.0f) {
+    drawPicture(pictureImage->picture, matrix, clip);
+    return;
+  }
+  // Lift the outer clip to a single <g clip-path> wrapping the brush group so nested playback
+  // ops do not redefine identical clipPath resources. See drawLayer for the same pattern.
+  auto clipPath = clip.getClipPath();
+  auto bound = matrix.mapRect(pictureImage->picture->getBounds());
+  bool needsClip = !clipPath.isEmpty() && !clipPath.contains(bound);
+  std::string clipID;
+  if (needsClip) {
+    clipID = defineClipPath(clipPath);
+  }
+  clipGroupElement = nullptr;
+  currentClipPath = {};
+  {
+    std::unique_ptr<ElementWriter> clipElement;
+    if (needsClip) {
+      clipElement = std::make_unique<ElementWriter>("g", xmlWriter, resourceBucket.get());
+      clipElement->addAttribute("clip-path", "url(#" + clipID + ")");
+    }
+    ElementWriter brushGroup("g", xmlWriter, resourceBucket.get());
+    if (!filterUrl.empty()) {
+      brushGroup.addAttribute("filter", filterUrl);
+    }
+    if (!blendModeStyle.empty()) {
+      brushGroup.addAttribute("style", blendModeStyle);
+    }
+    if (alpha != 1.0f) {
+      brushGroup.addAttribute("opacity", alpha);
+    }
+    drawPicture(pictureImage->picture, matrix, needsClip ? ClipStack{} : clip);
+  }
+  clipGroupElement = nullptr;
+  currentClipPath = {};
 }
 
 void SVGExportContext::drawLayer(std::shared_ptr<Picture> picture,

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -174,8 +174,7 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     // Honor non-identity brushes on PictureImage: alpha-only goes through <g opacity>
     // to preserve vectors; any shader/filter/blend forces rasterization via exportPixmap.
     bool canExportAsVector = brush.shader == nullptr && brush.maskFilter == nullptr &&
-                             brush.colorFilter == nullptr &&
-                             brush.blendMode == BlendMode::SrcOver;
+                             brush.colorFilter == nullptr && brush.blendMode == BlendMode::SrcOver;
     if (canExportAsVector) {
       const auto pictureImage = static_cast<const PictureImage*>(image.get());
       auto newMatrix = matrix;

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -182,7 +182,7 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
       if (svgBlendMode.empty() || svgBlendMode == "normal") {
         canVectorize = false;
       } else {
-        blendModeStyle = "mix-blend-mode:" + svgBlendMode;
+        blendModeStyle = "mix-blend-mode: " + svgBlendMode;
       }
     }
     std::string filterUrl;
@@ -207,6 +207,7 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     auto modifyImage = ConvertImageColorSpace(image, context, _targetColorSpace, _assignColorSpace);
     Bitmap bitmap = ImageExportToBitmap(context, modifyImage);
     if (!bitmap.isEmpty()) {
+      applyClip(clip, matrix.mapRect(Rect::MakeWH(image->width(), image->height())));
       exportPixmap(Pixmap(bitmap), matrix, brush);
     }
   } else if (type == Types::ImageType::Filter) {
@@ -453,9 +454,9 @@ void SVGExportContext::exportPictureImageAsVector(const PictureImage* pictureIma
   if (needsClip) {
     clipID = defineClipPath(clipPath);
   }
-  clipGroupElement = nullptr;
-  currentClipPath = {};
   {
+    clipGroupElement = nullptr;
+    currentClipPath = {};
     std::unique_ptr<ElementWriter> clipElement;
     if (needsClip) {
       clipElement = std::make_unique<ElementWriter>("g", xmlWriter, resourceBucket.get());
@@ -472,9 +473,9 @@ void SVGExportContext::exportPictureImageAsVector(const PictureImage* pictureIma
       brushGroup.addAttribute("opacity", alpha);
     }
     drawPicture(pictureImage->picture, matrix, needsClip ? ClipStack{} : clip);
+    clipGroupElement = nullptr;
+    currentClipPath = {};
   }
-  clipGroupElement = nullptr;
-  currentClipPath = {};
 }
 
 void SVGExportContext::drawLayer(std::shared_ptr<Picture> picture,

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -187,11 +187,17 @@ void SVGExportContext::drawImage(std::shared_ptr<Image> image, const SamplingOpt
     }
     std::string filterUrl;
     if (canVectorize && brush.colorFilter) {
-      ElementWriter defs("defs", xmlWriter, resourceBucket.get(), _targetColorSpace,
-                         _assignColorSpace);
-      filterUrl = defs.addColorFilterResource(brush.colorFilter).filter;
-      if (filterUrl.empty()) {
+      auto colorFilterType = Types::Get(brush.colorFilter.get());
+      if (colorFilterType != Types::ColorFilterType::Blend &&
+          colorFilterType != Types::ColorFilterType::Matrix) {
         canVectorize = false;
+      } else {
+        ElementWriter defs("defs", xmlWriter, resourceBucket.get(), _targetColorSpace,
+                           _assignColorSpace);
+        filterUrl = defs.addColorFilterResource(brush.colorFilter).filter;
+        if (filterUrl.empty()) {
+          canVectorize = false;
+        }
       }
     }
     if (canVectorize) {

--- a/src/svg/SVGExportContext.h
+++ b/src/svg/SVGExportContext.h
@@ -38,6 +38,7 @@ namespace tgfx {
 class ResourceStore;
 class ElementWriter;
 class PictureImage;
+class ColorFilter;
 
 class SVGExportContext : public DrawContext {
  public:
@@ -110,12 +111,16 @@ class SVGExportContext : public DrawContext {
 
   /**
    * Replays a PictureImage as SVG vector elements, wrapped in a single <g> carrying any
-   * non-empty filterUrl, any non-empty blendModeStyle (as a CSS mix-blend-mode), and any
-   * alpha < 1. All three empty/identity skip the corresponding attributes; the wrapper is
-   * elided when none apply.
+   * colorFilter as a <filter> resource, any non-empty blendModeStyle (as a CSS mix-blend-mode),
+   * and any alpha < 1. All three empty/identity skip the corresponding attributes; the wrapper
+   * is elided when none apply. The colorFilter must be one of the SVG-expressible types (Matrix
+   * or Blend with a mappable BlendMode); the caller is responsible for filtering out the rest.
+   * The associated <defs>/<filter> is emitted from inside this function, AFTER the active clip
+   * group is closed, so it is placed at the same level as the brush <g> that consumes it.
    */
   void exportPictureImageAsVector(const PictureImage* pictureImage, const Matrix& matrix,
-                                  const ClipStack& clip, const std::string& filterUrl,
+                                  const ClipStack& clip,
+                                  const std::shared_ptr<ColorFilter>& colorFilter,
                                   const std::string& blendModeStyle, float alpha);
 
   void exportGlyphRunAsPath(const GlyphRun& glyphRun, const Matrix& matrix, const Brush& brush,

--- a/src/svg/SVGExportContext.h
+++ b/src/svg/SVGExportContext.h
@@ -37,6 +37,7 @@ namespace tgfx {
 
 class ResourceStore;
 class ElementWriter;
+class PictureImage;
 
 class SVGExportContext : public DrawContext {
  public:
@@ -106,6 +107,16 @@ class SVGExportContext : public DrawContext {
   static bool RequiresViewportReset(const Brush& brush);
 
   void exportPixmap(const Pixmap& pixmap, const Matrix& matrix, const Brush& brush);
+
+  /**
+   * Replays a PictureImage as SVG vector elements, wrapped in a single <g> carrying any
+   * non-empty filterUrl, any non-empty blendModeStyle (as a CSS mix-blend-mode), and any
+   * alpha < 1. All three empty/identity skip the corresponding attributes; the wrapper is
+   * elided when none apply.
+   */
+  void exportPictureImageAsVector(const PictureImage* pictureImage, const Matrix& matrix,
+                                  const ClipStack& clip, const std::string& filterUrl,
+                                  const std::string& blendModeStyle, float alpha);
 
   void exportGlyphRunAsPath(const GlyphRun& glyphRun, const Matrix& matrix, const Brush& brush,
                             const Stroke* stroke);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -474,9 +474,11 @@
         "DstColorSpace": "0d4409dd",
         "ImageMask": "f8344be7",
         "InvertPictureImageMask": "9a80633b",
-        "LayerDropShadow": "a99262da",
+        "LayerDropShadow": "743efde6",
         "LayerMaskBlur": "cd3ccd97b",
-        "PictureImageMask": "9a80633b"
+        "PictureImageMask": "9a80633b",
+        "PictureImageWithAlpha": "743efde6",
+        "PictureImageWithColorFilter": "743efde6"
     },
     "SVGTest": {
         "blur": "b1db872",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -479,7 +479,8 @@
         "PictureImageMask": "9a80633b",
         "PictureImageWithAlpha": "743efde6",
         "PictureImageWithAlphaAndClip": "a7a1cbb4",
-        "PictureImageWithColorFilter": "743efde6"
+        "PictureImageWithBlendMode": "3b02a134",
+        "PictureImageWithColorFilter": "3b02a134"
     },
     "SVGTest": {
         "blur": "b1db872",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -478,6 +478,7 @@
         "LayerMaskBlur": "9a253385",
         "PictureImageMask": "9a80633b",
         "PictureImageWithAlpha": "743efde6",
+        "PictureImageWithAlphaAndClip": "a7a1cbb4",
         "PictureImageWithColorFilter": "743efde6"
     },
     "SVGTest": {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -475,7 +475,7 @@
         "ImageMask": "f8344be7",
         "InvertPictureImageMask": "9a80633b",
         "LayerDropShadow": "743efde6",
-        "LayerMaskBlur": "cd3ccd97b",
+        "LayerMaskBlur": "9a253385",
         "PictureImageMask": "9a80633b",
         "PictureImageWithAlpha": "743efde6",
         "PictureImageWithColorFilter": "743efde6"

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -23,6 +23,7 @@
 #include "gtest/gtest.h"
 #include "tgfx/core/Buffer.h"
 #include "tgfx/core/Color.h"
+#include "tgfx/core/ColorFilter.h"
 #include "tgfx/core/Matrix.h"
 #include "tgfx/core/Paint.h"
 #include "tgfx/core/Path.h"
@@ -974,6 +975,81 @@ TGFX_TEST(SVGExportTest, ClipWithMatrixTransform) {
   exporter->close();
 
   EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/ClipWithMatrixTransform"));
+}
+
+TGFX_TEST(SVGExportTest, PictureImageWithAlpha) {
+  // Covers the alpha-only branch of SVGExportContext::drawImage for PictureImage: when a
+  // PictureImage is drawn with paint.alpha < 1 and no shader/mask/color filter, the exporter
+  // should wrap the playback in a <g opacity="..."> while preserving vector output inside.
+
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+
+  auto SVGStream = MemoryWriteStream::Make();
+  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200));
+  auto canvas = exporter->getCanvas();
+
+  PictureRecorder recorder;
+  auto pictureCanvas = recorder.beginRecording();
+  {
+    Paint redPaint;
+    redPaint.setColor(Color::Red());
+    pictureCanvas->drawRect(Rect::MakeWH(100, 100), redPaint);
+
+    Paint bluePaint;
+    bluePaint.setColor(Color::Blue());
+    pictureCanvas->drawCircle(65, 65, 35, bluePaint);
+  }
+  auto picture = recorder.finishRecordingAsPicture();
+  ASSERT_TRUE(picture != nullptr);
+  auto image = Image::MakeFrom(picture, 100, 100);
+  ASSERT_TRUE(image != nullptr);
+
+  Paint paint;
+  paint.setAlpha(0.5f);
+  canvas->drawImage(image, 50, 50, &paint);
+
+  exporter->close();
+  EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/PictureImageWithAlpha"));
+}
+
+TGFX_TEST(SVGExportTest, PictureImageWithColorFilter) {
+  // Covers the rasterization branch of SVGExportContext::drawImage for PictureImage: when the
+  // brush carries a non-identity effect (here a ColorFilter), the exporter must fall back to
+  // rasterizing the picture image so the effect is fully honored. The resulting SVG should
+  // embed the content as an <image> rather than replaying the picture as vectors.
+
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+
+  auto SVGStream = MemoryWriteStream::Make();
+  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200));
+  auto canvas = exporter->getCanvas();
+
+  PictureRecorder recorder;
+  auto pictureCanvas = recorder.beginRecording();
+  {
+    Paint redPaint;
+    redPaint.setColor(Color::Red());
+    pictureCanvas->drawRect(Rect::MakeWH(100, 100), redPaint);
+
+    Paint bluePaint;
+    bluePaint.setColor(Color::Blue());
+    pictureCanvas->drawCircle(65, 65, 35, bluePaint);
+  }
+  auto picture = recorder.finishRecordingAsPicture();
+  ASSERT_TRUE(picture != nullptr);
+  auto image = Image::MakeFrom(picture, 100, 100);
+  ASSERT_TRUE(image != nullptr);
+
+  Paint paint;
+  paint.setColorFilter(ColorFilter::Blend(Color::White(), BlendMode::Difference));
+  canvas->drawImage(image, 50, 50, &paint);
+
+  exporter->close();
+  EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/PictureImageWithColorFilter"));
 }
 
 /**

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -1052,6 +1052,51 @@ TGFX_TEST(SVGExportTest, PictureImageWithColorFilter) {
   EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/PictureImageWithColorFilter"));
 }
 
+TGFX_TEST(SVGExportTest, PictureImageWithAlphaAndClip) {
+  // Covers the alpha-only branch of SVGExportContext::drawImage for PictureImage under an
+  // active outer clip. The exporter must close the outer clip group before opening the
+  // <g opacity="..."> wrapper and let nested playback ops rebuild their own clip groups
+  // inside it, instead of short-circuiting on a stale currentClipPath that no longer
+  // corresponds to the current parent element.
+
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+
+  auto SVGStream = MemoryWriteStream::Make();
+  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200));
+  auto canvas = exporter->getCanvas();
+
+  Paint backgroundPaint;
+  backgroundPaint.setColor(Color::White());
+  canvas->drawRect(Rect::MakeWH(200, 200), backgroundPaint);
+
+  PictureRecorder recorder;
+  auto pictureCanvas = recorder.beginRecording();
+  {
+    Paint redPaint;
+    redPaint.setColor(Color::Red());
+    pictureCanvas->drawRect(Rect::MakeWH(100, 100), redPaint);
+
+    Paint bluePaint;
+    bluePaint.setColor(Color::Blue());
+    pictureCanvas->drawCircle(65, 65, 35, bluePaint);
+  }
+  auto picture = recorder.finishRecordingAsPicture();
+  auto image = Image::MakeFrom(picture, 100, 100);
+
+  canvas->save();
+  canvas->clipRect(Rect::MakeXYWH(70, 70, 100, 100));
+
+  Paint paint;
+  paint.setAlpha(0.5f);
+  canvas->drawImage(image, 50, 50, &paint);
+  canvas->restore();
+
+  exporter->close();
+  EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/PictureImageWithAlphaAndClip"));
+}
+
 /**
  * Complex RRect (per-corner different radii) cannot be represented by SVG <rect> because
  * <rect> only supports uniform rx/ry. Verify the exporter falls back to <path>.

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -1015,10 +1015,9 @@ TGFX_TEST(SVGExportTest, PictureImageWithAlpha) {
 }
 
 TGFX_TEST(SVGExportTest, PictureImageWithColorFilter) {
-  // Covers the rasterization branch of SVGExportContext::drawImage for PictureImage: when the
-  // brush carries a non-identity effect (here a ColorFilter), the exporter must fall back to
-  // rasterizing the picture image so the effect is fully honored. The resulting SVG should
-  // embed the content as an <image> rather than replaying the picture as vectors.
+  // Covers the colorFilter-only branch of SVGExportContext::drawImage for PictureImage:
+  // when the brush carries a Blend or Matrix ColorFilter, the exporter should emit a
+  // <g filter="url(...)"> wrapping a vector replay of the picture, not a rasterized image.
 
   ContextScope scope;
   auto context = scope.getContext();
@@ -1050,6 +1049,47 @@ TGFX_TEST(SVGExportTest, PictureImageWithColorFilter) {
 
   exporter->close();
   EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/PictureImageWithColorFilter"));
+}
+
+TGFX_TEST(SVGExportTest, PictureImageWithBlendMode) {
+  // Covers the blend-mode branch of SVGExportContext::drawImage for PictureImage: when the
+  // brush carries a separable blend mode (Multiply here), the exporter should wrap the
+  // vector replay in a <g style="mix-blend-mode: ..."> rather than rasterizing.
+
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+
+  auto SVGStream = MemoryWriteStream::Make();
+  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(200, 200));
+  auto canvas = exporter->getCanvas();
+
+  Paint backgroundPaint;
+  backgroundPaint.setColor(Color::FromRGBA(255, 200, 0));
+  canvas->drawRect(Rect::MakeWH(200, 200), backgroundPaint);
+
+  PictureRecorder recorder;
+  auto pictureCanvas = recorder.beginRecording();
+  {
+    Paint redPaint;
+    redPaint.setColor(Color::Red());
+    pictureCanvas->drawRect(Rect::MakeWH(100, 100), redPaint);
+
+    Paint bluePaint;
+    bluePaint.setColor(Color::Blue());
+    pictureCanvas->drawCircle(65, 65, 35, bluePaint);
+  }
+  auto picture = recorder.finishRecordingAsPicture();
+  ASSERT_TRUE(picture != nullptr);
+  auto image = Image::MakeFrom(picture, 100, 100);
+  ASSERT_TRUE(image != nullptr);
+
+  Paint paint;
+  paint.setBlendMode(BlendMode::Multiply);
+  canvas->drawImage(image, 50, 50, &paint);
+
+  exporter->close();
+  EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/PictureImageWithBlendMode"));
 }
 
 TGFX_TEST(SVGExportTest, PictureImageWithAlphaAndClip) {

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -1123,7 +1123,9 @@ TGFX_TEST(SVGExportTest, PictureImageWithAlphaAndClip) {
     pictureCanvas->drawCircle(65, 65, 35, bluePaint);
   }
   auto picture = recorder.finishRecordingAsPicture();
+  ASSERT_TRUE(picture != nullptr);
   auto image = Image::MakeFrom(picture, 100, 100);
+  ASSERT_TRUE(image != nullptr);
 
   canvas->save();
   canvas->clipRect(Rect::MakeXYWH(70, 70, 100, 100));


### PR DESCRIPTION
问题
`SVGExportContext::drawImage` 的 PictureImage 分支直接 playback，完全丢弃了外层 brush。用户对 picture image 调用 `canvas->drawImage(img, x, y, &paint)` 时，paint 的 alpha / shader / colorFilter / maskFilter / blendMode 都不会应用到导出的 SVG 上。

修复
按 brush 携带的效果是否能用 SVG `<g>` 群组属性表达来分档，优先保矢量：

- `brush.nothingToDraw()`：直接 return
- shader / maskFilter：SVG 没有等价的群组属性 → 栅格化
- 非 SrcOver blendMode：有 SVG 映射（Multiply / Screen / Difference 等可分离 blend）→ 加 `style="mix-blend-mode:..."` 矢量化；Porter-Duff 类无映射 → 栅格化
- colorFilter：Blend / Matrix 类型 → 生成 `<filter>` 资源 + `<g filter="url(...)">` 矢量化；其他类型（Luma / AlphaThreshold / Compose）→ 栅格化
- alpha < 1：在群组 `<g>` 上加 `opacity` 属性

可矢量化的属性可以叠加挂在同一个 `<g>` 上。栅格化路径走 `ImageExportToBitmap` + `exportPixmap`。

测试
- `PictureImageWithAlpha`：alpha-only，验证 `<g opacity>` 且内部保矢量
- `PictureImageWithAlphaAndClip`：alpha + 外部 clip，验证 clip 状态正确清理、`<g clip-path>` 提到 `<g opacity>` 之外
- `PictureImageWithColorFilter`：Blend ColorFilter，验证 `<defs><filter>` + `<g filter=>` 包裹矢量回放
- `PictureImageWithBlendMode`：Multiply blendMode，验证 `<g style="mix-blend-mode:multiply">` 与背景合成