### PR TITLE
Fix Xcode 15.4 Metal compile error caused by unique_ptr of incomplete types.

### DIFF
--- a/src/gpu/metal/MetalGPU.h
+++ b/src/gpu/metal/MetalGPU.h
@@ -144,12 +144,12 @@ class MetalGPU : public GPU {
   static uint32_t MakeSamplerKey(const SamplerDescriptor& descriptor);
 
   id<MTLDevice> metalDevice = nil;
-  std::unique_ptr<MetalCaps> caps = nullptr;
-  std::unique_ptr<MetalCommandQueue> commandQueue = nullptr;
+  std::unique_ptr<MetalCaps> caps;
+  std::unique_ptr<MetalCommandQueue> commandQueue;
   // Keep one shader compiler per MetalGPU so glslang stays initialized across shader
   // compilations. The win is not the Compiler object itself, which is lightweight, but avoiding
   // repeated rebuilds of glslang's global built-in symbol tables after init/finalize churn.
-  std::unique_ptr<shaderc::Compiler> compiler = nullptr;
+  std::unique_ptr<shaderc::Compiler> compiler;
   std::list<MetalResource*> resources = {};
   std::shared_ptr<ReturnQueue> returnQueue = ReturnQueue::Make();
   CVMetalTextureCacheRef textureCache = nil;


### PR DESCRIPTION
## 问题

在 GitHub CI（Xcode 15.4 / macOS SDK 15.4）上编译 Metal 后端时，所有包含 `MetalGPU.h` 的 `.mm` 文件报错：

```
error: invalid application of 'sizeof' to an incomplete type 'tgfx::MetalCommandQueue'
error: invalid application of 'sizeof' to an incomplete type 'shaderc::Compiler'
```

这是之前 Metal CI job 被注释掉的原因。

## 根因

`MetalGPU.h` 中三个 `std::unique_ptr` 成员使用了 `= nullptr` 默认初始化：

```cpp
std::unique_ptr<MetalCommandQueue> commandQueue = nullptr;  // 前向声明
std::unique_ptr<shaderc::Compiler> compiler = nullptr;      // 前向声明
```

Xcode 15.4 的 libc++ 在处理 `= nullptr`（copy-list-initialization）时，会在当前编译单元中实例化 `unique_ptr::~unique_ptr()`，其内部有 `static_assert(sizeof(_Tp) >= 0)` 检查。当 `MetalBuffer.mm`、`MetalCommandEncoder.mm` 等文件通过 include 链引入 `MetalGPU.h` 时，`MetalCommandQueue` 和 `shaderc::Compiler` 仍为不完整类型（仅有前向声明），触发编译错误。

本地 Xcode 16+ 不报错是因为新版 libc++ 放宽了该检查。

## 修复

移除 `= nullptr` 初始化。`std::unique_ptr` 默认构造即为 null，语义完全等价。移除后编译器不再需要在头文件包含处实例化析构函数——析构只在 `MetalGPU.mm` 中发生（该文件已 include 完整类型定义）。

## 改动

- `src/gpu/metal/MetalGPU.h`：3 行，`= nullptr` → 去掉初始化器

## 验证

- ✅ 本地 Metal 编译通过（`cmake --build --target TGFXFullTest_Metal`）
- ⏳ CI 验证（本 PR 触发后自动跑）