### PR TITLE
Fix Metal missing sampler binding after Vulkan texture binding offset.

### DIFF
--- a/src/gpu/metal/MetalShaderModule.mm
+++ b/src/gpu/metal/MetalShaderModule.mm
@@ -24,6 +24,7 @@
 #include "MetalGPU.h"
 #include "core/utils/Log.h"
 #include "gpu/ShaderCompiler.h"
+#include "gpu/UniformData.h"
 // Suppress warnings from SPIRV-Cross headers
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-conversion"
@@ -78,6 +79,16 @@ static std::string injectSampleMask(const std::string& glslCode, uint32_t consta
   return result;
 }
 
+// Map SPIR-V texture/sampler bindings to Metal texture indices (0, 1, 2, ...).
+// Vulkan-style bindings reserve 0/1 for UBOs (TEXTURE_BINDING_POINT_START = 2); Metal texture
+// slots are independent of buffer slots and are remapped at runtime by MetalRenderPipeline.
+static uint32_t toMslTextureSamplerIndex(uint32_t spvBinding) {
+  if (spvBinding >= static_cast<uint32_t>(TEXTURE_BINDING_POINT_START)) {
+    return spvBinding - static_cast<uint32_t>(TEXTURE_BINDING_POINT_START);
+  }
+  return spvBinding;
+}
+
 // Convert a SPIR-V binary to MSL source code.
 static std::string convertSPIRVToMSL(const std::vector<uint32_t>& spirvBinary, ShaderStage stage) {
   spirv_cross::Parser spvParser(spirvBinary.data(), spirvBinary.size());
@@ -119,8 +130,9 @@ static std::string convertSPIRVToMSL(const std::vector<uint32_t>& spirvBinary, S
     uint32_t spvBinding = mslCompiler.get_decoration(image.id, spv::DecorationBinding);
     uint32_t spvDescSet = mslCompiler.get_decoration(image.id, spv::DecorationDescriptorSet);
     auto key = std::make_pair(spvDescSet, spvBinding);
-    bindingMap[key].mslTexture = spvBinding;
-    bindingMap[key].mslSampler = spvBinding;
+    uint32_t mslIndex = toMslTextureSamplerIndex(spvBinding);
+    bindingMap[key].mslTexture = mslIndex;
+    bindingMap[key].mslSampler = mslIndex;
   }
 
   for (auto& [key, info] : bindingMap) {


### PR DESCRIPTION
复现方式

使用 mac/metal/Hello2D 示例即可复现

错误信息

```
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:], line 6001: error 'Draw Errors Validation
Fragment Function(main0): missing Sampler binding at index 2 for _39Smplr[0].
'
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:]:6001: failed assertion `Draw Errors Validation
Fragment Function(main0): missing Sampler binding at index 2 for _39Smplr[0].
'
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:]:6001: failed assertion `Draw Errors Validation
Fragment Function(main0): missing Sampler binding at index 2 for _39Smplr[0].
```

问题

Vulkan 后端将纹理 sampler 的 descriptor binding 从 0 起改为从 2 起（0/1 预留给 UBO）后，片段着色器在 index 2 处取样，但运行时未在该 index 绑定 sampler，触发上述断言。

原因

ShaderCompiler 在 GLSL 中写入 layout(binding=2) 符合 Vulkan 布局；MetalRenderPass 通过 MetalRenderPipeline 将逻辑 binding 2 映射到 Metal texture index 0 再 setFragmentSamplerState；但 MetalShaderModule 在 SPIR-V 转 MSL 时仍把 binding 2 原样用作 [[sampler(2)]]，与运行时绑定位置不一致。

修改

在 MetalShaderModule 中将 SPIR-V 的 texture/sampler binding（>= TEXTURE_BINDING_POINT_START）重映射为从 0 开始的 Metal texture/sampler index，与 MetalRenderPipeline 的运行时重映射对齐。UBO 的 buffer binding 0/1 不变。

是在 https://github.com/Tencent/tgfx/pull/1425 这个PR中引入的