### PR TITLE
Fix use-after-free in BackgroundCapturer::Run by reordering local variable declarations.

### DIFF
--- a/src/layers/BackgroundHandler.cpp
+++ b/src/layers/BackgroundHandler.cpp
@@ -348,8 +348,8 @@ void BackgroundCapturer::Run(Layer* captureRoot, const DrawArgs& baseArgs,
   }
 
   auto* bgCanvas = bgSource->getCanvas();
-  AutoCanvasRestore autoRestore(bgCanvas);
   BackgroundCapturer capturer(snapshots, std::move(bgSource));
+  AutoCanvasRestore autoRestore(bgCanvas);
   DrawArgs captureArgs = baseArgs;
   captureArgs.backgroundHandler = &capturer;
   captureArgs.renderRects = &renderRects;


### PR DESCRIPTION
## Problem

`AutoCanvasRestore` destructor calls `Canvas::restore()` on an already-freed Canvas, causing access violation (0xC0000005 reading 0xFFFFFFFFFFFFFFFF).

## Root Cause

In `BackgroundCapturer::Run`, the declaration order was:
1. `AutoCanvasRestore autoRestore(bgCanvas)`
2. `BackgroundCapturer capturer(snapshots, std::move(bgSource))`

C++ destroys locals in reverse declaration order, so `capturer` (which owns `bgSource` → `Surface` → `Canvas`) is destroyed first, then `autoRestore` tries to call `restore()` on the now-freed Canvas.

## Fix

Swap the declaration order so `autoRestore` is declared after `capturer`, ensuring it destructs before `capturer` and the Canvas is still alive.