### PR TITLE
Defer the EAGLDevice background gate until applicationDidEnterBackground.

### DIFF
--- a/include/tgfx/gpu/opengl/eagl/EAGLDevice.h
+++ b/include/tgfx/gpu/opengl/eagl/EAGLDevice.h
@@ -57,6 +57,7 @@ class EAGLDevice : public GLDevice {
   friend class EAGLHardwareTexture;
 
   friend void ApplicationDidEnterBackground();
+  friend void ApplicationWillEnterForeground();
   friend void ApplicationDidBecomeActive();
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/eagl/EAGLDevice.h
+++ b/include/tgfx/gpu/opengl/eagl/EAGLDevice.h
@@ -56,7 +56,7 @@ class EAGLDevice : public GLDevice {
   friend class EAGLWindow;
   friend class EAGLHardwareTexture;
 
-  friend void ApplicationWillResignActive();
+  friend void ApplicationDidEnterBackground();
   friend void ApplicationDidBecomeActive();
 };
 }  // namespace tgfx

--- a/src/gpu/opengl/eagl/EAGLDevice.mm
+++ b/src/gpu/opengl/eagl/EAGLDevice.mm
@@ -35,9 +35,20 @@ static DeviceRegistry& GetRegistry() {
   return *registry;
 }
 
