### PR TITLE
Fix iOS 15 launch dyld crash caused by shaderc libc++ symbol reference.

### DIFF
--- a/vendor.json
+++ b/vendor.json
@@ -266,7 +266,7 @@
           "-DSHADERC_SKIP_TESTS=ON",
           "-DSHADERC_SKIP_EXAMPLES=ON",
           "-DSHADERC_SKIP_INSTALL=ON",
-          "-DCMAKE_CXX_FLAGS=\"-w -D_LIBCPP_DISABLE_AVAILABILITY\""
+          "-DCMAKE_CXX_FLAGS=\"-w\""
         ],
         "platforms": [
           "mac"
@@ -283,7 +283,7 @@
           "-DSHADERC_SKIP_TESTS=ON",
           "-DSHADERC_SKIP_EXAMPLES=ON",
           "-DSHADERC_SKIP_INSTALL=ON",
-          "-DCMAKE_CXX_FLAGS=\"-w -D_LIBCPP_DISABLE_AVAILABILITY\"",
+          "-DCMAKE_CXX_FLAGS=\"-w\"",
           "-DDEPLOYMENT_TARGET=13.0"
         ],
         "platforms": [


### PR DESCRIPTION
## 问题现象

* 偶然在iOS 15上运行时我的业务代码时发现启动时，dyld 直接崩溃，报错如下：
```
Symbol not found: __ZNSt3__122__libcpp_verbose_abortEPKcz
Referenced from: SeatCanvas.framework/SeatCanvas
Expected in: /usr/lib/libc++.1.dylib
```
* demangle 后为 `std::__1::__libcpp_verbose_abort(char const*, ...)`排查确认该符号来自 tgfx.a 中 shaderc / SPIRV 相关静态库对象，并非业务代码引入。
* 同时发现最新的提交 Metal Hello2D demo 运行报错如下
<img width="2014" height="1040" alt="image" src="https://github.com/user-attachments/assets/10c3ab6c-0c35-44da-956d-17626202885e" />

## 根因分析

* vendor.json 中 iOS 平台 shaderc 的 `CMAKE_CXX_FLAGS` 包含 `-D_LIBCPP_DISABLE_AVAILABILITY` 定位到是在 https://github.com/Tencent/tgfx/pull/1354 这次添加的 `-D_LIBCPP_DISABLE_AVAILABILITY`

* 在 Xcode 26.4 / iPhoneOS 26.4 SDK 下，Debug 构建会启用 libc++ hardening`_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG` 正常情况下，libc++ 的 availability 机制会识别 `__libcpp_verbose_abort` 在 iOS 15 上不可用，并在编译期退化为 `__builtin_abort()` 不会产生外部符号引用。

* 但 `_LIBCPP_DISABLE_AVAILABILITY` 关闭了这一保护，导致 shaderc 及其依赖（glslang、SPIRV-Tools 等）编译出的 .o 文件中包含对 `__libcpp_verbose_abort ` 的外部引用。这些对象被链入 tgfx.a 后，宿主 App 在 iOS 15 设备上加载时，系统 libc++ 中找不到该符号，dyld 在启动阶段即失败。

## 修复方案

* 从 vendor.json iOS shaderc 平台配置中移除 `-D_LIBCPP_DISABLE_AVAILABILITY`让 libc++ availability 机制正常工作

## Test plan
- [x] `./autotest.sh` 验证测试通过
- [ ] `./autotest.sh USE_METAL`  CanvasTest.PictureMaskPath 测试失败
- [x] iOS/macOS 上验证 Metal Hello2D demo 渲染正常(需临时修改下 ShaderCompiler.cpp:88 binding=0)
- [x] iOS 15 环境验证通过，App 启动不再出现 dyld 崩溃