### PR TITLE
Add Path::computeTightBounds() for exact bounding box computation.

### DIFF
--- a/include/tgfx/core/Path.h
+++ b/include/tgfx/core/Path.h
@@ -115,6 +115,16 @@ class Path {
   Rect getBounds() const;
 
   /**
+   * Returns the axis-aligned extrema (minimum and maximum values) of lines and curves in the Path.
+   * Returns (0, 0, 0, 0) if the Path contains no points. The bounds width and height may be larger
+   * or smaller than the area affected when drawing. Includes Point associated with kMove that
+   * define empty contours. Behaves identically to getBounds() when the Path contains only lines. If
+   * the Path contains curves, the computed bounds includes the maximum extent of the quad, conic, or
+   * cubic; is slower than getBounds(); and unlike getBounds(), does not cache the result.
+   */
+  Rect computeTightBounds() const;
+
+  /**
    * Returns true if Path is empty.
    */
   bool isEmpty() const;

--- a/src/core/Path.cpp
+++ b/src/core/Path.cpp
@@ -194,6 +194,11 @@ Rect Path::getBounds() const {
   return pathRef->getBounds();
 }
 
+Rect Path::computeTightBounds() const {
+  auto skRect = pathRef->path.computeTightBounds();
+  return {skRect.fLeft, skRect.fTop, skRect.fRight, skRect.fBottom};
+}
+
 bool Path::isEmpty() const {
   return pathRef->path.isEmpty();
 }


### PR DESCRIPTION
新增 Path::computeTightBounds() 接口，通过计算曲线段（quad/conic/cubic）的极值点来获取路径的精确包围盒。

与现有 getBounds() 的区别：
- getBounds() 返回所有控制点的包围框，对于贝塞尔曲线会偏大（因为控制点在曲线外侧）
- computeTightBounds() 对每段曲线求导并找到 X/Y 方向的极值点，返回数学上精确的轴对齐包围盒
- 仅包含直线段时两者结果相同
- computeTightBounds() 不缓存结果，计算开销较大

底层调用 pathkit 已有的 SkPath::computeTightBounds() 实现。