### PR TITLE
Enable Metal and Vulkan SwiftShader CI jobs.

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -77,51 +77,109 @@ jobs:
           name: mac_opengl_result
           path: result
 
-  # TODO: Enable mac-metal job after merging into main (Metal has compile error on Xcode 15.4)
-  # mac-metal:
-  #   name: mac (metal)
-  #   runs-on: macos-14
-  #   steps:
-  #     - name: Check Out Repo
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         lfs: true
-  #     - name: Get Third-Party Cache
-  #       id: third-party-cache
-  #       uses: actions/cache/restore@v4
-  #       with:
-  #         path: |
-  #           third_party
-  #           test/baseline/.cache/metal
-  #         key: autotest-mac-metal-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}-${{ hashFiles('test/baseline/version.json') }}
-  #         restore-keys: autotest-mac-metal-
-  #     - uses: tecolicom/actions-use-homebrew-tools@v1
-  #       with:
-  #         tools: ninja yasm
-  #     - name: Run depsync
-  #       run: |
-  #         npm install depsync -g
-  #         depsync
-  #       shell: bash
-  #     - name: Run Autotest
-  #       run: |
-  #         chmod +x autotest.sh
-  #         ./autotest.sh USE_METAL
-  #       env:
-  #         TRACY_NO_INVARIANT_CHECK: 1
-  #     - name: Save Third-Party Cache
-  #       if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
-  #       uses: actions/cache/save@v4
-  #       with:
-  #         path: |
-  #           third_party
-  #           test/baseline/.cache/metal
-  #         key: autotest-mac-metal-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}-${{ hashFiles('test/baseline/version.json') }}
-  #     - name: Upload Result
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: mac_metal_result
-  #         path: result
+  mac-metal:
+    name: mac (metal)
+    runs-on: macos-14
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Get Third-Party Cache
+        id: third-party-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            third_party
+            test/baseline/.cache/metal
+          key: autotest-mac-metal-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}-${{ hashFiles('test/baseline/version.json') }}
+          restore-keys: autotest-mac-metal-
+
+      - uses: tecolicom/actions-use-homebrew-tools@v1
+        with:
+          tools: ninja yasm
+
+      - name: Run depsync
+        run: |
+          npm install depsync -g
+          depsync
+        shell: bash
+
+      - name: Run Autotest
+        run: |
+          chmod +x autotest.sh
+          ./autotest.sh USE_METAL
+        env:
+          TRACY_NO_INVARIANT_CHECK: 1
+
+      - name: Save Third-Party Cache
+        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            third_party
+            test/baseline/.cache/metal
+          key: autotest-mac-metal-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}-${{ hashFiles('test/baseline/version.json') }}
+
+      - name: Upload Result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac_metal_result
+          path: result
+
+  mac-vulkan:
+    name: mac (vulkan-swiftshader)
+    runs-on: macos-14
+    steps:
+      - name: Check Out Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Get Third-Party Cache
+        id: third-party-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            third_party
+            test/baseline/.cache/vulkan-swiftshader
+          key: autotest-mac-vulkan-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}-${{ hashFiles('test/baseline/version.json') }}
+          restore-keys: autotest-mac-vulkan-
+
+      - uses: tecolicom/actions-use-homebrew-tools@v1
+        with:
+          tools: ninja yasm
+
+      - name: Run depsync
+        run: |
+          npm install depsync -g
+          depsync
+        shell: bash
+
+      - name: Run Autotest
+        run: |
+          chmod +x autotest.sh
+          ./autotest.sh USE_VULKAN_SWIFTSHADER
+        env:
+          TRACY_NO_INVARIANT_CHECK: 1
+
+      - name: Save Third-Party Cache
+        if: ${{ (github.event_name == 'push') && (steps.third-party-cache.outputs.cache-hit != 'true') }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            third_party
+            test/baseline/.cache/vulkan-swiftshader
+          key: autotest-mac-vulkan-${{ hashFiles('DEPS') }}-${{ hashFiles('vendor.json') }}-${{ hashFiles('test/baseline/version.json') }}
+
+      - name: Upload Result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac_vulkan_result
+          path: result
 

--- a/autotest.sh
+++ b/autotest.sh
@@ -35,8 +35,8 @@ elif [[ "$1" == "USE_METAL" ]]; then
   TARGET_SUFFIX="Metal"
   cmake -DTGFX_USE_METAL=ON -DTGFX_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ../
 elif [[ "$1" == "USE_VULKAN" ]]; then
-  TARGET_SUFFIX="Vulkan"
-  cmake -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -g -O0" -DTGFX_USE_VULKAN=ON -DTGFX_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ../
+  echo "ERROR: USE_VULKAN (native GPU) is not supported on macOS. Use USE_VULKAN_SWIFTSHADER instead."
+  exit 1
 elif [[ "$1" == "USE_OPENGL" ]]; then
   TARGET_SUFFIX="OpenGL"
   cmake -DCMAKE_CXX_FLAGS="-fprofile-arcs -ftest-coverage -g -O0" -DTGFX_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ../

--- a/update_baseline.bat
+++ b/update_baseline.bat
@@ -86,7 +86,7 @@ if !errorlevel! neq 0 (
 )
 
 :: Set up SwiftShader Vulkan library so volk can load it at runtime.
-if /I "%BACKEND_ARG%"=="USE_VULKAN_SWIFTSHADER" copy /y "%WORKSPACE%\vendor\swiftshader\win\x64\vk_swiftshader.dll" "%CD%\vulkan-1.dll" >nul 2>&1
+if /I "%~1"=="USE_VULKAN_SWIFTSHADER" copy /y "%~dp0vendor\swiftshader\win\x64\vk_swiftshader.dll" "%CD%\vulkan-1.dll" >nul 2>&1
 
 UpdateBaseline_%TARGET_SUFFIX%.exe
 if !errorlevel! equ 0 (

--- a/update_baseline.bat
+++ b/update_baseline.bat
@@ -77,22 +77,18 @@ if %errorlevel% neq 0 (
     goto :restore
 )
 
-:: TODO: Remove fallback after this branch is merged into main.
-:: Main branch still uses the old target name "UpdateBaseline". Once merged, only the new name
-:: "UpdateBaseline_{Backend}" will exist and the else branch can be deleted.
-cmake --build . --target UpdateBaseline_%TARGET_SUFFIX% 2>nul
+cmake --build . --target UpdateBaseline_%TARGET_SUFFIX%
 if !errorlevel! neq 0 (
-    cmake --build . --target UpdateBaseline
-    if !errorlevel! neq 0 (
-        echo Build failed
-        set "BASELINE_FAILED=true"
-        cd ..
-        goto :restore
-    )
-    UpdateBaseline.exe
-) else (
-    UpdateBaseline_%TARGET_SUFFIX%.exe
+    echo Build failed
+    set "BASELINE_FAILED=true"
+    cd ..
+    goto :restore
 )
+
+:: Set up SwiftShader Vulkan library so volk can load it at runtime.
+if /I "%BACKEND_ARG%"=="USE_VULKAN_SWIFTSHADER" copy /y "%WORKSPACE%\vendor\swiftshader\win\x64\vk_swiftshader.dll" "%CD%\vulkan-1.dll" >nul 2>&1
+
+UpdateBaseline_%TARGET_SUFFIX%.exe
 if !errorlevel! equ 0 (
     echo ~~~~~~~~~~~~~~~~~~~Update Baseline (%BACKEND_NAME%) Success~~~~~~~~~~~~~~~~~~~~~
 ) else (

--- a/update_baseline.sh
+++ b/update_baseline.sh
@@ -77,15 +77,19 @@
         -DTGFX_BUILD_TESTS=ON -DTGFX_SKIP_BASELINE_CHECK=ON \
         -DCMAKE_BUILD_TYPE=Debug ../
 
-  # TODO: Remove fallback after this branch is merged into main.
-  # Main branch still uses the old target name "UpdateBaseline". Once merged, only the new name
-  # "UpdateBaseline_{Backend}" will exist and the else branch can be deleted.
-  if cmake --build . --target UpdateBaseline_${TARGET_SUFFIX} -- -j 12 2>/dev/null; then
-    ./UpdateBaseline_${TARGET_SUFFIX}
-  else
-    cmake --build . --target UpdateBaseline -- -j 12
-    ./UpdateBaseline
+  cmake --build . --target UpdateBaseline_${TARGET_SUFFIX} -- -j 12
+
+  # Set up SwiftShader Vulkan library so volk can load it at runtime.
+  if [[ "$1" == "USE_VULKAN_SWIFTSHADER" ]]; then
+    HOST_ARCH=$(uname -m)
+    if [[ "$HOST_ARCH" == "x86_64" ]]; then
+      HOST_ARCH=x64
+    fi
+    cp "../vendor/swiftshader/mac/$HOST_ARCH/libvk_swiftshader.dylib" "$(pwd)/libvulkan.dylib"
+    export DYLD_LIBRARY_PATH="$(pwd):${DYLD_LIBRARY_PATH:-}"
   fi
+
+  ./UpdateBaseline_${TARGET_SUFFIX}
 
   if test $? -eq 0; then
      echo "~~~~~~~~~~~~~~~~~~~Update Baseline ($BACKEND_NAME) Success~~~~~~~~~~~~~~~~~~~~~"


### PR DESCRIPTION
## 概述

启用 Metal 和 Vulkan SwiftShader 的 GitHub CI 流水线，并清理合入 main 后不再需要的临时兼容代码。

## 改动内容

### 1. 启用 CI Job（`.github/workflows/autotest.yml`）

| Job | Runner | 参数 | 说明 |
|-----|--------|------|------|
| `mac-metal` | macos-14 | `USE_METAL` | 取消注释，恢复 Metal CI |
| `mac-vulkan` | macos-14 | `USE_VULKAN_SWIFTSHADER` | 新增，使用 SwiftShader 软件渲染 |

### 2. 清理临时兼容代码

- **`update_baseline.sh`**：删除旧目标名 `UpdateBaseline` 的 fallback 分支；新增 Vulkan SwiftShader 运行时 `libvulkan.dylib` 加载逻辑
- **`update_baseline.bat`**：同上，Windows 版删除 fallback + 添加 `vulkan-1.dll` rename

### 3. 限制 `USE_VULKAN` 参数（`autotest.sh`）

macOS 无原生 Vulkan 驱动，`USE_VULKAN`（真机 GPU）在 Mac 上改为报错退出并提示使用 `USE_VULKAN_SWIFTSHADER`。

## 本地验证

- ✅ `./autotest.sh USE_METAL`：472 测试全部通过
- ✅ `./autotest.sh USE_VULKAN_SWIFTSHADER`：通过
- ✅ `./autotest.sh USE_OPENGL_SWIFTSHADER`：不受影响