### PR TITLE
Fix Path::addArc producing corrupted curves on MSVC due to unspecified argument evaluation order.

### DIFF
--- a/src/core/Path.cpp
+++ b/src/core/Path.cpp
@@ -481,7 +481,13 @@ void Path::addArc(const Rect& oval, float startAngle, float sweepAngle) {
   auto path = &(writableRef()->path);
   path->moveTo(iter.current());
   for (int i = 0; i < numBeziers; i++) {
-    path->cubicTo(iter.next(), iter.next(), iter.next());
+    // Bind each iter.next() to a local first; argument evaluation order is unspecified, and MSVC
+    // evaluates right-to-left while Clang/GCC go left-to-right, which would otherwise reverse the
+    // (c1, c2, end) order on Windows and produce a corrupted path.
+    auto c1 = iter.next();
+    auto c2 = iter.next();
+    auto end = iter.next();
+    path->cubicTo(c1, c2, end);
   }
 }
 


### PR DESCRIPTION
Path::addArc 中循环调用 path->cubicTo(iter.next(), iter.next(), iter.next()) 时，三次 iter.next() 通过修改内部 index 产生有副作用的引用返回值，并依赖函数实参的求值顺序保证生成 (c1, c2, end) 的正确顺序。

C++ 标准并未规定函数实参之间的求值顺序，编译器实现差异较大：Clang 与 GCC 通常从左到右求值，因而在 macOS、Linux 以及 Android 上 cubicTo 拿到的顺序是 (c1, c2, end)；MSVC 通常从右到左求值，Windows 上拿到的顺序变成 (end, c2, c1)，使得通过 addArc 构造的圆弧/椭圆 path 在所有 Windows 后端 (D3D12 / Vulkan / OpenGL) 都呈现破碎或扭曲的几何，且因为消费的是同一份错误 path，三套后端的输出完全一致。

修复方式：在循环中先把三次 iter.next() 的返回值依次拷贝到独立的局部变量（auto 推导为值类型，避免悬挂引用同一槽位），再以确定的顺序传给 cubicTo，从而消除对未指定求值顺序的依赖，使行为在所有编译器与平台上保持一致。