### PR TITLE
Fix sNaN quieting in vertex color packing causing rendering color errors.

### DIFF
--- a/src/gpu/QuadsVertexProvider.cpp
+++ b/src/gpu/QuadsVertexProvider.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "QuadsVertexProvider.h"
+#include <cstring>
 #include <optional>
 #include "core/ColorSpaceXformSteps.h"
 #include "core/utils/ColorHelper.h"
@@ -391,11 +392,11 @@ static inline void ComputeAAVerticesDegenerate(const Vertices4& vertices, const 
  * @param coord The 4 vertices of the quad in Z-order.
  * @param coverage Coverage value for AA (1.0 for inner, 0.0 for outer).
  * @param uvCoord Optional UV coordinates for texture mapping.
- * @param color Optional compressed color value to write.
+ * @param color Optional packed uint32 color value to write.
  */
 static inline void WriteQuadVertices(float* vertices, size_t& index, const Vertices4& coord,
                                      float coverage, const std::optional<Vertices4>& uvCoord,
-                                     const std::optional<float>& color) {
+                                     const std::optional<uint32_t>& color) {
   for (int i = 0; i < 4; ++i) {
     vertices[index++] = coord.xs[i];
     vertices[index++] = coord.ys[i];
@@ -405,7 +406,7 @@ static inline void WriteQuadVertices(float* vertices, size_t& index, const Verti
       vertices[index++] = uvCoord->ys[i];
     }
     if (color) {
-      vertices[index++] = *color;
+      std::memcpy(&vertices[index++], &*color, sizeof(*color));
     }
   }
 }
@@ -444,10 +445,9 @@ class NonAAQuadsVertexProvider : public QuadsVertexProvider {
     }
     for (size_t i = 0; i < quads.size(); ++i) {
       auto& record = quads[i];
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (_hasColor) {
-        const auto uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<const float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
       auto transformedQuad = record->quad;
       transformedQuad.transform(record->matrix);
@@ -461,7 +461,7 @@ class NonAAQuadsVertexProvider : public QuadsVertexProvider {
           vertices[index++] = uv.y;
         }
         if (_hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
       }
     }
@@ -546,10 +546,9 @@ class AAQuadsVertexProvider : public QuadsVertexProvider {
       }
     }
 
-    std::optional<float> color = std::nullopt;
+    std::optional<uint32_t> color = std::nullopt;
     if (_hasColor) {
-      const auto uintColor = ToUintPMColor(record.color, steps);
-      color = *reinterpret_cast<const float*>(&uintColor);
+      color = ToUintPMColor(record.color, steps);
     }
 
     WriteQuadVertices(vertices, index, insetCoord, 1.0f, insetUV, color);

--- a/src/gpu/RRectsVertexProvider.cpp
+++ b/src/gpu/RRectsVertexProvider.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "RRectsVertexProvider.h"
+#include <cstring>
 #include "core/utils/ColorHelper.h"
 #include "core/utils/ColorSpaceHelper.h"
 #include "core/utils/Log.h"
@@ -230,10 +231,9 @@ class AARRectsVertexProvider final : public RRectsVertexProvider {
       auto viewMatrix = record->viewMatrix;
       auto rRect = record->rRect;
       auto scales = viewMatrix.getAxisScales();
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
 
       auto stroke = strokes.size() > currentIndex ? strokes[currentIndex].get() : nullptr;
@@ -288,7 +288,7 @@ class AARRectsVertexProvider final : public RRectsVertexProvider {
         vertices[index++] = point.x;
         vertices[index++] = point.y;
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         vertices[index++] = xMaxOffset;
         vertices[index++] = yOuterOffsets[i];
@@ -302,7 +302,7 @@ class AARRectsVertexProvider final : public RRectsVertexProvider {
         vertices[index++] = point.x;
         vertices[index++] = point.y;
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         vertices[index++] = FLOAT_NEARLY_ZERO;
         vertices[index++] = yOuterOffsets[i];
@@ -316,7 +316,7 @@ class AARRectsVertexProvider final : public RRectsVertexProvider {
         vertices[index++] = point.x;
         vertices[index++] = point.y;
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         vertices[index++] = FLOAT_NEARLY_ZERO;
         vertices[index++] = yOuterOffsets[i];
@@ -330,7 +330,7 @@ class AARRectsVertexProvider final : public RRectsVertexProvider {
         vertices[index++] = point.x;
         vertices[index++] = point.y;
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         vertices[index++] = xMaxOffset;
         vertices[index++] = yOuterOffsets[i];
@@ -381,10 +381,9 @@ class NonAARRectsVertexProvider final : public RRectsVertexProvider {
       DEBUG_ASSERT(!record->rRect.isComplex());
       auto viewMatrix = record->viewMatrix;
       auto rRect = record->rRect;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
 
       auto scales = viewMatrix.getAxisScales();
@@ -431,7 +430,7 @@ class NonAARRectsVertexProvider final : public RRectsVertexProvider {
         vertices[index++] = rect.bottom;
         // Optional color
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         // strokeWidth (2 floats) - only for stroke mode
         if (bitFields.hasStroke) {
@@ -483,10 +482,9 @@ class AAComplexRRectsVertexProvider final : public RRectsVertexProvider {
       auto viewMatrix = record->viewMatrix;
       auto rRect = record->rRect;
       auto scales = viewMatrix.getAxisScales();
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
 
       auto stroke = strokes.size() > currentIndex ? strokes[currentIndex].get() : nullptr;
@@ -543,7 +541,7 @@ class AAComplexRRectsVertexProvider final : public RRectsVertexProvider {
           vertices[index++] = point.x;
           vertices[index++] = point.y;
           if (bitFields.hasColor) {
-            vertices[index++] = compressedColor;
+            std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
           }
           vertices[index++] = xOffset;
           vertices[index++] = yOffset;
@@ -600,10 +598,9 @@ class NonAAComplexRRectsVertexProvider final : public RRectsVertexProvider {
     for (auto& record : rects) {
       auto viewMatrix = record->viewMatrix;
       auto rRect = record->rRect;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
 
       auto scales = viewMatrix.getAxisScales();
@@ -657,7 +654,7 @@ class NonAAComplexRRectsVertexProvider final : public RRectsVertexProvider {
         vertices[index++] = rect.bottom;
         // Optional color
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         // strokeWidth (2 floats) - only for stroke mode
         if (bitFields.hasStroke) {

--- a/src/gpu/RectsVertexProvider.cpp
+++ b/src/gpu/RectsVertexProvider.cpp
@@ -18,6 +18,7 @@
 
 #include "RectsVertexProvider.h"
 #include <array>
+#include <cstring>
 #include "core/ColorSpaceXformSteps.h"
 #include "core/utils/ColorHelper.h"
 #include "core/utils/ColorSpaceHelper.h"
@@ -80,10 +81,9 @@ class AARectsVertexProvider : public RectsVertexProvider {
       auto& record = rects[i];
       auto& viewMatrix = record->viewMatrix;
       auto& rect = record->rect;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
 
       auto scale = sqrtf(viewMatrix.getScaleX() * viewMatrix.getScaleX() +
@@ -121,7 +121,7 @@ class AARectsVertexProvider : public RectsVertexProvider {
             vertices[index++] = uvQuad.point(k).y;
           }
           if (bitFields.hasColor) {
-            vertices[index++] = compressedColor;
+            std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
           }
           if (needSubset) {
             WriteSubset(vertices, index, subset);
@@ -168,10 +168,9 @@ class NonAARectsVertexProvider : public RectsVertexProvider {
       auto& record = rects[i];
       auto& viewMatrix = record->viewMatrix;
       auto& rect = record->rect;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
       auto quad = Quad::MakeFrom(rect, &viewMatrix);
       auto& uvRect = hasUVRect ? *uvRects[i] : rect;
@@ -188,7 +187,7 @@ class NonAARectsVertexProvider : public RectsVertexProvider {
           vertices[index++] = uvQuad.point(j - 1).y;
         }
         if (bitFields.hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
         if (needSubset) {
           WriteSubset(vertices, index, subset);
@@ -217,7 +216,7 @@ class AAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
   }
 
   void writeQuad(float* vertices, size_t& index, const Quad& quad, const Quad& uvQuad,
-                 float compressedColor, float coverage) const {
+                 uint32_t uintColor, float coverage) const {
     for (size_t i = 0; i < 4; ++i) {
       vertices[index++] = quad.point(i).x;
       vertices[index++] = quad.point(i).y;
@@ -227,7 +226,7 @@ class AAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
         vertices[index++] = uvQuad.point(i).y;
       }
       if (bitFields.hasColor) {
-        vertices[index++] = compressedColor;
+        std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
       }
     }
   }
@@ -273,10 +272,9 @@ class AAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
       auto inUV = inSide;
       auto assistUV = outSideAssist;
       float vOffset = 0.0f;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
       if (hasUVCoord) {
         auto& uvRect = *uvRects[i];
@@ -332,27 +330,27 @@ class AAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
       if (hasUVCoord) {
         uvQuad = Quad::MakeFrom(outUV.makeOutset(outset, outset));
       }
-      writeQuad(vertices, index, outOutsetQuad, uvQuad, compressedColor, outerCoverage);
+      writeQuad(vertices, index, outOutsetQuad, uvQuad, uintColor, outerCoverage);
       if (isBevelJoin) {
         const auto assistOutsetQuad =
             Quad::MakeFrom(outSideAssist.makeOutset(outset, outset), &viewMatrix);
         if (hasUVCoord) {
           uvQuad = Quad::MakeFrom(assistUV.makeOutset(outset, outset));
         }
-        writeQuad(vertices, index, assistOutsetQuad, uvQuad, compressedColor, outerCoverage);
+        writeQuad(vertices, index, assistOutsetQuad, uvQuad, uintColor, outerCoverage);
       }
       const auto outInsetQuad = Quad::MakeFrom(outSide.makeInset(inset, inset), &viewMatrix);
       if (hasUVCoord) {
         uvQuad = Quad::MakeFrom(outUV.makeInset(inset, inset));
       }
-      writeQuad(vertices, index, outInsetQuad, uvQuad, compressedColor, innerCoverage);
+      writeQuad(vertices, index, outInsetQuad, uvQuad, uintColor, innerCoverage);
       if (isBevelJoin) {
         const auto assistInsetQuad =
             Quad::MakeFrom(outSideAssist.makeInset(inset, inset), &viewMatrix);
         if (hasUVCoord) {
           uvQuad = Quad::MakeFrom(assistUV.makeInset(inset, inset));
         }
-        writeQuad(vertices, index, assistInsetQuad, uvQuad, compressedColor, innerCoverage);
+        writeQuad(vertices, index, assistInsetQuad, uvQuad, uintColor, innerCoverage);
       }
       if (!isDegenerate) {
         // Interior inset rect (toward stroke).
@@ -360,7 +358,7 @@ class AAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
         if (hasUVCoord) {
           uvQuad = Quad::MakeFrom(inUV.makeOutset(inset, inset));
         }
-        writeQuad(vertices, index, innerInsetQuad, uvQuad, compressedColor, innerCoverage);
+        writeQuad(vertices, index, innerInsetQuad, uvQuad, uintColor, innerCoverage);
         // Interior outset rect (away from stroke, toward center of rect).
         Rect interiorAABoundary = inSide.makeInset(interiorOutset, interiorOutset);
         float coverageBackset = 0.0f;  // Adds back coverage when the interior AA edges cross.
@@ -391,15 +389,15 @@ class AAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
           }
           uvQuad = Quad::MakeFrom(uvBoundary);
         }
-        writeQuad(vertices, index, innerAAQuad, uvQuad, compressedColor, interiorCoverage);
+        writeQuad(vertices, index, innerAAQuad, uvQuad, uintColor, interiorCoverage);
       } else {
         // When the interior rect has become degenerate we smoosh to a single point
         const auto innerQuad = Quad::MakeFrom(inSide, &viewMatrix);
         if (hasUVCoord) {
           uvQuad = Quad::MakeFrom(inUV);
         }
-        writeQuad(vertices, index, innerQuad, uvQuad, compressedColor, innerCoverage);
-        writeQuad(vertices, index, innerQuad, uvQuad, compressedColor, innerCoverage);
+        writeQuad(vertices, index, innerQuad, uvQuad, uintColor, innerCoverage);
+        writeQuad(vertices, index, innerQuad, uvQuad, uintColor, innerCoverage);
       }
     }
   }
@@ -424,7 +422,7 @@ class NonAAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
   }
 
   void writeQuad(float* vertices, size_t& index, const Quad& quad, const Quad& uvQuad,
-                 float compressedColor) const {
+                 uint32_t uintColor) const {
     for (size_t i = 0; i < 4; ++i) {
       vertices[index++] = quad.point(i).x;
       vertices[index++] = quad.point(i).y;
@@ -433,7 +431,7 @@ class NonAAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
         vertices[index++] = uvQuad.point(i).y;
       }
       if (bitFields.hasColor) {
-        vertices[index++] = compressedColor;
+        std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
       }
     }
   }
@@ -481,10 +479,9 @@ class NonAAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
       auto inUV = inSide;
       auto assistUV = outSideAssist;
       auto vOffset = 0.0f;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
       if (hasUVCoord) {
         auto& uvRect = *uvRects[i];
@@ -521,19 +518,19 @@ class NonAAAngularStrokeRectsVertexProvider final : public RectsVertexProvider {
       if (hasUVCoord) {
         uvQuad = Quad::MakeFrom(outUV);
       }
-      writeQuad(vertices, index, outQuad, uvQuad, compressedColor);
+      writeQuad(vertices, index, outQuad, uvQuad, uintColor);
       if (lineJoin() == LineJoin::Bevel) {
         const auto assistQuad = Quad::MakeFrom(outSideAssist, &viewMatrix);
         if (hasUVCoord) {
           uvQuad = Quad::MakeFrom(assistUV);
         }
-        writeQuad(vertices, index, assistQuad, uvQuad, compressedColor);
+        writeQuad(vertices, index, assistQuad, uvQuad, uintColor);
       }
       const auto inQuad = Quad::MakeFrom(inSide, &viewMatrix);
       if (hasUVCoord) {
         uvQuad = Quad::MakeFrom(inUV);
       }
-      writeQuad(vertices, index, inQuad, uvQuad, compressedColor);
+      writeQuad(vertices, index, inQuad, uvQuad, uintColor);
     }
   }
 };
@@ -582,10 +579,9 @@ class AARoundStrokeRectsVertexProvider final : public RectsVertexProvider {
       auto viewMatrix = record->viewMatrix;
       auto scales = viewMatrix.getAxisScales();
       auto rect = record->rect;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
       rect.scale(scales.x, scales.y);
       viewMatrix.preScale(1.0f / scales.x, 1.0f / scales.y);
@@ -639,7 +635,7 @@ class AARoundStrokeRectsVertexProvider final : public RectsVertexProvider {
             vertices[index++] = vCoords[k];
           }
           if (hasColor) {
-            vertices[index++] = compressedColor;
+            std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
           }
         }
       }
@@ -686,7 +682,7 @@ class AARoundStrokeRectsVertexProvider final : public RectsVertexProvider {
             vertices[index++] = uvQuad.point(k).y;
           }
           if (hasColor) {
-            vertices[index++] = compressedColor;
+            std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
           }
         }
       }
@@ -738,10 +734,9 @@ class NonAARoundStrokeRectsVertexProvider final : public RectsVertexProvider {
       auto viewMatrix = record->viewMatrix;
       auto scales = viewMatrix.getAxisScales();
       auto rect = record->rect;
-      float compressedColor = 0.f;
+      uint32_t uintColor = 0;
       if (bitFields.hasColor) {
-        uint32_t uintColor = ToUintPMColor(record->color, steps.get());
-        compressedColor = *reinterpret_cast<float*>(&uintColor);
+        uintColor = ToUintPMColor(record->color, steps.get());
       }
       rect.scale(scales.x, scales.y);
       viewMatrix.preScale(1.0f / scales.x, 1.0f / scales.y);
@@ -784,7 +779,7 @@ class NonAARoundStrokeRectsVertexProvider final : public RectsVertexProvider {
             vertices[index++] = vCoords[k];
           }
           if (hasColor) {
-            vertices[index++] = compressedColor;
+            std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
           }
         }
       }
@@ -814,7 +809,7 @@ class NonAARoundStrokeRectsVertexProvider final : public RectsVertexProvider {
           vertices[index++] = inUVQuad.point(k).y;
         }
         if (hasColor) {
-          vertices[index++] = compressedColor;
+          std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));
         }
       }
     }


### PR DESCRIPTION
修复reinterpret_cast 进行 uint32 → float 类型双关
（type-punning）导致的颜色错误。

原代码通过 *reinterpret_cast<float*>(&uintColor) 将打包好的 uint32 颜色值“伪装”成
float 写入顶点缓冲区，期望按位原样保留。但当 uint32 的位模式恰好对应一个 sNaN
（signaling NaN）时，赋值过程中数据会被加载进浮点寄存器，硬件/编译器（默认浮点模型）
会将其静默化为 qNaN——即强制把尾数最高位置 1，从而修改原始位模式中的某一位。

颜色值 0xFF8B7464 解释为 float 时正好是一个 sNaN：
  位模式 1111 1111 1000 1011 0111 0100 0110 0100
        ^符号 ^^^^^^^^^^^指数全 1   ^尾数最高位为 0 → sNaN
经过浮点寄存器搬运后，尾数最高位被置 1，位模式变为
  1111 1111 1100 1011 0111 0100 0110 0100，即 0xFFCB7464。
顶点缓冲区中最终落盘的颜色由 0xFF8B7464 变成了 0xFFCB7464，渲染颜色出错。

该问题在 iOS 版微信小程序（WeChat）平台上已实测复现。

此外，reinterpret_cast 在 uint32 与 float 之间互转还违反了 C++ 严格别名规则
（strict aliasing），属于未定义行为，未来编译器优化策略变化时仍可能引入新的问题。

替换为 std::memcpy 后，数据按字节原样拷贝，全程不进入浮点寄存器，sNaN 静默化
不再发生，也消除了严格别名违规。

修改前（sNaN 静默化 + 严格别名违规）：
  float compressedColor = 0.f;
  if (bitFields.hasColor) {
    uint32_t uintColor = ToUintPMColor(record->color, steps.get());
    compressedColor = *reinterpret_cast<float*>(&uintColor);
  }
  vertices[index++] = compressedColor;

修改后（按字节拷贝，标准合规）：
  uint32_t uintColor = 0;
  if (bitFields.hasColor) {
    uintColor = ToUintPMColor(record->color, steps.get());
  }
  std::memcpy(&vertices[index++], &uintColor, sizeof(uintColor));

性能无影响：编译器对 4 字节定长 memcpy 会优化为与直接赋值相同的单条整数 mov 指令，
不走浮点路径。