### PR TITLE
Split UBO and texture into separate Vulkan descriptor sets.

### DIFF
--- a/src/gpu/ProgramInfo.cpp
+++ b/src/gpu/ProgramInfo.cpp
@@ -263,7 +263,7 @@ void ProgramInfo::setUniformsAndSamplers(RenderPass* renderPass, Program* progra
                                   fragmentOffset);
 
   auto samplers = getSamplers();
-  unsigned textureBinding = TEXTURE_BINDING_POINT_START;
+  unsigned textureBinding = 0;
   auto gpu = renderTarget->getContext()->gpu();
   for (auto& [texture, state] : samplers) {
     SamplerDescriptor descriptor(ToAddressMode(state.tileModeX), ToAddressMode(state.tileModeY),

--- a/src/gpu/ShaderCompiler.cpp
+++ b/src/gpu/ShaderCompiler.cpp
@@ -19,6 +19,7 @@
 #include "ShaderCompiler.h"
 #include <regex>
 #include <shaderc/shaderc.hpp>
+#include "UniformData.h"
 #include "core/utils/Log.h"
 
 namespace tgfx {
@@ -57,16 +58,20 @@ static std::string upgradeGLSLVersion(const std::string& source) {
 static std::string assignInternalUBOBindings(const std::string& source) {
   static std::regex vertexUboRegex(R"(layout\s*\(\s*std140\s*\)\s*uniform\s+VertexUniformBlock)");
   auto result = std::regex_replace(source, vertexUboRegex,
-                                   "layout(std140, set=0, binding=0) uniform VertexUniformBlock");
+                                   "layout(std140, set=" + std::to_string(UBO_DESCRIPTOR_SET) +
+                                       ", binding=" + std::to_string(VERTEX_UBO_BINDING_POINT) +
+                                       ") uniform VertexUniformBlock");
   static std::regex fragmentUboRegex(
       R"(layout\s*\(\s*std140\s*\)\s*uniform\s+FragmentUniformBlock)");
   return std::regex_replace(result, fragmentUboRegex,
-                            "layout(std140, set=0, binding=1) uniform FragmentUniformBlock");
+                            "layout(std140, set=" + std::to_string(UBO_DESCRIPTOR_SET) +
+                                ", binding=" + std::to_string(FRAGMENT_UBO_BINDING_POINT) +
+                                ") uniform FragmentUniformBlock");
 }
 
 static std::string replaceCustomUBO(const std::smatch& match, int& counter) {
-  return "layout(std140, set=0, binding=" + std::to_string(counter++) + ") uniform " +
-         match[1].str();
+  return "layout(std140, set=" + std::to_string(UBO_DESCRIPTOR_SET) +
+         ", binding=" + std::to_string(counter++) + ") uniform " + match[1].str();
 }
 
 // Add binding to any remaining uniform blocks (custom shaders) sequentially from 0 in set 0.
@@ -77,8 +82,9 @@ static std::string assignCustomUBOBindings(const std::string& source) {
 }
 
 static std::string replaceSamplerBinding(const std::smatch& match, int& counter) {
-  return "layout(set=1, binding=" + std::to_string(counter++) + ") uniform " + match[1].str() +
-         " " + match[2].str() + ";";
+  return "layout(set=" + std::to_string(TEXTURE_DESCRIPTOR_SET) +
+         ", binding=" + std::to_string(counter++) + ") uniform " + match[1].str() + " " +
+         match[2].str() + ";";
 }
 
 // Add binding to sampler uniforms sequentially from 0 in descriptor set 1.

--- a/src/gpu/ShaderCompiler.cpp
+++ b/src/gpu/ShaderCompiler.cpp
@@ -19,7 +19,6 @@
 #include "ShaderCompiler.h"
 #include <regex>
 #include <shaderc/shaderc.hpp>
-#include "UniformData.h"
 #include "core/utils/Log.h"
 
 namespace tgfx {
@@ -53,23 +52,24 @@ static std::string upgradeGLSLVersion(const std::string& source) {
 }
 
 // Assign fixed binding points for internal UBOs to match CPU-side constants:
-// VertexUniformBlock -> binding 0 (VERTEX_UBO_BINDING_POINT)
-// FragmentUniformBlock -> binding 1 (FRAGMENT_UBO_BINDING_POINT)
+// VertexUniformBlock -> set 0, binding 0 (VERTEX_UBO_BINDING_POINT)
+// FragmentUniformBlock -> set 0, binding 1 (FRAGMENT_UBO_BINDING_POINT)
 static std::string assignInternalUBOBindings(const std::string& source) {
   static std::regex vertexUboRegex(R"(layout\s*\(\s*std140\s*\)\s*uniform\s+VertexUniformBlock)");
   auto result = std::regex_replace(source, vertexUboRegex,
-                                   "layout(std140, binding=0) uniform VertexUniformBlock");
+                                   "layout(std140, set=0, binding=0) uniform VertexUniformBlock");
   static std::regex fragmentUboRegex(
       R"(layout\s*\(\s*std140\s*\)\s*uniform\s+FragmentUniformBlock)");
   return std::regex_replace(result, fragmentUboRegex,
-                            "layout(std140, binding=1) uniform FragmentUniformBlock");
+                            "layout(std140, set=0, binding=1) uniform FragmentUniformBlock");
 }
 
 static std::string replaceCustomUBO(const std::smatch& match, int& counter) {
-  return "layout(std140, binding=" + std::to_string(counter++) + ") uniform " + match[1].str();
+  return "layout(std140, set=0, binding=" + std::to_string(counter++) + ") uniform " +
+         match[1].str();
 }
 
-// Add binding to any remaining uniform blocks (custom shaders) sequentially from 0.
+// Add binding to any remaining uniform blocks (custom shaders) sequentially from 0 in set 0.
 static std::string assignCustomUBOBindings(const std::string& source) {
   static std::regex uboRegex(R"(layout\s*\(\s*std140\s*\)\s*uniform\s+(\w+))");
   int binding = 0;
@@ -77,15 +77,15 @@ static std::string assignCustomUBOBindings(const std::string& source) {
 }
 
 static std::string replaceSamplerBinding(const std::smatch& match, int& counter) {
-  return "layout(binding=" + std::to_string(counter++) + ") uniform " + match[1].str() + " " +
-         match[2].str() + ";";
+  return "layout(set=1, binding=" + std::to_string(counter++) + ") uniform " + match[1].str() +
+         " " + match[2].str() + ";";
 }
 
-// Add binding to sampler uniforms sequentially from TEXTURE_BINDING_POINT_START.
-// This aligns with the descriptor set layout where bindings 0 and 1 are reserved for UBOs.
+// Add binding to sampler uniforms sequentially from 0 in descriptor set 1.
+// UBOs reside in set 0, so texture bindings start fresh from 0 without collision.
 static std::string assignSamplerBindings(const std::string& source) {
   static std::regex samplerRegex(R"(uniform\s+(sampler\w+)\s+(\w+);)");
-  int binding = TEXTURE_BINDING_POINT_START;
+  int binding = 0;
   return replaceAllMatches(source, samplerRegex, replaceSamplerBinding, binding);
 }
 

--- a/src/gpu/UniformData.h
+++ b/src/gpu/UniformData.h
@@ -30,9 +30,12 @@
 namespace tgfx {
 static constexpr char VertexUniformBlockName[] = "VertexUniformBlock";
 static constexpr char FragmentUniformBlockName[] = "FragmentUniformBlock";
+// Descriptor set indices for multi-set Vulkan layout. UBOs and textures reside in separate
+// descriptor sets so their bindings both start from 0, eliminating cross-backend offset mapping.
+static constexpr int UBO_DESCRIPTOR_SET = 0;
+static constexpr int TEXTURE_DESCRIPTOR_SET = 1;
 static constexpr int VERTEX_UBO_BINDING_POINT = 0;
 static constexpr int FRAGMENT_UBO_BINDING_POINT = 1;
-static constexpr int TEXTURE_BINDING_POINT_START = 2;
 
 /**
  * An object representing the collection of uniform data in CPU side.

--- a/src/gpu/glsl/GLSLProgramBuilder.cpp
+++ b/src/gpu/glsl/GLSLProgramBuilder.cpp
@@ -205,7 +205,7 @@ std::shared_ptr<Program> GLSLProgramBuilder::finalize() {
                                     ShaderVisibility::Fragment};
     descriptor.layout.uniformBlocks.push_back(fragmentBinding);
   }
-  int textureBinding = TEXTURE_BINDING_POINT_START;
+  int textureBinding = 0;
   for (const auto& sampler : _uniformHandler.getSamplers()) {
     descriptor.layout.textureSamplers.emplace_back(sampler.name(), textureBinding++);
   }

--- a/src/gpu/vulkan/VulkanGPU.cpp
+++ b/src/gpu/vulkan/VulkanGPU.cpp
@@ -480,9 +480,9 @@ void VulkanGPU::processUnreferencedResources() {
 
 // Per-pool capacity for descriptor set allocation. Pools are chained on demand when exhausted
 // (see VulkanCommandEncoder::allocateDescriptorSet), so this value controls granularity rather
-// than a hard per-frame limit. 1024 covers most 2D frames in a single pool; complex scenes
-// transparently chain additional pools as needed.
-static constexpr uint32_t POOL_MAX_DESCRIPTOR_SETS = 1024;
+// than a hard per-frame limit. Each draw allocates 2 sets (UBO + texture), so 2048 covers
+// ~1024 draws per pool before chaining.
+static constexpr uint32_t POOL_MAX_DESCRIPTOR_SETS = 2048;
 static constexpr uint32_t POOL_MAX_UNIFORM_BUFFERS = 2048;
 static constexpr uint32_t POOL_MAX_COMBINED_SAMPLERS = 1024;
 

--- a/src/gpu/vulkan/VulkanRenderPass.cpp
+++ b/src/gpu/vulkan/VulkanRenderPass.cpp
@@ -380,13 +380,16 @@ void VulkanRenderPass::bindDescriptorSetIfDirty() {
   lastBound.descriptorDirty = false;
 
   auto device = vulkanGPU->device();
-  auto setLayout = lastBound.pipeline->vulkanDescriptorSetLayout();
-  if (setLayout == VK_NULL_HANDLE) {
+  auto uboLayout = lastBound.pipeline->vulkanUboSetLayout();
+  auto texLayout = lastBound.pipeline->vulkanTextureSetLayout();
+  if (uboLayout == VK_NULL_HANDLE || texLayout == VK_NULL_HANDLE) {
     return;
   }
 
-  auto descriptorSet = encoder->allocateDescriptorSet(setLayout);
-  if (descriptorSet == VK_NULL_HANDLE) {
+  // Allocate two descriptor sets: set 0 for UBOs, set 1 for textures.
+  auto uboSet = encoder->allocateDescriptorSet(uboLayout);
+  auto texSet = encoder->allocateDescriptorSet(texLayout);
+  if (uboSet == VK_NULL_HANDLE || texSet == VK_NULL_HANDLE) {
     LOGE("VulkanRenderPass: descriptor set allocation failed, draw will be dropped.");
     return;
   }
@@ -397,6 +400,7 @@ void VulkanRenderPass::bindDescriptorSetIfDirty() {
   bufferInfos.reserve(lastBound.uniformBindings.size());
   imageInfos.reserve(lastBound.textureBindings.size());
 
+  // Write UBO descriptors into set 0.
   for (unsigned i = 0; i < static_cast<unsigned>(lastBound.uniformBindings.size()); i++) {
     auto& ub = lastBound.uniformBindings[i];
     if (ub.buffer == VK_NULL_HANDLE || !lastBound.pipeline->hasUniformBinding(i)) {
@@ -405,7 +409,7 @@ void VulkanRenderPass::bindDescriptorSetIfDirty() {
     bufferInfos.push_back({ub.buffer, ub.offset, ub.size});
     VkWriteDescriptorSet write = {};
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write.dstSet = descriptorSet;
+    write.dstSet = uboSet;
     write.dstBinding = i;
     write.descriptorCount = 1;
     write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -413,6 +417,8 @@ void VulkanRenderPass::bindDescriptorSetIfDirty() {
     writes.push_back(write);
   }
 
+  // Write texture/sampler descriptors into set 1. Binding index equals the texture unit index
+  // (both start from 0), so no offset translation is needed.
   for (auto userBinding : lastBound.pipeline->getTextureBindings()) {
     auto unitIndex = lastBound.pipeline->getTextureIndex(userBinding);
     if (unitIndex >= lastBound.textureBindings.size()) {
@@ -426,8 +432,8 @@ void VulkanRenderPass::bindDescriptorSetIfDirty() {
     imageInfos.push_back({tb.sampler, tb.imageView, VK_IMAGE_LAYOUT_GENERAL});
     VkWriteDescriptorSet write = {};
     write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write.dstSet = descriptorSet;
-    write.dstBinding = lastBound.pipeline->getDescriptorBinding(userBinding);
+    write.dstSet = texSet;
+    write.dstBinding = unitIndex;
     write.descriptorCount = 1;
     write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     write.pImageInfo = &imageInfos.back();
@@ -438,9 +444,10 @@ void VulkanRenderPass::bindDescriptorSetIfDirty() {
     vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
   }
 
+  // Bind both descriptor sets in a single call.
+  VkDescriptorSet sets[] = {uboSet, texSet};
   vkCmdBindDescriptorSets(commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                          lastBound.pipeline->vulkanPipelineLayout(), 0, 1, &descriptorSet, 0,
-                          nullptr);
+                          lastBound.pipeline->vulkanPipelineLayout(), 0, 2, sets, 0, nullptr);
 }
 
 void VulkanRenderPass::setVertexBuffer(unsigned slot, std::shared_ptr<GPUBuffer> buffer,

--- a/src/gpu/vulkan/VulkanRenderPipeline.cpp
+++ b/src/gpu/vulkan/VulkanRenderPipeline.cpp
@@ -229,12 +229,13 @@ bool VulkanRenderPipeline::createDescriptorSetLayouts(VulkanGPU* gpu,
   }
 
   // Set 1: Combined image sampler bindings, starting from binding 0.
+  // Currently all texture sampling occurs in fragment shaders. If vertex texture sampling is
+  // needed in the future (e.g. displacement mapping), stageFlags should be extended accordingly.
   std::vector<VkDescriptorSetLayoutBinding> texBindings;
-  unsigned texUnit = 0;
-  for (auto& entry : descriptor.layout.textureSamplers) {
-    (void)entry;
+  auto samplerCount = descriptor.layout.textureSamplers.size();
+  for (size_t i = 0; i < samplerCount; i++) {
     VkDescriptorSetLayoutBinding binding = {};
-    binding.binding = texUnit++;
+    binding.binding = static_cast<unsigned>(i);
     binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     binding.descriptorCount = 1;
     binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;

--- a/src/gpu/vulkan/VulkanRenderPipeline.cpp
+++ b/src/gpu/vulkan/VulkanRenderPipeline.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<VulkanRenderPipeline> VulkanRenderPipeline::Make(
 
 VulkanRenderPipeline::VulkanRenderPipeline(VulkanGPU* gpu,
                                            const RenderPipelineDescriptor& descriptor) {
-  if (!createDescriptorSetLayout(gpu, descriptor)) {
+  if (!createDescriptorSetLayouts(gpu, descriptor)) {
     return;
   }
   if (!createPipelineLayout(gpu)) {
@@ -154,21 +154,17 @@ VulkanRenderPipeline::VulkanRenderPipeline(VulkanGPU* gpu,
   }
   createPipeline(gpu, descriptor);
 
+  // Build texture binding mapping: user-facing binding -> sequential texture unit index.
+  // With multi descriptor set layout, texture bindings start from 0 in both SPIR-V (set 1)
+  // and the runtime API, so this map is effectively an identity mapping.
   unsigned textureUnit = 0;
   for (auto& entry : descriptor.layout.textureSamplers) {
-    auto spirvBinding = static_cast<unsigned>(TEXTURE_BINDING_POINT_START) + textureUnit;
     textureUnits[entry.binding] = textureUnit++;
-    textureDescriptorBindings[entry.binding] = spirvBinding;
     textureBindingSet.insert(entry.binding);
   }
   for (auto& entry : descriptor.layout.uniformBlocks) {
     uniformBlockVisibility[entry.binding] = entry.visibility;
     uniformBindingSet.insert(entry.binding);
-  }
-
-  // Verify uniform and texture descriptor bindings do not overlap in the same descriptor set.
-  for (auto& [userBinding, descriptorBinding] : textureDescriptorBindings) {
-    DEBUG_ASSERT(uniformBindingSet.count(descriptorBinding) == 0);
   }
 }
 
@@ -182,23 +178,19 @@ void VulkanRenderPipeline::onRelease(VulkanGPU* gpu) {
     vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
     pipelineLayout = VK_NULL_HANDLE;
   }
-  if (descriptorSetLayout != VK_NULL_HANDLE) {
-    vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
-    descriptorSetLayout = VK_NULL_HANDLE;
+  if (uboSetLayout != VK_NULL_HANDLE) {
+    vkDestroyDescriptorSetLayout(device, uboSetLayout, nullptr);
+    uboSetLayout = VK_NULL_HANDLE;
+  }
+  if (textureSetLayout != VK_NULL_HANDLE) {
+    vkDestroyDescriptorSetLayout(device, textureSetLayout, nullptr);
+    textureSetLayout = VK_NULL_HANDLE;
   }
 }
 
 unsigned VulkanRenderPipeline::getTextureIndex(unsigned binding) const {
   auto result = textureUnits.find(binding);
   if (result != textureUnits.end()) {
-    return result->second;
-  }
-  return binding;
-}
-
-unsigned VulkanRenderPipeline::getDescriptorBinding(unsigned binding) const {
-  auto result = textureDescriptorBindings.find(binding);
-  if (result != textureDescriptorBindings.end()) {
     return result->second;
   }
   return binding;
@@ -212,48 +204,61 @@ uint32_t VulkanRenderPipeline::getUniformBlockVisibility(unsigned binding) const
   return ShaderVisibility::VertexFragment;
 }
 
-bool VulkanRenderPipeline::createDescriptorSetLayout(VulkanGPU* gpu,
-                                                     const RenderPipelineDescriptor& descriptor) {
-  std::vector<VkDescriptorSetLayoutBinding> bindings;
+bool VulkanRenderPipeline::createDescriptorSetLayouts(VulkanGPU* gpu,
+                                                      const RenderPipelineDescriptor& descriptor) {
+  auto device = gpu->device();
 
+  // Set 0: Uniform buffer bindings only.
+  std::vector<VkDescriptorSetLayoutBinding> uboBindings;
   for (auto& entry : descriptor.layout.uniformBlocks) {
     VkDescriptorSetLayoutBinding binding = {};
     binding.binding = entry.binding;
     binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     binding.descriptorCount = 1;
     binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings.push_back(binding);
+    uboBindings.push_back(binding);
+  }
+  VkDescriptorSetLayoutCreateInfo uboLayoutInfo = {};
+  uboLayoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+  uboLayoutInfo.bindingCount = static_cast<uint32_t>(uboBindings.size());
+  uboLayoutInfo.pBindings = uboBindings.data();
+  auto result = vkCreateDescriptorSetLayout(device, &uboLayoutInfo, nullptr, &uboSetLayout);
+  if (result != VK_SUCCESS) {
+    LOGE("VulkanRenderPipeline: vkCreateDescriptorSetLayout (UBO set) failed.");
+    return false;
   }
 
+  // Set 1: Combined image sampler bindings, starting from binding 0.
+  std::vector<VkDescriptorSetLayoutBinding> texBindings;
   unsigned texUnit = 0;
   for (auto& entry : descriptor.layout.textureSamplers) {
+    (void)entry;
     VkDescriptorSetLayoutBinding binding = {};
-    binding.binding = static_cast<unsigned>(TEXTURE_BINDING_POINT_START) + texUnit++;
+    binding.binding = texUnit++;
     binding.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     binding.descriptorCount = 1;
     binding.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    bindings.push_back(binding);
+    texBindings.push_back(binding);
   }
-
-  VkDescriptorSetLayoutCreateInfo layoutInfo = {};
-  layoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-  layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
-  layoutInfo.pBindings = bindings.data();
-
-  auto result =
-      vkCreateDescriptorSetLayout(gpu->device(), &layoutInfo, nullptr, &descriptorSetLayout);
+  VkDescriptorSetLayoutCreateInfo texLayoutInfo = {};
+  texLayoutInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+  texLayoutInfo.bindingCount = static_cast<uint32_t>(texBindings.size());
+  texLayoutInfo.pBindings = texBindings.data();
+  result = vkCreateDescriptorSetLayout(device, &texLayoutInfo, nullptr, &textureSetLayout);
   if (result != VK_SUCCESS) {
-    LOGE("VulkanRenderPipeline: vkCreateDescriptorSetLayout failed.");
+    LOGE("VulkanRenderPipeline: vkCreateDescriptorSetLayout (texture set) failed.");
     return false;
   }
+
   return true;
 }
 
 bool VulkanRenderPipeline::createPipelineLayout(VulkanGPU* gpu) {
+  VkDescriptorSetLayout setLayouts[] = {uboSetLayout, textureSetLayout};
   VkPipelineLayoutCreateInfo layoutInfo = {};
   layoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-  layoutInfo.setLayoutCount = 1;
-  layoutInfo.pSetLayouts = &descriptorSetLayout;
+  layoutInfo.setLayoutCount = 2;
+  layoutInfo.pSetLayouts = setLayouts;
 
   auto result = vkCreatePipelineLayout(gpu->device(), &layoutInfo, nullptr, &pipelineLayout);
   if (result != VK_SUCCESS) {

--- a/src/gpu/vulkan/VulkanRenderPipeline.h
+++ b/src/gpu/vulkan/VulkanRenderPipeline.h
@@ -44,13 +44,17 @@ class VulkanRenderPipeline : public RenderPipeline, public VulkanResource {
     return pipelineLayout;
   }
 
-  VkDescriptorSetLayout vulkanDescriptorSetLayout() const {
-    return descriptorSetLayout;
+  /// Returns the descriptor set layout for UBO bindings (set 0).
+  VkDescriptorSetLayout vulkanUboSetLayout() const {
+    return uboSetLayout;
+  }
+
+  /// Returns the descriptor set layout for texture/sampler bindings (set 1).
+  VkDescriptorSetLayout vulkanTextureSetLayout() const {
+    return textureSetLayout;
   }
 
   unsigned getTextureIndex(unsigned binding) const;
-
-  unsigned getDescriptorBinding(unsigned binding) const;
 
   uint32_t getUniformBlockVisibility(unsigned binding) const;
 
@@ -73,15 +77,17 @@ class VulkanRenderPipeline : public RenderPipeline, public VulkanResource {
   VulkanRenderPipeline(VulkanGPU* gpu, const RenderPipelineDescriptor& descriptor);
   ~VulkanRenderPipeline() override = default;
 
-  bool createDescriptorSetLayout(VulkanGPU* gpu, const RenderPipelineDescriptor& descriptor);
+  bool createDescriptorSetLayouts(VulkanGPU* gpu, const RenderPipelineDescriptor& descriptor);
   bool createPipelineLayout(VulkanGPU* gpu);
   bool createPipeline(VulkanGPU* gpu, const RenderPipelineDescriptor& descriptor);
 
   VkPipeline pipeline = VK_NULL_HANDLE;
   VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
-  VkDescriptorSetLayout descriptorSetLayout = VK_NULL_HANDLE;
+  // Descriptor set 0: UBO bindings (vertex UBO at binding 0, fragment UBO at binding 1).
+  VkDescriptorSetLayout uboSetLayout = VK_NULL_HANDLE;
+  // Descriptor set 1: texture/sampler bindings (binding 0, 1, 2, ...).
+  VkDescriptorSetLayout textureSetLayout = VK_NULL_HANDLE;
   std::unordered_map<unsigned, unsigned> textureUnits = {};
-  std::unordered_map<unsigned, unsigned> textureDescriptorBindings = {};
   std::unordered_map<unsigned, uint32_t> uniformBlockVisibility = {};
   std::unordered_set<unsigned> uniformBindingSet = {};
   std::unordered_set<unsigned> textureBindingSet = {};

--- a/src/gpu/vulkan/VulkanRenderPipeline.h
+++ b/src/gpu/vulkan/VulkanRenderPipeline.h
@@ -62,10 +62,6 @@ class VulkanRenderPipeline : public RenderPipeline, public VulkanResource {
     return uniformBindingSet.count(binding) > 0;
   }
 
-  bool hasTextureBinding(unsigned binding) const {
-    return textureBindingSet.count(binding) > 0;
-  }
-
   const std::unordered_set<unsigned>& getTextureBindings() const {
     return textureBindingSet;
   }


### PR DESCRIPTION
## 问题

PR #1425 引入 Vulkan 统一 binding 布局后，纹理 binding 从 `TEXTURE_BINDING_POINT_START=2` 开始分配，以避免与 UBO（binding 0/1）冲突。该设计为 Vulkan 零成本对齐，但对 Metal 和 OpenGL 产生了副作用：

- **Metal**：SPIR-V → MSL 转换时将 binding=2 原样映射为 `[[sampler(2)]]`，而运行时通过 `MetalRenderPipeline::textureUnits` 将其重映射为 index 0 后调用 `setFragmentTexture:atIndex:0`。声明与绑定不匹配，触发 Metal validation error：`missing Sampler binding at index 2`（PR #1438 报告的问题）。
- **OpenGL**：运行时通过 `uniform1i` 重映射，无 crash 但增加了不必要的间接层。

根因是 UBO 和纹理共享单一 binding 编号空间（单 descriptor set），Vulkan 的约束泄漏到了所有后端。

## 方案

将 UBO 和纹理/采样器拆分到**不同的 Vulkan descriptor set**：

```
set=0: UBO bindings (binding 0 = Vertex UBO, binding 1 = Fragment UBO)
set=1: Texture/Sampler bindings (binding 0, 1, 2, ... 从 0 开始)
```

效果：
- 纹理 binding 在所有后端统一从 0 开始，消除 `TEXTURE_BINDING_POINT_START` 全局常量
- Metal 编译时/运行时无需偏移映射，天然对齐
- Vulkan 两个 set 独立，binding 不冲突
- OpenGL texture unit 映射简化为恒等关系

## 改动文件

| 文件 | 说明 |
|------|------|
| `src/gpu/UniformData.h` | 删除 `TEXTURE_BINDING_POINT_START`，新增 `UBO_DESCRIPTOR_SET` / `TEXTURE_DESCRIPTOR_SET` |
| `src/gpu/ShaderCompiler.cpp` | UBO 注入 `set=0`，sampler 注入 `set=1, binding=0,...` |
| `src/gpu/glsl/GLSLProgramBuilder.cpp` | 纹理 binding 从 0 开始 |
| `src/gpu/ProgramInfo.cpp` | 纹理 binding 从 0 开始 |
| `src/gpu/vulkan/VulkanRenderPipeline.h` | 拆分为 `uboSetLayout` + `textureSetLayout` |
| `src/gpu/vulkan/VulkanRenderPipeline.cpp` | 两个独立 layout + pipeline layout 传 2 个 set |
| `src/gpu/vulkan/VulkanRenderPass.cpp` | 分配/写入/绑定两个 descriptor set |
| `src/gpu/vulkan/VulkanGPU.cpp` | descriptor pool maxSets 翻倍（每 draw 分配 2 个 set）|

## 测试验证

- ✅ OpenGL 编译通过，渲染正常
- ✅ Metal `autotest.sh USE_METAL`：472 测试中 471 通过，唯一失败为 pre-existing bug（`CanvasTest.PictureMaskPath`，PathOp 问题）
- ⏳ Vulkan SwiftShader 待 CI 验证

## 关联 PR

- 替代 PR #1438 的 hotfix 方案，从架构层面根治 Metal sampler binding 不匹配问题
- PR #1438 引入的 `toMslTextureSamplerIndex()` workaround 在本方案下不再需要