### PR TITLE
Fix PDF transparent gradient alpha loss on SMask.

### DIFF
--- a/src/pdf/PDFExportContext.cpp
+++ b/src/pdf/PDFExportContext.cpp
@@ -779,10 +779,6 @@ std::shared_ptr<Data> PDFExportContext::getContent() {
   if (content->bytesWritten() == 0) {
     return Data::MakeEmpty();
   }
-  // Drain any pending graphic-state pushes left by the last draw. updateMatrixClip pushes a `q`
-  // whenever the incoming ClipStack changes, but no caller pops the final push, so without this
-  // drain the page content stream ends with an unmatched `q`.
-  // activeStackState.drainStack();
   auto buffer = MemoryWriteStream::Make();
   if (!_initialTransform.isIdentity()) {
     PDFUtils::AppendTransform(_initialTransform, buffer);

--- a/src/pdf/PDFExportContext.cpp
+++ b/src/pdf/PDFExportContext.cpp
@@ -779,6 +779,10 @@ std::shared_ptr<Data> PDFExportContext::getContent() {
   if (content->bytesWritten() == 0) {
     return Data::MakeEmpty();
   }
+  // Drain any pending graphic-state pushes left by the last draw. updateMatrixClip pushes a `q`
+  // whenever the incoming ClipStack changes, but no caller pops the final push, so without this
+  // drain the page content stream ends with an unmatched `q`.
+  // activeStackState.drainStack();
   auto buffer = MemoryWriteStream::Make();
   if (!_initialTransform.isIdentity()) {
     PDFUtils::AppendTransform(_initialTransform, buffer);

--- a/src/pdf/PDFGradientShader.cpp
+++ b/src/pdf/PDFGradientShader.cpp
@@ -476,7 +476,12 @@ std::shared_ptr<MemoryWriteStream> CreatePatternFillContent(int gsIndex, int pat
 PDFIndirectReference CreateSmaskGraphicState(PDFDocumentImpl* doc,
                                              const PDFGradientShader::Key& state) {
   PDFGradientShader::Key luminosityState = CloneKey(state);
+  // Encode each stop's alpha as a gray RGB triplet so the Luminosity SMask reproduces the
+  // gradient's transparency. Without this, the SMask renders pure white and the alpha is lost.
   for (auto& color : luminosityState.info.colors) {
+    color.red = color.alpha;
+    color.green = color.alpha;
+    color.blue = color.alpha;
     color.alpha = 1.0f;
   }
   luminosityState.hash = Hash(luminosityState);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -354,6 +354,7 @@
         "LayerDiamondGradient": "87b290333",
         "LayerLinearGradient": "23582ded6",
         "LayerRadialGradient": "23582ded6",
+        "LinearGradientWhiteAlpha": "7b69a2e2",
         "NonRegularBlendMode": "fb7474423",
         "SimpleText": "c13eac52",
         "SrcBlendOverlap": "fb7474423"

--- a/test/src/PDFExportTest.cpp
+++ b/test/src/PDFExportTest.cpp
@@ -631,6 +631,31 @@ TGFX_TEST(PDFExportTest, LayerLinearGradient) {
   EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/LayerLinearGradient"));
 }
 
+TGFX_TEST(PDFExportTest, LinearGradientWhiteAlpha) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+
+  auto PDFStream = MemoryWriteStream::Make();
+  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
+  auto canvas = document->beginPage(256.f, 256.f);
+  canvas->drawColor(Color::Black());
+
+  auto shader = Shader::MakeLinearGradient(
+      Point{0.f, 0.f}, Point{256.f, 0.f},
+      {Color::FromRGBA(255, 255, 255, 128), Color::FromRGBA(255, 255, 255, 26)}, {});
+
+  Paint paint;
+  paint.setShader(shader);
+  canvas->drawRect(Rect::MakeWH(256.f, 256.f), paint);
+
+  document->endPage();
+  document->close();
+  PDFStream->flush();
+
+  EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/LinearGradientWhiteAlpha"));
+}
+
 TGFX_TEST(PDFExportTest, LayerRadialGradient) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
修复 PDF 导出带透明度的线性/径向/锥形/菱形渐变时颜色错误的问题。

CreateSmaskGraphicState 构造 luminosity SMask 用的渐变副本时，只把每个 stop 的 alpha 清成 1.0，没有把原 alpha 编码进 RGB。luminosity SMask 取颜色亮度作为 alpha mask，因此 RGB 必须等于 (alpha, alpha, alpha) 才能表达透明度；否则 SMask 渲染为纯白（亮度=1），相当于完全不透明，原 alpha 信息丢失。

修复方式：将原 alpha 写入 RGB 三通道后再将 alpha 设为 1.0，luminosity 正确反映各 stop 的透明度。

新增测试 PDFExportTest.LinearGradientWhiteAlpha，覆盖 50% 到 10% 白色透明渐变叠在黑底上的导出场景。

<img width="518" height="323" alt="Clipboard_Screenshot_1779440570" src="https://github.com/user-attachments/assets/1a3fc625-170e-4f84-b8df-44aa2fbcf506" />
<img width="505" height="327" alt="Clipboard_Screenshot_1779440583" src="https://github.com/user-attachments/assets/fc2f5346-d93e-4937-b77e-0569f787a8f3" />
