### PR TITLE
Fix clip mask vertical flip on BottomLeft origin surfaces

### DIFF
--- a/src/gpu/OpsCompositor.cpp
+++ b/src/gpu/OpsCompositor.cpp
@@ -755,8 +755,9 @@ AppliedClip OpsCompositor::applyClip(const ClipStack& clipStack) {
     return out;
   }
   clipBounds.roundOut();
-  FlipYIfNeeded(&clipBounds, renderTarget.get());
-  out.scissor = clipBounds;
+  auto scissorBounds = clipBounds;
+  FlipYIfNeeded(&scissorBounds, renderTarget.get());
+  out.scissor = scissorBounds;
 
   // Stage 3: Iterate through valid elements.
   auto& elements = clipStack.elements();

--- a/src/gpu/opengl/qt/QGLDrawableProxy.h
+++ b/src/gpu/opengl/qt/QGLDrawableProxy.h
@@ -48,7 +48,7 @@ class QGLDrawableProxy : public RenderTargetProxy {
   int _height = 0;
   PixelFormat _format = PixelFormat::RGBA_8888;
   int _sampleCount = 1;
-  ImageOrigin _origin = ImageOrigin::BottomLeft;
+  ImageOrigin _origin = ImageOrigin::TopLeft;
   QGLWindow* _window = nullptr;
   mutable std::shared_ptr<RenderTargetProxy> textureRTProxy = nullptr;
   std::weak_ptr<RenderTargetProxy> weakThis;

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -194,7 +194,7 @@ std::shared_ptr<RenderTargetProxy> QGLWindow::onCreateRenderTarget(Context* cont
     return nullptr;
   }
   drawableProxy = std::make_shared<QGLDrawableProxy>(context, width, height, PixelFormat::RGBA_8888,
-                                                     1, ImageOrigin::BottomLeft, this);
+                                                     1, ImageOrigin::TopLeft, this);
   std::static_pointer_cast<QGLDrawableProxy>(drawableProxy)->weakThis = drawableProxy;
   return drawableProxy;
 }

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -552,8 +552,7 @@
         "ZoomUpTinyStrokeShape": "cd6a8dff"
     },
     "SurfaceRenderTest": {
-        "ClipPath_BottomLeft": "fdf3a44b",
-        "ClipPath_TopLeft": "fdf3a44b",
+        "ClipPathOrigin": "fdf3a44b",
         "EmptyLocalBounds": "bf48e614",
         "ImageSnapshot1": "bf48e614",
         "ImageSnapshot2": "bf48e614",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -552,6 +552,8 @@
         "ZoomUpTinyStrokeShape": "cd6a8dff"
     },
     "SurfaceRenderTest": {
+        "ClipPath_BottomLeft": "fdf3a44b",
+        "ClipPath_TopLeft": "fdf3a44b",
         "EmptyLocalBounds": "bf48e614",
         "ImageSnapshot1": "bf48e614",
         "ImageSnapshot2": "bf48e614",

--- a/test/src/SurfaceRenderTest.cpp
+++ b/test/src/SurfaceRenderTest.cpp
@@ -149,4 +149,56 @@ TGFX_TEST(SurfaceRenderTest, OutOfRenderTarget) {
   EXPECT_TRUE(Baseline::Compare(surface, "SurfaceRenderTest/OutOfRenderTarget"));
 }
 
+TGFX_TEST(SurfaceRenderTest, ClipPathOrigin) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto width = 200;
+  auto height = 300;
+
+  Path trianglePath;
+  trianglePath.moveTo(100, 50);
+  trianglePath.lineTo(150, 120);
+  trianglePath.lineTo(50, 120);
+  trianglePath.close();
+
+  Paint paint;
+  paint.setColor(Color::Red());
+
+  auto topLeftSurface = Surface::Make(context, width, height);
+  ASSERT_TRUE(topLeftSurface != nullptr);
+  auto canvas = topLeftSurface->getCanvas();
+  canvas->clear(Color::White());
+  canvas->save();
+  canvas->clipPath(trianglePath);
+  canvas->drawRect(Rect::MakeWH(width, height), paint);
+  canvas->restore();
+  EXPECT_TRUE(Baseline::Compare(topLeftSurface, "SurfaceRenderTest/ClipPath_TopLeft"));
+
+  auto texture = context->gpu()->createTexture({width, height, PixelFormat::RGBA_8888});
+  ASSERT_TRUE(texture != nullptr);
+  auto bottomLeftSurface =
+      Surface::MakeFrom(context, texture->getBackendTexture(), ImageOrigin::BottomLeft);
+  ASSERT_TRUE(bottomLeftSurface != nullptr);
+  canvas = bottomLeftSurface->getCanvas();
+  canvas->clear(Color::White());
+  canvas->save();
+  canvas->clipPath(trianglePath);
+  canvas->drawRect(Rect::MakeWH(width, height), paint);
+  canvas->restore();
+  EXPECT_TRUE(Baseline::Compare(bottomLeftSurface, "SurfaceRenderTest/ClipPath_BottomLeft"));
+
+  auto colorSpace = topLeftSurface->colorSpace();
+  auto info =
+      ImageInfo::Make(width, height, ColorType::RGBA_8888, AlphaType::Premultiplied, 0, colorSpace);
+  Buffer topLeftBuffer(info.byteSize());
+  Buffer bottomLeftBuffer(info.byteSize());
+  ASSERT_TRUE(topLeftSurface->readPixels(info, topLeftBuffer.data()));
+  ASSERT_TRUE(bottomLeftSurface->readPixels(info, bottomLeftBuffer.data()));
+  bool pixelsMatch = memcmp(topLeftBuffer.data(), bottomLeftBuffer.data(), info.byteSize()) == 0;
+  EXPECT_TRUE(pixelsMatch)
+      << "ClipPath rendering differs between TopLeft and BottomLeft origin surfaces. "
+         "The clip mask may be vertically flipped on BottomLeft surfaces.";
+}
+
 }  // namespace tgfx

