### PR TITLE
Open SaveFile output stream in binary mode to avoid Windows CRLF corruption of encoded images.

### DIFF
--- a/linux/src/main.cpp
+++ b/linux/src/main.cpp
@@ -33,7 +33,9 @@ static std::string GetRootPath() {
 static void SaveFile(std::shared_ptr<tgfx::Data> data, const std::string& output) {
   std::filesystem::path path = output;
   std::filesystem::create_directories(path.parent_path());
-  std::ofstream out(path);
+  // Open in binary mode; otherwise on Windows '\n' (0x0A) bytes inside the binary payload would
+  // be expanded to "\r\n" (0x0D 0x0A), corrupting encoded image data such as WebP.
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
   out.write(reinterpret_cast<const char*>(data->data()),
             static_cast<std::streamsize>(data->size()));
   out.close();

--- a/test/src/utils/TestUtils.cpp
+++ b/test/src/utils/TestUtils.cpp
@@ -61,7 +61,9 @@ std::shared_ptr<Data> ReadFile(const std::string& path) {
 void SaveFile(std::shared_ptr<Data> data, const std::string& key) {
   std::filesystem::path path = OUT_ROOT + "/" + key;
   std::filesystem::create_directories(path.parent_path());
-  std::ofstream out(path);
+  // Open in binary mode; otherwise on Windows '\n' (0x0A) bytes inside the binary payload would
+  // be expanded to "\r\n" (0x0D 0x0A), corrupting encoded image data such as WebP.
+  std::ofstream out(path, std::ios::binary | std::ios::trunc);
   out.write(reinterpret_cast<const char*>(data->data()),
             static_cast<std::streamsize>(data->size()));
   out.close();


### PR DESCRIPTION
TestUtils::SaveFile 与 linux/src/main.cpp 中的 SaveFile 都用 std::ofstream 默认的文本模式打开输出文件。在 Windows 上文本模式会将写入内容里的 \n (0x0A) 自动展开成 \r\n (0x0D 0x0A)，导致写出的二进制数据（如 WebP/JPEG/PNG 编码字节流）被破坏。

例如一份 29432 字节的 WebP 数据中包含 124 个 0x0A 字节，落盘后膨胀到 29556 字节，且二进制内容被改写，下次读取时解码器会全部失败。这正是 Windows 上截图测试输出无法被读取/复用的根因。

修复方式：在打开输出流时显式指定 std::ios::binary | std::ios::trunc，确保字节按原样写入。Baseline.cpp 中的 ofstream 写的是 JSON 文本（MD5/version），文本模式合理，未做修改。