### PR TITLE
Fix inner radius boundary check for zero-width rounded rect strokes.

### DIFF
--- a/src/gpu/RRectsVertexProvider.cpp
+++ b/src/gpu/RRectsVertexProvider.cpp
@@ -248,7 +248,7 @@ class AARRectsVertexProvider final : public RRectsVertexProvider {
       if (stroke) {
         innerXRadius = xRadius - strokeParams.halfStrokeX;
         innerYRadius = yRadius - strokeParams.halfStrokeY;
-        stroked = innerXRadius > 0.0f && innerYRadius > 0.0f;
+        stroked = innerXRadius >= 0.0f && innerYRadius >= 0.0f;
         xRadius += strokeParams.halfStrokeX;
         yRadius += strokeParams.halfStrokeY;
         rectBounds.outset(strokeParams.halfStrokeX, strokeParams.halfStrokeY);

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -28,6 +28,7 @@
     },
     "CanvasTest": {
         "AARRectOp": "f377f9d5d",
+        "AARRectOpZeroInnerRadius": "7ad889d5",
         "BlendFormula": "543054b5",
         "CMYKWithoutICCProfile": "29dde9e0",
         "ClipAntiAlias": "c37a86c8",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -2226,6 +2226,29 @@ TGFX_TEST(CanvasTest, NonAARRectOpStroke) {
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/NonAARRectOpStroke"));
 }
 
+TGFX_TEST(CanvasTest, AARRectOpZeroInnerRadius) {
+  // Verifies the boundary case where the stroke half-width exactly equals the corner radius,
+  // making the inner radius zero. The AA stroke path must still treat this as stroked rather
+  // than falling back to a filled shape.
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 400, 190);
+  ASSERT_TRUE(surface != nullptr);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+
+  Paint paint;
+  paint.setStyle(PaintStyle::Stroke);
+  paint.setStroke(Stroke(30));
+  paint.setColor(Color::Red());
+  // RRect 270x60 with corner radius 15. halfStroke (15) equals the corner radius, so the inner
+  // radius is exactly zero, exercising the >= boundary in AARRectsVertexProvider.
+  canvas->drawRRect(RRect::MakeRectXY(Rect::MakeXYWH(65, 65, 270, 60), 15, 15), paint);
+
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/AARRectOpZeroInnerRadius"));
+}
+
 TGFX_TEST(CanvasTest, NonAARRectOpTransform) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
当描边宽度为 0 时，内半径可能等于 0。修改判断条件从 > 改为 >=，允许内半径等于 0 的情况，避免在零宽度描边场景下出现渲染错误。