### PR TITLE
Fix null texture crash in FragmentProcessor::computeProcessorKey

### DIFF
--- a/src/gpu/processors/DeviceSpaceTextureEffect.cpp
+++ b/src/gpu/processors/DeviceSpaceTextureEffect.cpp
@@ -24,6 +24,10 @@ DeviceSpaceTextureEffect::DeviceSpaceTextureEffect(std::shared_ptr<TextureProxy>
     : FragmentProcessor(ClassID()), textureProxy(std::move(textureProxy)), uvMatrix(uvMatrix) {
 }
 
+size_t DeviceSpaceTextureEffect::onCountTextureSamplers() const {
+  return textureProxy->getTextureView() ? 1 : 0;
+}
+
 std::shared_ptr<Texture> DeviceSpaceTextureEffect::onTextureAt(size_t) const {
   auto textureView = textureProxy->getTextureView();
   return textureView == nullptr ? nullptr : textureView->getTexture();

--- a/src/gpu/processors/DeviceSpaceTextureEffect.h
+++ b/src/gpu/processors/DeviceSpaceTextureEffect.h
@@ -36,9 +36,7 @@ class DeviceSpaceTextureEffect : public FragmentProcessor {
 
   DeviceSpaceTextureEffect(std::shared_ptr<TextureProxy> textureProxy, const Matrix& uvMatrix);
 
-  size_t onCountTextureSamplers() const override {
-    return 1;
-  }
+  size_t onCountTextureSamplers() const override;
 
   std::shared_ptr<Texture> onTextureAt(size_t) const override;
 

--- a/src/gpu/processors/FragmentProcessor.cpp
+++ b/src/gpu/processors/FragmentProcessor.cpp
@@ -87,7 +87,10 @@ void FragmentProcessor::computeProcessorKey(Context* context, BytesKey* bytesKey
   onComputeProcessorKey(bytesKey);
   auto textureSamplerCount = onCountTextureSamplers();
   for (size_t i = 0; i < textureSamplerCount; ++i) {
-    TextureView::ComputeTextureKey(textureAt(i), bytesKey);
+    auto texture = textureAt(i);
+    if (texture != nullptr) {
+      TextureView::ComputeTextureKey(texture, bytesKey);
+    }
   }
   for (const auto& childProcessor : childProcessors) {
     childProcessor->computeProcessorKey(context, bytesKey);

--- a/src/gpu/processors/TextureGradientColorizer.h
+++ b/src/gpu/processors/TextureGradientColorizer.h
@@ -39,7 +39,7 @@ class TextureGradientColorizer : public FragmentProcessor {
   }
 
   size_t onCountTextureSamplers() const override {
-    return 1;
+    return gradient->getTextureView() ? 1 : 0;
   }
 
   std::shared_ptr<Texture> onTextureAt(size_t) const override {


### PR DESCRIPTION
## 问题

修复 `FragmentProcessor::computeProcessorKey` 中的空指针崩溃 (WINDOWS-DESKTOP-24)，发生在 `TextureProxy` 的纹理视图尚未就绪或已被释放时。

**崩溃堆栈：**

```
tgfx::Texture::format (Texture.h:123)                          ← EXCEPTION_ACCESS_VIOLATION_READ / 0x10
tgfx::TextureView::ComputeTextureKey (TextureView.cpp:44)
tgfx::FragmentProcessor::computeProcessorKey (FragmentProcessor.cpp:90)
tgfx::FragmentProcessor::computeProcessorKey (FragmentProcessor.cpp:93)
tgfx::GeometryProcessor::computeProcessorKey (GeometryProcessor.cpp:30)
tgfx::ProgramInfo::getProgram (ProgramInfo.cpp:122)
tgfx::ProgramInfo::ProgramInfo (ProgramInfo.cpp:35)
tgfx::DrawOp::execute (DrawOp.cpp:40)
tgfx::OpsRenderTask::execute (OpsRenderTask.cpp:41)
```

**根因：** `DeviceSpaceTextureEffect` 和 `TextureGradientColorizer` 的 `onCountTextureSamplers()` 硬编码返回 `1`，不考虑纹理是否可用。当运行时 `TextureProxy::getTextureView()` 返回 null 时，`computeProcessorKey` 中的循环调用 `textureAt(i)` 得到 nullptr，随后 `TextureView::ComputeTextureKey` 通过 `texture->format()` 解引用空指针，触发崩溃。

## 崩溃调用链

### 阶段 1 — Proxy 创建（`resource = nullptr`）

```
OpsCompositor::getClipMaskFP
  └─ OpsCompositor::makeClipTexture
       └─ RenderTargetProxy::Make(context, width, height, alphaOnly, ...)
            └─ ProxyProvider::createRenderTargetProxy(...)
                 └─ TextureRenderTargetProxy → DefaultTextureProxy → ResourceProxy()
                      // resource = nullptr（默认构造，尚未创建 GPU 纹理）
```

### 阶段 2 — Proxy 包装为 FragmentProcessor（`resource` 仍为 `nullptr`）

```
OpsCompositor::makeClipTexture
  ├─ textureProxy = clipRenderTarget->asTextureProxy()
  ├─ addOpsRenderTask(clipRenderTarget, ...)     // 入队，尚未执行
  └─ return textureProxy                         // resource 仍为 nullptr

OpsCompositor::makeMaskFP(textureProxy, ...)
  ├─ DeviceSpaceTextureEffect::Make(textureProxy, uvMatrix)
  └─ FragmentProcessor::MulInputByChildAlpha(maskFP)
       └─ XfermodeFragmentProcessor(dst = DeviceSpaceTextureEffect)
```

### 阶段 3 — 渲染触发 `computeProcessorKey`

```
DrawOp::execute
  └─ ProgramInfo::getProgram
       └─ for fragmentProcessors:
            └─ XfermodeFP.computeProcessorKey
                 └─ for childProcessors:
                      └─ DeviceSpaceTextureEffect.computeProcessorKey
                           ├─ onCountTextureSamplers() → 1（硬编码，修复前）
                           └─ textureAt(0) → onTextureAt(0)
                                └─ textureProxy->getTextureView()
```

### 阶段 4 — `getTextureView()` 懒加载失败（Windows）

```
DefaultTextureProxy::getTextureView
  ├─ resource == nullptr → YES
  └─ resource = onMakeTexture(context)
       └─ TextureRenderTargetProxy::onMakeTexture
            └─ RenderTarget::Make(...) → GLGPU::createTexture 失败
                 // 可能原因：
                 // - GL context 未绑定到当前线程
                 // - GPU 显存耗尽
                 // - 驱动 framebuffer incomplete
                 └─ return nullptr
  // resource 保持 nullptr
  return nullptr
```

### 阶段 5 — 崩溃

```
textureAt(0) 返回 nullptr
  → TextureView::ComputeTextureKey(nullptr, bytesKey)
    → texture->format()       // texture 为 nullptr，offset 0x10
      → EXCEPTION_ACCESS_VIOLATION_READ / 0x10
```

## 修复方案

双层修复：

1. **源头修复：** `DeviceSpaceTextureEffect` 和 `TextureGradientColorizer` 的 `onCountTextureSamplers()` 现在检查纹理视图是否可用，不可用时返回 0。这使得循环在无纹理时不会执行。

2. **防御性保护：** 在 `FragmentProcessor::computeProcessorKey()` 中调用 `TextureView::ComputeTextureKey()` 前增加 null 检查，防止未来子类实现不一致时崩溃。

## Code Review 备注

- 修复模式与已有的 `TiledTextureEffect::onCountTextureSamplers()` 和 `TextureEffect::onCountTextureSamplers()` 一致，它们在纹理不可用时也返回 0。
- `PerlinNoiseFragmentProcessor` 保持硬编码 `return 2` 不变——其纹理在构造时直接创建（非懒加载 proxy），不存在 null 的情况。
- 缓存 key 正确性：`onCountTextureSamplers()` 返回 0 时纹理不参与 key 计算；返回 1 时写入纹理 key。两者产生不同的缓存 key，不会混淆。

## 变更文件

- `DeviceSpaceTextureEffect.h/cpp` — 将 `onCountTextureSamplers()` 移至 .cpp，实现带 null 检查的逻辑
- `TextureGradientColorizer.h` — 更新内联 `onCountTextureSamplers()` 增加 null 检查
- `FragmentProcessor.cpp` — 在 `computeProcessorKey()` 循环中增加 null 保护