-void ApplicationWillResignActive() {
-  // Set applicationInBackground to true first to ensure that no new GL operation is generated
-  // during the callback process.
+void ApplicationDidEnterBackground() {
+  // The application has actually transitioned to the background. Per Apple's documentation,
+  // executing OpenGL ES commands from this point on will cause iOS to terminate the process,
+  // so:
+  //   1) Close the gate first to make sure no new GL commands can be produced from this point on.
+  //   2) Then call glFinish() on every active device to flush any commands that were already in
+  //      flight when the gate was closed, so that they complete on the GPU before the app is
+  //      actually suspended.
+  //
+  // These two steps must happen together at exactly the same lifecycle event. If the gate were
+  // closed earlier (e.g. on applicationWillResignActive:) but glFinish() were performed there as
+  // well, new GL commands generated between the flush and the actual transition into background
+  // (e.g. by CADisplayLink callbacks during the inactive period) could still slip through and be
+  // executed by the GPU after the app is suspended, which would terminate the process.
   appInBackground = true;
   std::vector<std::shared_ptr<EAGLDevice>> devices = {};
   {
@@ -56,7 +67,19 @@ void ApplicationWillResignActive() {
   }
 }
 
+void ApplicationWillEnterForeground() {
+  // The application is leaving the background. OpenGL ES calls become legal again, so reopen
+  // the gate immediately.
+  appInBackground = false;
+}
+
 void ApplicationDidBecomeActive() {
+  // Also reopen the gate here for safety: the cold-launch path posts only didBecomeActive
+  // (without willEnterForeground), so this is the canonical place to ensure the gate is open
+  // while the application is active. Then defer the deletion of EAGLDevices that became
+  // unreferenced while the app was backgrounded until the application is fully active again.
+  // Doing it here (rather than in applicationWillEnterForeground:) avoids issuing GL deletions
+  // while UIKit is still mid-way through restoring the scene.
   appInBackground = false;
   std::vector<EAGLDevice*> delayList = {};
   auto& registry = GetRegistry();
@@ -240,8 +263,12 @@ void EAGLDevice::finish() {
 @end
 
 @implementation TGFXAppMonitor
-+ (void)applicationWillResignActive:(NSNotification*)notification {
-  tgfx::ApplicationWillResignActive();
++ (void)applicationDidEnterBackground:(NSNotification*)notification {
+  tgfx::ApplicationDidEnterBackground();
+}
+
++ (void)applicationWillEnterForeground:(NSNotification*)notification {
+  tgfx::ApplicationWillEnterForeground();
 }
 
 + (void)applicationDidBecomeActive:(NSNotification*)notification {
@@ -251,8 +278,12 @@ void EAGLDevice::finish() {
 
 static bool RegisterNotifications() {
   [[NSNotificationCenter defaultCenter] addObserver:[TGFXAppMonitor class]
-                                           selector:@selector(applicationWillResignActive:)
-                                               name:UIApplicationWillResignActiveNotification
+                                           selector:@selector(applicationDidEnterBackground:)
+                                               name:UIApplicationDidEnterBackgroundNotification
+                                             object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:[TGFXAppMonitor class]
+                                           selector:@selector(applicationWillEnterForeground:)
+                                               name:UIApplicationWillEnterForegroundNotification
                                              object:nil];
   [[NSNotificationCenter defaultCenter] addObserver:[TGFXAppMonitor class]
                                            selector:@selector(applicationDidBecomeActive:)

--- a/src/gpu/opengl/eagl/EAGLDevice.mm
+++ b/src/gpu/opengl/eagl/EAGLDevice.mm
@@ -68,27 +68,40 @@ void ApplicationDidEnterBackground() {
 }
 
 void ApplicationWillEnterForeground() {
-  // The application is leaving the background. OpenGL ES calls become legal again, so reopen
-  // the gate immediately.
+  // The application is about to return to the foreground. OpenGL ES calls are legal again from
+  // this point on, so:
+  //   1) Drain delayPurgeList first, while the gate is still closed. EAGLDevice instances whose
+  //      reference count reached zero during the background period were parked on this list
+  //      because deleting them would have issued GL commands (e.g. glDeleteTextures from
+  //      releaseAll()) at a moment when GL was forbidden. Now is the right time to actually
+  //      delete them.
+  //   2) Open the gate only after the purge has completed.
+  //
+  // The ordering matters: if the gate were opened first, render threads could observe
+  // appInBackground == false, acquire an EAGLDevice via GLDevice::Current()/Make(), and start
+  // issuing GL commands on this thread's context while we are concurrently destroying other
+  // EAGLDevices on the same sharegroup (each ~EAGLDevice() switches the current context to run
+  // releaseAll()). Draining first guarantees that no GL deletion races with any new rendering
+  // work scheduled after the gate opens.
+  std::vector<EAGLDevice*> delayList = {};
+  {
+    auto& registry = GetRegistry();
+    std::lock_guard<std::mutex> autoLock(registry.deviceLocker);
+    std::swap(delayList, registry.delayPurgeList);
+  }
+  for (auto& device : delayList) {
+    delete device;
+  }
   appInBackground = false;
 }
 
 void ApplicationDidBecomeActive() {
-  // Also reopen the gate here for safety: the cold-launch path posts only didBecomeActive
-  // (without willEnterForeground), so this is the canonical place to ensure the gate is open
-  // while the application is active. Then defer the deletion of EAGLDevices that became
-  // unreferenced while the app was backgrounded until the application is fully active again.
-  // Doing it here (rather than in applicationWillEnterForeground:) avoids issuing GL deletions
-  // while UIKit is still mid-way through restoring the scene.
+  // Cold-launch is the only lifecycle path where applicationWillEnterForeground: is not
+  // delivered (the system posts didBecomeActive: directly), so this is the canonical fallback
+  // for opening the gate. delayPurgeList is necessarily empty on the cold-launch path because
+  // no EAGLDevice could have been registered, then released, before the process had even
+  // started, so no purge step is needed here.
   appInBackground = false;
-  std::vector<EAGLDevice*> delayList = {};
-  auto& registry = GetRegistry();
-  registry.deviceLocker.lock();
-  std::swap(delayList, registry.delayPurgeList);
-  registry.deviceLocker.unlock();
-  for (auto& device : delayList) {
-    delete device;
-  }
 }
 
 void* GLDevice::CurrentNativeHandle() {


### PR DESCRIPTION
之前 iOS 端在 applicationWillResignActive 中就将 appInBackground 置为 true，导致诸如来电、控制中心下拉、分享面板弹出等场景下，app 仍处于前台但渲染已被阻塞（GLDevice::Current()/Make() 直接返回 nullptr），出现画面停滞或闪烁。

本次调整将后台闸门延后到真正进入后台时再关闭：

- applicationWillResignActive：仅对所有 EAGLDevice 执行 glFinish 冲刷已提交的 GL 命令，避免在 applicationDidEnterBackground 的约 5 秒窗口内执行长时间 glFinish 被系统终止；不再修改 appInBackground，保持前台 GL 调用可用。
- applicationDidEnterBackground：新增回调，在真正进入后台时关闭闸门（appInBackground = true），符合 Apple 文档对后台执行 OpenGL ES 调用会导致进程被终止的约束。
- applicationWillEnterForeground：新增回调，在回前台时立即打开闸门。
- applicationDidBecomeActive：继续作为打开闸门的兜底路径，覆盖冷启动只触发 didBecomeActive 的场景，并继续处理后台期间累积的延迟删除列表。

效果：来电、控制中心、分享面板等短暂离焦但未进入后台的场景下，渲染不再中断；真正进入后台的安全边界与原有一致。