### PR TITLE
Fix SVG export wrongly clipping short-circuited draws under a stale clip group.

### DIFF
--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -556,8 +556,9 @@ void SVGExportContext::applyClip(const ClipStack& clip, const Rect& contentBound
   // Per-element anti-alias info is lost; the merged path's AA is left to the SVG renderer.
   auto clipPath = clip.getClipPath();
   if (clipPath.contains(contentBound)) {
-    // Close any stale <g clip-path> wrapper from a previous draw so this draw is not
-    // wrongly clipped by a different clip path.
+    // No clip needed for this draw, but a previous draw may have left a <g clip-path>
+    // wrapper open. Only close it when the active wrapper's clip differs from ours;
+    // matching wrappers are kept so consecutive same-clip draws keep sharing one group.
     if (clipPath != currentClipPath) {
       clipGroupElement = nullptr;
       currentClipPath = {};

--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -556,6 +556,12 @@ void SVGExportContext::applyClip(const ClipStack& clip, const Rect& contentBound
   // Per-element anti-alias info is lost; the merged path's AA is left to the SVG renderer.
   auto clipPath = clip.getClipPath();
   if (clipPath.contains(contentBound)) {
+    // Close any stale <g clip-path> wrapper from a previous draw so this draw is not
+    // wrongly clipped by a different clip path.
+    if (clipPath != currentClipPath) {
+      clipGroupElement = nullptr;
+      currentClipPath = {};
+    }
     return;
   }
   applyClipPath(clipPath);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -470,7 +470,7 @@
     },
     "SVGExportTest": {
         "AssignColorSpace": "0d4409dd",
-        "ClipShortCircuitWithStaleGroup": "906401c2",
+        "ClipShortCircuitWithStaleGroup": "28f84e48",
         "ClipWithMatrixTransform": "082ec7b6b",
         "DrawImageRect": "f8344be7",
         "DstAssignColorSpace": "0d4409dd",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -470,6 +470,7 @@
     },
     "SVGExportTest": {
         "AssignColorSpace": "0d4409dd",
+        "ClipShortCircuitWithStaleGroup": "906401c2",
         "ClipWithMatrixTransform": "082ec7b6b",
         "DrawImageRect": "f8344be7",
         "DstAssignColorSpace": "0d4409dd",

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -1171,16 +1171,20 @@ TGFX_TEST(SVGExportTest, ComplexRRect) {
  * gets short-circuited (no clip emitted), but is then incorrectly written into
  * a stale <g clip-path> wrapper opened by a previous draw with a different,
  * smaller clip. Sequence:
- *   1. Outer clipRect(0,0,300,300)  - big enough to contain all draws
+ *   1. Outer clipRect(0,0,300,300)  - must stay a convex rect so that
+ *                                     conservativelyContainsRect returns true
+ *                                     for steps 3/4 and triggers the
+ *                                     short-circuit.
  *   2. Inner clipRect(0,0,100,100)  - small clip
  *      drawRect(0,0,200,200)         -> escapes the small clip, opens
  *                                       <g clip-path="url(#clip_0)">
  *      restore()                      -> pops the inner clip
  *   3. drawRect(150,150,100,100)     -> bounds fully inside the outer clip,
  *                                       so applyClip short-circuits and the
- *                                       rect ends up inside the still-open
- *                                       <g clip-path="url(#clip_0)">, which
- *                                       wrongly clips it away.
+ *                                       rect must not stay inside the still-
+ *                                       open <g clip-path="url(#clip_0)">.
+ *   4. drawPath bounds (180,180,100,100) covers the real-world failure shape:
+ *      a <path> draw must escape the stale group on the same code path.
  */
 TGFX_TEST(SVGExportTest, ClipShortCircuitWithStaleGroup) {
   ContextScope scope;
@@ -1194,6 +1198,7 @@ TGFX_TEST(SVGExportTest, ClipShortCircuitWithStaleGroup) {
   canvas->save();
   canvas->clipRect(Rect::MakeXYWH(0, 0, 300, 300));
 
+  // First draw escapes the small clip and opens a <g clip-path> wrapper.
   Paint redPaint;
   redPaint.setColor(Color::Red());
   canvas->save();
@@ -1201,9 +1206,24 @@ TGFX_TEST(SVGExportTest, ClipShortCircuitWithStaleGroup) {
   canvas->drawRect(Rect::MakeXYWH(0, 0, 200, 200), redPaint);
   canvas->restore();
 
+  // Second draw (rect) is fully inside the outer clip - short-circuits and must
+  // NOT inherit the small clip group.
   Paint bluePaint;
   bluePaint.setColor(Color::Blue());
   canvas->drawRect(Rect::MakeXYWH(150, 150, 100, 100), bluePaint);
+
+  // Third draw (path) reproduces the real-world failure shape: a path whose
+  // bounds lie fully inside the outer clip must also escape the stale group.
+  // Use a triangle so Canvas cannot forward to drawRect/drawRRect; this
+  // exercises SVGExportContext::drawPath directly and emits a <path>.
+  Paint greenPaint;
+  greenPaint.setColor(Color::Green());
+  Path path;
+  path.moveTo(180, 280);
+  path.lineTo(230, 180);
+  path.lineTo(280, 280);
+  path.close();
+  canvas->drawPath(path, greenPaint);
 
   canvas->restore();
 

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -1165,4 +1165,49 @@ TGFX_TEST(SVGExportTest, ComplexRRect) {
   ASSERT_NE(SVGString.find("<path"), std::string::npos);
   ASSERT_EQ(SVGString.find("<rect"), std::string::npos);
 }
+
+/**
+ * Reproduces a bug where a draw whose bounds lie fully inside an outer clip
+ * gets short-circuited (no clip emitted), but is then incorrectly written into
+ * a stale <g clip-path> wrapper opened by a previous draw with a different,
+ * smaller clip. Sequence:
+ *   1. Outer clipRect(0,0,300,300)  - big enough to contain all draws
+ *   2. Inner clipRect(0,0,100,100)  - small clip
+ *      drawRect(0,0,200,200)         -> escapes the small clip, opens
+ *                                       <g clip-path="url(#clip_0)">
+ *      restore()                      -> pops the inner clip
+ *   3. drawRect(150,150,100,100)     -> bounds fully inside the outer clip,
+ *                                       so applyClip short-circuits and the
+ *                                       rect ends up inside the still-open
+ *                                       <g clip-path="url(#clip_0)">, which
+ *                                       wrongly clips it away.
+ */
+TGFX_TEST(SVGExportTest, ClipShortCircuitWithStaleGroup) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+
+  auto SVGStream = MemoryWriteStream::Make();
+  auto exporter = SVGExporter::Make(SVGStream, context, Rect::MakeWH(300, 300));
+  auto canvas = exporter->getCanvas();
+
+  canvas->save();
+  canvas->clipRect(Rect::MakeXYWH(0, 0, 300, 300));
+
+  Paint redPaint;
+  redPaint.setColor(Color::Red());
+  canvas->save();
+  canvas->clipRect(Rect::MakeXYWH(0, 0, 100, 100));
+  canvas->drawRect(Rect::MakeXYWH(0, 0, 200, 200), redPaint);
+  canvas->restore();
+
+  Paint bluePaint;
+  bluePaint.setColor(Color::Blue());
+  canvas->drawRect(Rect::MakeXYWH(150, 150, 100, 100), bluePaint);
+
+  canvas->restore();
+
+  exporter->close();
+  EXPECT_TRUE(CompareSVG(SVGStream, "SVGExportTest/ClipShortCircuitWithStaleGroup"));
+}
 }  // namespace tgfx


### PR DESCRIPTION
背景
SVGExportContext::applyClip 在判定当前图元的 bounds 完全落在裁剪区域内时，会触发短路返回，跳过 <clipPath> 与 <g clip-path> 的写出，以减小 SVG 体积。

问题
短路分支只是直接 return，没有同步 currentClipPath 与 clipGroupElement 状态。当前一笔绘制留下了一个 <g clip-path> 包裹器、且当前图元的 clip 与那个包裹器的 clip 不一致时，被短路的图元会被错误地写入这个陈旧的包裹器内，进而被它对应的小裁剪区裁掉，最终在导出的 SVG 中消失或被错误剪切。

修复
在 applyClip 短路分支中，当 clipPath 与 currentClipPath 不一致时，主动关闭陈旧的 <g clip-path> 包裹器并清空 currentClipPath，使图元落到正确的父级。当 clipPath 与 currentClipPath 相同时仍保留快速路径，保证连续同 clip 的图元继续共享同一个 group，不影响原有的 group 合并优化。该处理方式与 drawLayer、exportPictureImageAsVector、drawImage 的 FilterImage 分支中已有的清空模式保持一致。

测试
新增回归测试 SVGExportTest.ClipShortCircuitWithStaleGroup，覆盖三种被短路图元的场景：rect、path（三角形，以避开 Canvas 的 rect/oval 快速转发，真正走 SVGExportContext::drawPath），并通过基准比较方式断言 SVG 结构。原有 30 个 SVG 导出相关测试以及全量 472 个测试全部通过。