### PR TITLE
Fix EAGLDevice destructor crash inside _gleTerminateContext when releasing GL resources.

### DIFF
--- a/src/gpu/opengl/eagl/EAGLDevice.mm
+++ b/src/gpu/opengl/eagl/EAGLDevice.mm
@@ -172,7 +172,28 @@ EAGLDevice::~EAGLDevice() {
     tail->cacheArrayIndex = index;
     deviceList.pop_back();
   }
+  // Force the EAGLContext to be current before releaseAll() so that any cached GPU resources
+  // (programs/shaders/textures/...) can be released via glDelete* even when the app has been
+  // reported as backgrounded. Without this, releaseAll() would skip all glDelete* calls and the
+  // following [_eaglContext release] could crash inside _gleTerminateContext when GLEngine cleans
+  // up its internal program/shader hash tables on a stale sharegroup.
+  EAGLContext* previousContext = [[EAGLContext currentContext] retain];
+  bool madeCurrent = previousContext == _eaglContext ||
+                     [EAGLContext setCurrentContext:_eaglContext];
   releaseAll();
+  if (madeCurrent) {
+    // Flush any pending GL deletions issued by releaseAll() so that the EAGLContext can be
+    // safely deallocated below.
+    glFinish();
+  }
+  // Restore the previous current context. The EAGLContext being destroyed must not remain the
+  // current context when [_eaglContext release] triggers its dealloc.
+  if (previousContext != _eaglContext) {
+    [EAGLContext setCurrentContext:previousContext];
+  } else {
+    [EAGLContext setCurrentContext:nil];
+  }
+  [previousContext release];
   [_eaglContext release];
 }
 
@@ -197,12 +218,18 @@ void EAGLDevice::onUnlockContext() {
 }
 
 bool EAGLDevice::makeCurrent(bool force) {
-  if (!force && appInBackground) {
-    return false;
-  }
   oldContext = [[EAGLContext currentContext] retain];
+  // Fast path: the EAGLContext is already current on this thread. This must be checked before
+  // the appInBackground gate so that nested locks (e.g. GLDevice::releaseAll() called from
+  // ~EAGLDevice() after the destructor has forced setCurrentContext) can still succeed even
+  // when the app has been reported as backgrounded.
   if (oldContext == _eaglContext) {
     return true;
+  }
+  if (!force && appInBackground) {
+    [oldContext release];
+    oldContext = nil;
+    return false;
   }
   if (![EAGLContext setCurrentContext:_eaglContext]) {
     [oldContext release];

--- a/src/gpu/opengl/eagl/EAGLDevice.mm
+++ b/src/gpu/opengl/eagl/EAGLDevice.mm
@@ -178,8 +178,8 @@ EAGLDevice::~EAGLDevice() {
   // following [_eaglContext release] could crash inside _gleTerminateContext when GLEngine cleans
   // up its internal program/shader hash tables on a stale sharegroup.
   EAGLContext* previousContext = [[EAGLContext currentContext] retain];
-  bool madeCurrent = previousContext == _eaglContext ||
-                     [EAGLContext setCurrentContext:_eaglContext];
+  bool madeCurrent =
+      previousContext == _eaglContext || [EAGLContext setCurrentContext:_eaglContext];
   releaseAll();
   if (madeCurrent) {
     // Flush any pending GL deletions issued by releaseAll() so that the EAGLContext can be


### PR DESCRIPTION
修复 iOS 应用进入后台时销毁 EAGLDevice 偶发崩溃的问题。

崩溃路径：~EAGLDevice() 调用 releaseAll() 时，由于 appInBackground 闸门，makeCurrent() 直接返回 false，导致缓存的 GPU 资源（programs/shaders/textures 等）跳过了所有 glDelete* 调用；随后 [_eaglContext release] 触发 _gleTerminateContext 在过期 sharegroup 上清理 GLEngine 内部 program/shader 哈希表时崩溃。

修复方式：
1. 在 ~EAGLDevice() 中先强制将 _eaglContext 设为当前上下文，再调用 releaseAll() 释放 GL 资源，glFinish() 后恢复原上下文。
2. 调整 makeCurrent() 中已 current 的快速路径检查顺序，使其位于 appInBackground 闸门之前，确保析构期间嵌套调用能正常成功。