### PR TITLE
Added missing <cstdint> headers

### DIFF
--- a/include/tgfx/core/Data.h
+++ b/include/tgfx/core/Data.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/include/tgfx/core/Matrix.h
+++ b/include/tgfx/core/Matrix.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include "tgfx/core/Rect.h"
 #include "tgfx/core/Vec.h"

--- a/src/core/AtlasTypes.h
+++ b/src/core/AtlasTypes.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include "RectPackSkyline.h"
 #include "core/utils/Log.h"


### PR DESCRIPTION
The project doesn't compile for me on the most recent version of GCC (16.1.1) without explicitly adding these headers in these files