### PR TITLE
WebGL2/Emscripten: use glVertexAttribIPointer for integer vertex formats

### DIFF
--- a/src/gpu/opengl/GLCoreFunctions.h
+++ b/src/gpu/opengl/GLCoreFunctions.h
@@ -105,6 +105,7 @@
   M(glTexSubImage2D)                  \
   M(glUniform1i)                      \
   M(glUseProgram)                     \
+  M(glVertexAttribIPointer)           \
   M(glVertexAttribPointer)            \
   M(glVertexAttribDivisor)            \
   M(glViewport)                       \

--- a/src/gpu/opengl/GLFunctions.h
+++ b/src/gpu/opengl/GLFunctions.h
@@ -167,6 +167,8 @@ using GLUseProgram = void GL_FUNCTION_TYPE(unsigned program);
 using GLVertexAttribPointer = void GL_FUNCTION_TYPE(unsigned indx, int size, unsigned type,
                                                     unsigned char normalized, int stride,
                                                     const void* ptr);
+using GLVertexAttribIPointer = void GL_FUNCTION_TYPE(unsigned indx, int size, unsigned type,
+                                                     int stride, const void* ptr);
 using GLVertexAttribDivisor = void GL_FUNCTION_TYPE(unsigned index, int divisor);
 using GLViewport = void GL_FUNCTION_TYPE(int x, int y, int width, int height);
 
