### PR TITLE
Fix flickering when rendering multiple noise filters

### DIFF
--- a/include/tgfx/layers/filters/LayerFilter.h
+++ b/include/tgfx/layers/filters/LayerFilter.h
@@ -36,9 +36,13 @@ class LayerFilter : public LayerProperty {
    * Applies this filter to the given input image at the specified scale factor.
    * @param input The source image to filter.
    * @param scale The scale factor to apply to scale-dependent filter parameters.
-   * @param contentBounds The layer content bounds adjusted into the current input image coordinate
-   * space. Filters whose effect is anchored to the layer geometry use this rectangle to recover the
-   * anchor regardless of how the input image is clipped relative to the content bounds.
+   * @param contentBounds The layer content bounds expressed in a coordinate system whose origin
+   * coincides with the input image pixel (0, 0) mapped back to layer-local space. The origin of
+   * this rectangle is always zero, so its center is determined solely by the content shape
+   * (width × height) and does not include any layer-local position offset. Filters whose effect
+   * is anchored to the layer geometry use this rectangle's center as a stable anchor point that
+   * remains consistent regardless of how the input image is clipped or where the content is
+   * positioned within the layer.
    * @param offset If non-null, receives the (x, y) translation of the filtered image relative to
    * the input image origin.
    * @return The filtered image, or nullptr on failure.

--- a/include/tgfx/layers/filters/LayerFilter.h
+++ b/include/tgfx/layers/filters/LayerFilter.h
@@ -36,10 +36,9 @@ class LayerFilter : public LayerProperty {
    * Applies this filter to the given input image at the specified scale factor.
    * @param input The source image to filter.
    * @param scale The scale factor to apply to scale-dependent filter parameters.
-   * @param contentBounds The layer content bounds, expressed in the input image coordinate space
-   * (the input image origin is the coordinate origin). Filters whose effect is anchored to the
-   * layer geometry use this rectangle to recover the anchor regardless of how the input image is
-   * clipped relative to the content bounds.
+   * @param contentBounds The layer content bounds adjusted into the current input image coordinate
+   * space. Filters whose effect is anchored to the layer geometry use this rectangle to recover the
+   * anchor regardless of how the input image is clipped relative to the content bounds.
    * @param offset If non-null, receives the (x, y) translation of the filtered image relative to
    * the input image origin.
    * @return The filtered image, or nullptr on failure.

--- a/src/gpu/glsl/processors/GLSLPerlinNoiseFragmentProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLPerlinNoiseFragmentProcessor.cpp
@@ -50,21 +50,18 @@ PlacementPtr<PerlinNoiseFragmentProcessor> PerlinNoiseFragmentProcessor::Make(
     return nullptr;
   }
 
-  auto permTex = permutationsView->getTexture();
-  auto noiseTex = noiseView->getTexture();
   return allocator->make<GLSLPerlinNoiseFragmentProcessor>(
-      noiseType, numOctaves, stitchTiles, std::move(paintingData), std::move(permTex),
-      std::move(noiseTex), uvMatrix);
+      noiseType, numOctaves, stitchTiles, std::move(paintingData), std::move(permutationsView),
+      std::move(noiseView), uvMatrix);
 }
 
 GLSLPerlinNoiseFragmentProcessor::GLSLPerlinNoiseFragmentProcessor(
     PerlinNoiseType noiseType, int numOctaves, bool stitchTiles,
     std::unique_ptr<PerlinNoiseShader::PaintingData> paintingData,
-    std::shared_ptr<Texture> permutationsTexture, std::shared_ptr<Texture> noiseTexture,
+    std::shared_ptr<TextureView> permutationsView, std::shared_ptr<TextureView> noiseView,
     const Matrix* uvMatrix)
     : PerlinNoiseFragmentProcessor(noiseType, numOctaves, stitchTiles, std::move(paintingData),
-                                   std::move(permutationsTexture), std::move(noiseTexture),
-                                   uvMatrix) {
+                                   std::move(permutationsView), std::move(noiseView), uvMatrix) {
 }
 
 void GLSLPerlinNoiseFragmentProcessor::emitCode(EmitArgs& args) const {

--- a/src/gpu/glsl/processors/GLSLPerlinNoiseFragmentProcessor.h
+++ b/src/gpu/glsl/processors/GLSLPerlinNoiseFragmentProcessor.h
@@ -25,8 +25,8 @@ class GLSLPerlinNoiseFragmentProcessor : public PerlinNoiseFragmentProcessor {
  public:
   GLSLPerlinNoiseFragmentProcessor(PerlinNoiseType noiseType, int numOctaves, bool stitchTiles,
                                    std::unique_ptr<PerlinNoiseShader::PaintingData> paintingData,
-                                   std::shared_ptr<Texture> permutationsTexture,
-                                   std::shared_ptr<Texture> noiseTexture, const Matrix* uvMatrix);
+                                   std::shared_ptr<TextureView> permutationsView,
+                                   std::shared_ptr<TextureView> noiseView, const Matrix* uvMatrix);
 
   void emitCode(EmitArgs& args) const override;
 

--- a/src/gpu/processors/PerlinNoiseFragmentProcessor.cpp
+++ b/src/gpu/processors/PerlinNoiseFragmentProcessor.cpp
@@ -17,17 +17,18 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gpu/processors/PerlinNoiseFragmentProcessor.h"
+#include "gpu/resources/TextureView.h"
 
 namespace tgfx {
 
 PerlinNoiseFragmentProcessor::PerlinNoiseFragmentProcessor(
     PerlinNoiseType noiseType, int numOctaves, bool stitchTiles,
     std::unique_ptr<PerlinNoiseShader::PaintingData> paintingData,
-    std::shared_ptr<Texture> permutationsTexture, std::shared_ptr<Texture> noiseTexture,
+    std::shared_ptr<TextureView> permutationsView, std::shared_ptr<TextureView> noiseView,
     const Matrix* uvMatrix)
     : FragmentProcessor(ClassID()), noiseType(noiseType), numOctaves(numOctaves),
       stitchTiles(stitchTiles), paintingData(std::move(paintingData)),
-      permutationsTexture(std::move(permutationsTexture)), noiseTexture(std::move(noiseTexture)) {
+      permutationsView(std::move(permutationsView)), noiseView(std::move(noiseView)) {
   if (uvMatrix) {
     coordTransform = CoordTransform(*uvMatrix);
   }
@@ -50,9 +51,9 @@ void PerlinNoiseFragmentProcessor::onComputeProcessorKey(BytesKey* bytesKey) con
 
 std::shared_ptr<Texture> PerlinNoiseFragmentProcessor::onTextureAt(size_t index) const {
   if (index == 0) {
-    return permutationsTexture;
+    return permutationsView->getTexture();
   }
-  return noiseTexture;
+  return noiseView->getTexture();
 }
 
 SamplerState PerlinNoiseFragmentProcessor::onSamplerStateAt(size_t) const {

--- a/src/gpu/processors/PerlinNoiseFragmentProcessor.h
+++ b/src/gpu/processors/PerlinNoiseFragmentProcessor.h
@@ -25,6 +25,7 @@
 namespace tgfx {
 class Context;
 class Texture;
+class TextureView;
 
 class PerlinNoiseFragmentProcessor : public FragmentProcessor {
  public:
@@ -52,15 +53,15 @@ class PerlinNoiseFragmentProcessor : public FragmentProcessor {
 
   PerlinNoiseFragmentProcessor(PerlinNoiseType noiseType, int numOctaves, bool stitchTiles,
                                std::unique_ptr<PerlinNoiseShader::PaintingData> paintingData,
-                               std::shared_ptr<Texture> permutationsTexture,
-                               std::shared_ptr<Texture> noiseTexture, const Matrix* uvMatrix);
+                               std::shared_ptr<TextureView> permutationsView,
+                               std::shared_ptr<TextureView> noiseView, const Matrix* uvMatrix);
 
   PerlinNoiseType noiseType;
   int numOctaves;
   bool stitchTiles;
   std::unique_ptr<PerlinNoiseShader::PaintingData> paintingData;
-  std::shared_ptr<Texture> permutationsTexture;
-  std::shared_ptr<Texture> noiseTexture;
+  std::shared_ptr<TextureView> permutationsView;
+  std::shared_ptr<TextureView> noiseView;
   CoordTransform coordTransform;
 };
 }  // namespace tgfx

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -1096,9 +1096,9 @@ std::shared_ptr<Image> Layer::applyFilters(std::shared_ptr<Image> image, float c
     return image;
   }
   // Each filter may shift the output image origin by filterOffset. Subsequent filters receive an
-  // image in the shifted coordinate system, so the contentBounds rect (originally expressed in the
-  // input image coordinate space) must be translated by -filterOffset before being passed to the
-  // next filter, otherwise geometry-anchored filters would sample in a stale coordinate system.
+  // image in the shifted coordinate system, so contentBounds must be translated by -filterOffset
+  // before being passed to the next filter, otherwise geometry-anchored filters would sample in a
+  // stale coordinate system.
   Rect currentContentBounds = contentBounds;
   for (const auto& layerFilter : _filters) {
     DEBUG_ASSERT(layerFilter != nullptr);
@@ -1429,6 +1429,8 @@ std::shared_ptr<Image> Layer::createSubtreeCacheImage(const DrawArgs& args, floa
   if (!_filters.empty()) {
     Point filterOffset = {};
     auto contentBounds = mapContentBoundsToImage(contentScale, pictureBounds);
+    contentBounds.offset(-(contentBounds.left + pictureBounds.left),
+                         -(contentBounds.top + pictureBounds.top));
     image = applyFilters(std::move(image), contentScale, contentBounds, &filterOffset);
     offset += filterOffset;
   }

--- a/src/layers/OffscreenRenderer.cpp
+++ b/src/layers/OffscreenRenderer.cpp
@@ -66,6 +66,8 @@ OffscreenResult OffscreenRenderer::RenderContent(Layer* layer, const DrawArgs& a
   // extensions) so geometry-anchored filters such as NoiseFilter recover the layer-local anchor
   // regardless of how the input image is clipped relative to the full content bounds.
   auto inputContentBounds = layer->mapContentBoundsToImage(density.getMaxScale(), imageClip);
+  inputContentBounds.offset(-(inputContentBounds.left + imageClip.left),
+                            -(inputContentBounds.top + imageClip.top));
 
   OffscreenResult result;
   // Need a Surface backing only when a descendant Background-sourced style will read back

--- a/src/layers/filters/NoiseFilter.cpp
+++ b/src/layers/filters/NoiseFilter.cpp
@@ -144,9 +144,8 @@ std::shared_ptr<Image> NoiseFilter::onFilterImage(std::shared_ptr<Image> input, 
   if (_density == 0.0f) {
     return input;
   }
-  // Anchor the noise pattern to the content bounds center, expressed in input image pixel space.
-  // contentBounds is already in the input image coordinate space (see Layer::mapContentBoundsToImage),
-  // so its center is the anchor position directly without an extra scale multiplication.
+  // contentBounds has already folded in the layer-local content offset, so its center directly
+  // matches the anchor used by NoiseStyle.
   Point shift = {contentBounds.centerX(), contentBounds.centerY()};
   auto noiseShader = buildAtShift(scale, shift);
   if (noiseShader == nullptr) {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -222,7 +222,7 @@
         "TileClear_PartialTileWithNewLayer": "bf48e614"
     },
     "LayerFilterTest": {
-        "AnchorStability": "a8bfb235",
+        "AnchorStability": "22739e1e",
         "BasicMonoDuoMulti": "a8bfb235",
         "BlendMode": "a8bfb235",
         "DensitySweep": "a8bfb235",


### PR DESCRIPTION
本次修改主要修复多个噪声滤镜同时渲染时，Perlin 噪声贴图可能被复用导致画面闪烁的问题。

核心原因是 PerlinNoiseFragmentProcessor 之前只保存从 TextureView 中取出的 Texture，而 TextureView::MakeAlpha() 和 TextureView::MakeRGBA() 创建的资源来自 scratch cache。当 TextureView 本身提前释放后，对应 scratch 资源可能被后续噪声滤镜复用或覆盖，导致多个噪声实例之间采样到不稳定的排列表和噪声纹理。

本次改为让 PerlinNoiseFragmentProcessor 持有完整的 TextureView，并在采样时通过 TextureView 获取底层 Texture，从而保证噪声相关 GPU 资源在 fragment processor 生命周期内不会被错误回收或复用。