--- a/test/src/SurfaceRenderTest.cpp
+++ b/test/src/SurfaceRenderTest.cpp
@@ -173,7 +173,7 @@ TGFX_TEST(SurfaceRenderTest, ClipPathOrigin) {
   canvas->clipPath(trianglePath);
   canvas->drawRect(Rect::MakeWH(width, height), paint);
   canvas->restore();
-  EXPECT_TRUE(Baseline::Compare(topLeftSurface, "SurfaceRenderTest/ClipPath_TopLeft"));
+  EXPECT_TRUE(Baseline::Compare(topLeftSurface, "SurfaceRenderTest/ClipPathOrigin"));
 
   auto texture = context->gpu()->createTexture({width, height, PixelFormat::RGBA_8888});
   ASSERT_TRUE(texture != nullptr);
@@ -186,19 +186,7 @@ TGFX_TEST(SurfaceRenderTest, ClipPathOrigin) {
   canvas->clipPath(trianglePath);
   canvas->drawRect(Rect::MakeWH(width, height), paint);
   canvas->restore();
-  EXPECT_TRUE(Baseline::Compare(bottomLeftSurface, "SurfaceRenderTest/ClipPath_BottomLeft"));
-
-  auto colorSpace = topLeftSurface->colorSpace();
-  auto info =
-      ImageInfo::Make(width, height, ColorType::RGBA_8888, AlphaType::Premultiplied, 0, colorSpace);
-  Buffer topLeftBuffer(info.byteSize());
-  Buffer bottomLeftBuffer(info.byteSize());
-  ASSERT_TRUE(topLeftSurface->readPixels(info, topLeftBuffer.data()));
-  ASSERT_TRUE(bottomLeftSurface->readPixels(info, bottomLeftBuffer.data()));
-  bool pixelsMatch = memcmp(topLeftBuffer.data(), bottomLeftBuffer.data(), info.byteSize()) == 0;
-  EXPECT_TRUE(pixelsMatch)
-      << "ClipPath rendering differs between TopLeft and BottomLeft origin surfaces. "
-         "The clip mask may be vertically flipped on BottomLeft surfaces.";
+  EXPECT_TRUE(Baseline::Compare(bottomLeftSurface, "SurfaceRenderTest/ClipPathOrigin"));
 }
 
 }  // namespace tgfx


### PR DESCRIPTION
## Summary

Fixes an incorrect clip mask placement on render targets with `ImageOrigin::BottomLeft`. Two related root causes were addressed:

1. **`OpsCompositor::applyClip`** mutated `clipBounds` in place via `FlipYIfNeeded` and then reused the (now window-space) rect for both the scissor and the downstream mask FP. The mask FP path applies `getOriginTransform()` itself when origin is `BottomLeft`, producing a double Y-flip and mis-sampled mask.
2. **`QGLDrawableProxy`** advertised `ImageOrigin::BottomLeft`, but its underlying render target (created via `RenderTargetProxy::Make`) is actually `TopLeft`. The mismatched metadata is what triggered path (1) on Qt GL surfaces.

## Changes

- `src/gpu/OpsCompositor.cpp`: split `clipBounds` (logical/TopLeft, used by mask FP) from `scissorBounds` (window space, possibly Y-flipped, used by `glScissor`).
- `src/gpu/opengl/qt/QGLDrawableProxy.h` / `QGLWindow.cpp`: report `ImageOrigin::TopLeft` to match the wrapped texture.

Other `FlipYIfNeeded` call sites (`makeAnalyticFP`, `makeDstTextureInfo`) were already correct and remain unchanged. Other Window backends (EGL/CGL/EAGL/WGL/WebGL) wrap external native render targets that legitimately are `BottomLeft` and do not need the same change.