@@ -281,6 +283,7 @@ class GLFunctions {
   GLUniform1i* uniform1i = nullptr;
   GLUseProgram* useProgram = nullptr;
   GLVertexAttribPointer* vertexAttribPointer = nullptr;
+  GLVertexAttribIPointer* vertexAttribIPointer = nullptr;
   GLVertexAttribDivisor* vertexAttribDivisor = nullptr;
   GLViewport* viewport = nullptr;
   GLClientWaitSync* clientWaitSync = nullptr;

--- a/src/gpu/opengl/GLInterface.cpp
+++ b/src/gpu/opengl/GLInterface.cpp
@@ -239,6 +239,8 @@ std::shared_ptr<GLInterface> GLInterface::MakeNativeInterface(const GLProcGetter
   functions->useProgram = reinterpret_cast<GLUseProgram*>(getter->getProcAddress("glUseProgram"));
   functions->vertexAttribPointer =
       reinterpret_cast<GLVertexAttribPointer*>(getter->getProcAddress("glVertexAttribPointer"));
+  functions->vertexAttribIPointer =
+      reinterpret_cast<GLVertexAttribIPointer*>(getter->getProcAddress("glVertexAttribIPointer"));
   functions->vertexAttribDivisor =
       reinterpret_cast<GLVertexAttribDivisor*>(getter->getProcAddress("glVertexAttribDivisor"));
   functions->viewport = reinterpret_cast<GLViewport*>(getter->getProcAddress("glViewport"));

--- a/src/gpu/opengl/GLRenderPipeline.cpp
+++ b/src/gpu/opengl/GLRenderPipeline.cpp
@@ -107,6 +107,11 @@ void GLRenderPipeline::setTexture(GLGPU* gpu, unsigned binding, GLTexture* textu
   }
 }
 
+static bool IsIntegerVertexAttribType(unsigned type) {
+  return type == GL_INT || type == GL_UNSIGNED_INT || type == GL_BYTE || type == GL_UNSIGNED_BYTE ||
+         type == GL_SHORT || type == GL_UNSIGNED_SHORT;
+}
+
 void GLRenderPipeline::setVertexBuffer(GLGPU* gpu, unsigned slot, GLBuffer* buffer, size_t offset) {
   DEBUG_ASSERT(slot < bufferLayouts.size());
   if (slot >= bufferLayouts.size()) {
@@ -120,9 +125,15 @@ void GLRenderPipeline::setVertexBuffer(GLGPU* gpu, unsigned slot, GLBuffer* buff
   gl->bindBuffer(GL_ARRAY_BUFFER, buffer->bufferID());
   const auto& layout = bufferLayouts[slot];
   for (auto& attribute : layout.attributes) {
-    gl->vertexAttribPointer(static_cast<unsigned>(attribute.location), attribute.count,
-                            attribute.type, attribute.normalized, static_cast<int>(layout.stride),
-                            reinterpret_cast<void*>(attribute.offset + offset));
+    if (!attribute.normalized && IsIntegerVertexAttribType(attribute.type)) {
+      gl->vertexAttribIPointer(static_cast<unsigned>(attribute.location), attribute.count,
+                               attribute.type, static_cast<int>(layout.stride),
+                               reinterpret_cast<void*>(attribute.offset + offset));
+    } else {
+      gl->vertexAttribPointer(static_cast<unsigned>(attribute.location), attribute.count,
+                              attribute.type, attribute.normalized, static_cast<int>(layout.stride),
+                              reinterpret_cast<void*>(attribute.offset + offset));
+    }
   }
 }
 


### PR DESCRIPTION
## 概述

在 Emscripten/WebGL2 路径下，对 **未归一化的整型顶点格式**（`GL_BYTE`、`GL_SHORT`、`GL_INT` 及其无符号变体）绑定顶点指针时，原先统一使用 `glVertexAttribPointer`。当顶点着色器中消费的是 **整型 generic 属性**（例如 `in int`、`in ivec*`）时，WebGL 2 需要使用 **`glVertexAttribIPointer`**。本变更在 `__EMSCRIPTEN__` 下补齐该入口并完成分发，在 `setVertexBuffer` 中对「整型且 `normalized == false`」的属性走 I 指针路径，其余仍走 `glVertexAttribPointer`。

## 背景与问题

业务里使用自定义 `RenderPass`，顶点着色器中声明了整型顶点属性（例如 `in int inColorIndex;`）。顶点布局对应的 `VertexFormat` 与 GL 类型本身是合理的，但在 **浏览器 WebGL** 下会出现渲染异常或无法按预期工作；而同一份布局在原生 GLES/桌面 OpenGL 上往往能正常运行（驱动对 `vertexAttribPointer` 的处理相对宽松），因此问题主要暴露在 Web 侧。

### 控制台错误（WebGL）

在 Chromium 等环境下，开发者工具控制台里在 `glDrawArrays`（或由此触发的绘制）时可能看到：

`GL_INVALID_OPERATION: glDrawArrays: Vertex shader input type does not match the type of the bound vertex attribute.`

## 解决方案

1. **`GLFunctions.h` / `GLInterface.cpp`**：在 `#if defined(__EMSCRIPTEN__)` 内增加 `GLVertexAttribIPointer` 类型与 `vertexAttribIPointer` 成员，并通过 `getProcAddress("glVertexAttribIPointer")` 解析，与其它 GL 函数一致。
2. **`WebGLProcGetter.cpp`**：在现有的 `emscripten_webgl*` 宏映射表中增加 `glVertexAttribIPointer`，保证 Embind 能返回有效函数指针。
3. **`GLRenderPipeline::setVertexBuffer`**：在 Emscripten 下，若当前 attribute 为 **未归一化** 且 `type` 属于 `GL_BYTE`、`GL_UNSIGNED_BYTE`、`GL_SHORT`、`GL_UNSIGNED_SHORT`、`GL_INT`、`GL_UNSIGNED_INT`，则调用 **`glVertexAttribIPointer`**；否则仍调用 **`glVertexAttribPointer`**（纯浮点顶点、`normalized` 为 true 的格式等保持原逻辑）。

## 不涉及的范围

- 所有逻辑均用 **`__EMSCRIPTEN__`** 包裹，**非 Web 平台编译与运行路径不变**，避免在未见问题的原生栈上扩大改动面。
- 未改动 instance divisor 等与 `setPipelineDescriptor` 相关的状态；仅调整 `setVertexBuffer` 里每个 attribute 的指针绑定方式。