### PR TITLE
Replaces allowZoomBlur and tileThrottleEnabled with TileUpdateMode enum exposing Immediate Smooth and Fast tile update strategies.

### DIFF
--- a/android/app/src/main/cpp/JTGFXView.cpp
+++ b/android/app/src/main/cpp/JTGFXView.cpp
@@ -26,7 +26,7 @@ JTGFXView::JTGFXView(ANativeWindow* nativeWindow, std::shared_ptr<tgfx::Window> 
                      std::unique_ptr<hello2d::AppHost> appHost)
     : nativeWindow(nativeWindow), window(std::move(window)), appHost(std::move(appHost)) {
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
   updateSize();
 }

--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -64,6 +64,36 @@ enum class RenderMode {
 };
 
 /**
+ * TileUpdateMode defines how missing tiles are produced in tiled rendering mode when the
+ * zoomScale changes or when the viewport scrolls into uncached regions.
+ */
+enum class TileUpdateMode {
+  /**
+   * Missing tiles are rasterized at the current zoomScale within the same frame. Cached tiles
+   * from other zoom scales are never reused. This produces the highest visual fidelity but may
+   * cause frame drops during heavy zoom or pan. This is the default mode.
+   */
+  Immediate,
+
+  /**
+   * For each missing tile, the display list first tries to reuse a cached tile from another
+   * zoom scale as a temporary fallback (producing brief zoom blur). When no such cache is
+   * available, the tile is rasterized at the current zoomScale within the same frame to keep
+   * the result correct. Use this mode when you want a smoother visual transition during zoom
+   * while still guaranteeing visible content on every frame.
+   */
+  Smooth,
+
+  /**
+   * The number of tiles rasterized per frame is capped by setMaxTilesRefinedPerFrame(). Tiles
+   * beyond the cap are filled with cached content from other zoom scales, or with the background
+   * color when no fallback is available. This keeps the frame rate stable during heavy zoom or
+   * pan at the cost of longer-lasting blur or background-colored regions.
+   */
+  Fast
+};
+
+/**
  * DisplayList represents a collection of layers can be drawn to a Surface. Note: All layers in the
  * display list are not thread-safe and should only be accessed from a single thread.
  */
@@ -187,32 +217,32 @@ class DisplayList {
   void setMaxTileCount(int count);
 
   /**
-   * Returns true if zoom blur is allowed in tiled rendering mode. This setting is ignored in other
-   * render modes. When enabled, if the zoomScale changes and cached images at other zoom levels are
-   * available, the display list will use those caches to render first, then gradually update to the
-   * current zoomScale in later frames. Use setTileThrottleEnabled() and
-   * setMaxTilesRefinedPerFrame() to control how many tiles are updated per frame. This can improve
-   * zooming performance, but may cause temporary zoom blur
-   * artifacts. The default is false.
+   * Returns the current tile update mode. This setting only applies in tiled rendering mode and
+   * controls how missing tiles are produced when the zoomScale changes. The default is
+   * TileUpdateMode::Immediate.
    */
-  bool allowZoomBlur() const {
-    return _allowZoomBlur;
+  TileUpdateMode tileUpdateMode() const {
+    return _tileUpdateMode;
   }
 
   /**
-   * Sets whether to allow zoom blur in tiled rendering mode.
+   * Sets the tile update mode used in tiled rendering mode.
    */
-  void setAllowZoomBlur(bool allow) {
-    _allowZoomBlur = allow;
+  void setTileUpdateMode(TileUpdateMode mode) {
+    _tileUpdateMode = mode;
   }
 
   /**
-   * Returns the maximum number of tiles rasterized per frame. This setting only applies in tiled
-   * rendering mode and only takes effect when both tileThrottleEnabled() and allowZoomBlur() are
-   * true. Once the limit is reached, remaining tiles fall back to cached content from other zoom
-   * scales, or are filled with the background color when no fallback is available. Higher values
-   * fill the screen faster during zoom and pan at the cost of per-frame GPU load; lower values
-   * prioritize stable frame rate.
+   * Returns the per-frame budget for rasterizing missing tiles. This setting only applies in
+   * tiled rendering mode and is ignored when tileUpdateMode() is TileUpdateMode::Immediate. In
+   * TileUpdateMode::Smooth, once the budget is exhausted, tiles that have a cached fallback at
+   * another zoom scale will display the fallback instead of being rasterized; tiles without any
+   * fallback are still rasterized in the same frame to keep the result correct, so the actual
+   * tiles drawn per frame may exceed this limit. In TileUpdateMode::Fast, the budget is a hard
+   * cap: tiles beyond it fall back to cached content from other zoom scales, or are filled with
+   * the background color when no fallback is available. Higher values fill the screen faster
+   * during zoom and pan at the cost of per-frame GPU load; lower values prioritize stable frame
+   * rate.
    */
   int maxTilesRefinedPerFrame() const {
     return _maxTilesRefinedPerFrame;
@@ -223,28 +253,6 @@ class DisplayList {
    */
   void setMaxTilesRefinedPerFrame(int count) {
     _maxTilesRefinedPerFrame = count;
-  }
-
-  /**
-   * Returns true if tile throttling is enabled in tiled rendering mode. This setting is ignored
-   * in other render modes or if allowZoomBlur is false. When enabled, the number of tiles
-   * rasterized per frame is capped by maxTilesRefinedPerFrame(); remaining tiles fall back to
-   * cached content from other zoom scales, or are filled with the background color when no
-   * fallback is available. This keeps the frame rate stable during zoom and pan but may briefly
-   * show lower-resolution or background-colored regions. When disabled, all required tiles are
-   * rasterized in the current frame regardless of maxTilesRefinedPerFrame(), which may cause
-   * frame drops during heavy zoom or pan but avoids any transient blur or background fill. The
-   * default is false.
-   */
-  bool tileThrottleEnabled() const {
-    return _tileThrottleEnabled;
-  }
-
-  /**
-   * Sets whether tile throttling is enabled in tiled rendering mode.
-   */
-  void setTileThrottleEnabled(bool enabled) {
-    _tileThrottleEnabled = enabled;
   }
 
   /**
@@ -313,8 +321,7 @@ class DisplayList {
   RenderMode _renderMode = RenderMode::Partial;
   int _tileSize = 256;
   int _maxTileCount = 0;
-  bool _allowZoomBlur = false;
-  bool _tileThrottleEnabled = false;
+  TileUpdateMode _tileUpdateMode = TileUpdateMode::Immediate;
   int _maxTilesRefinedPerFrame = 5;
   int _subtreeCacheMaxSize = 0;
   bool _showDirtyRegions = false;

--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -207,11 +207,11 @@ class DisplayList {
 
   /**
    * Returns the maximum number of tiles rasterized per frame in tiled rendering mode. This
-   * setting is ignored in other render modes or if allowZoomBlur is false. Once the limit is
-   * reached, remaining tiles fall back to cached content from other zoom scales, or are filled
-   * with the background color when no fallback is available. Higher values fill the screen
-   * faster during zoom and pan at the cost of per-frame GPU load; lower values prioritize
-   * stable frame rate.
+   * setting only takes effect when both tileThrottleEnabled() and allowZoomBlur() are true, and
+   * is ignored in other render modes. Once the limit is reached, remaining tiles fall back to
+   * cached content from other zoom scales, or are filled with the background color when no
+   * fallback is available. Higher values fill the screen faster during zoom and pan at the cost
+   * of per-frame GPU load; lower values prioritize stable frame rate.
    */
   int maxTilesRefinedPerFrame() const {
     return _maxTilesRefinedPerFrame;
@@ -222,6 +222,28 @@ class DisplayList {
    */
   void setMaxTilesRefinedPerFrame(int count) {
     _maxTilesRefinedPerFrame = count;
+  }
+
+  /**
+   * Returns true if tile throttling is enabled in tiled rendering mode. This setting is ignored
+   * in other render modes or if allowZoomBlur is false. When enabled, the number of tiles
+   * rasterized per frame is capped by maxTilesRefinedPerFrame(); remaining tiles fall back to
+   * cached content from other zoom scales, or are filled with the background color when no
+   * fallback is available. This keeps the frame rate stable during zoom and pan but may briefly
+   * show lower-resolution or background-colored regions. When disabled, all required tiles are
+   * rasterized in the current frame regardless of maxTilesRefinedPerFrame(), which may cause
+   * frame drops during heavy zoom or pan but avoids any transient blur or background fill. The
+   * default is false.
+   */
+  bool tileThrottleEnabled() const {
+    return _tileThrottleEnabled;
+  }
+
+  /**
+   * Sets whether tile throttling is enabled in tiled rendering mode.
+   */
+  void setTileThrottleEnabled(bool enabled) {
+    _tileThrottleEnabled = enabled;
   }
 
   /**
@@ -291,6 +313,7 @@ class DisplayList {
   int _tileSize = 256;
   int _maxTileCount = 0;
   bool _allowZoomBlur = false;
+  bool _tileThrottleEnabled = false;
   int _maxTilesRefinedPerFrame = 5;
   int _subtreeCacheMaxSize = 0;
   bool _showDirtyRegions = false;

--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -190,8 +190,9 @@ class DisplayList {
    * Returns true if zoom blur is allowed in tiled rendering mode. This setting is ignored in other
    * render modes. When enabled, if the zoomScale changes and cached images at other zoom levels are
    * available, the display list will use those caches to render first, then gradually update to the
-   * current zoomScale in later frames. Use setMaxTilesRefinedPerFrame() to control how many tiles
-   * are updated per frame. This can improve zooming performance, but may cause temporary zoom blur
+   * current zoomScale in later frames. Use setTileThrottleEnabled() and
+   * setMaxTilesRefinedPerFrame() to control how many tiles are updated per frame. This can improve
+   * zooming performance, but may cause temporary zoom blur
    * artifacts. The default is false.
    */
   bool allowZoomBlur() const {

--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -206,12 +206,12 @@ class DisplayList {
   }
 
   /**
-   * Returns the maximum number of tiles rasterized per frame in tiled rendering mode. This
-   * setting only takes effect when both tileThrottleEnabled() and allowZoomBlur() are true, and
-   * is ignored in other render modes. Once the limit is reached, remaining tiles fall back to
-   * cached content from other zoom scales, or are filled with the background color when no
-   * fallback is available. Higher values fill the screen faster during zoom and pan at the cost
-   * of per-frame GPU load; lower values prioritize stable frame rate.
+   * Returns the maximum number of tiles rasterized per frame. This setting only applies in tiled
+   * rendering mode and only takes effect when both tileThrottleEnabled() and allowZoomBlur() are
+   * true. Once the limit is reached, remaining tiles fall back to cached content from other zoom
+   * scales, or are filled with the background color when no fallback is available. Higher values
+   * fill the screen faster during zoom and pan at the cost of per-frame GPU load; lower values
+   * prioritize stable frame rate.
    */
   int maxTilesRefinedPerFrame() const {
     return _maxTilesRefinedPerFrame;

--- a/ios/metal/Hello2D/TGFXView.mm
+++ b/ios/metal/Hello2D/TGFXView.mm
@@ -86,7 +86,7 @@
     lastSurfaceHeight = 0;
     presentImmediately = true;
     displayList.setRenderMode(tgfx::RenderMode::Tiled);
-    displayList.setAllowZoomBlur(true);
+    displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
     displayList.setMaxTileCount(512);
   }
   lastSurfaceWidth = static_cast<int>(self.drawableSize.width);

--- a/ios/opengl/Hello2D/TGFXView.mm
+++ b/ios/opengl/Hello2D/TGFXView.mm
@@ -80,7 +80,7 @@
     lastSurfaceHeight = 0;
     presentImmediately = true;
     displayList.setRenderMode(tgfx::RenderMode::Tiled);
-    displayList.setAllowZoomBlur(true);
+    displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
     displayList.setMaxTileCount(512);
   }
   lastSurfaceWidth = static_cast<int>(self.bounds.size.width * self.contentScaleFactor);

--- a/mac/metal/Hello2D/TGFXView.mm
+++ b/mac/metal/Hello2D/TGFXView.mm
@@ -73,7 +73,7 @@
     lastSurfaceHeight = 0;
     presentImmediately = true;
     displayList.setRenderMode(tgfx::RenderMode::Tiled);
-    displayList.setAllowZoomBlur(true);
+    displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
     displayList.setMaxTileCount(512);
   }
   lastSurfaceWidth = static_cast<int>(self.drawableSize.width);

--- a/mac/opengl/Hello2D/TGFXView.mm
+++ b/mac/opengl/Hello2D/TGFXView.mm
@@ -83,7 +83,7 @@ static CVReturn OnDisplayLinkCallback(CVDisplayLinkRef, const CVTimeStamp*, cons
     lastSurfaceHeight = 0;
     presentImmediately = true;
     displayList.setRenderMode(tgfx::RenderMode::Tiled);
-    displayList.setAllowZoomBlur(true);
+    displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
     displayList.setMaxTileCount(512);
   }
   CGSize backingSize = [self convertSizeToBacking:self.bounds.size];

--- a/ohos/hello2d/src/main/cpp/napi_init.cpp
+++ b/ohos/hello2d/src/main/cpp/napi_init.cpp
@@ -185,7 +185,7 @@ static napi_value StopDrawLoop(napi_env, napi_callback_info) {
 static std::shared_ptr<hello2d::AppHost> CreateAppHost() {
   auto appHost = std::make_shared<hello2d::AppHost>();
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
   static const std::string FallbackFontFileNames[] = {"/system/fonts/HarmonyOS_Sans.ttf",
                                                       "/system/fonts/HarmonyOS_Sans_SC.ttf",

--- a/qt/src/TGFXView.cpp
+++ b/qt/src/TGFXView.cpp
@@ -34,7 +34,7 @@ TGFXView::TGFXView(QQuickItem* parent) : QQuickItem(parent) {
   setFocus(true);
   createAppHost();
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
   updateLayerTree();
 }

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -585,7 +585,7 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
                                                       std::vector<DrawTask>* throttleScreenTasks,
                                                       bool autoClear) {
   auto maxBudget = _maxTilesRefinedPerFrame;
-  const auto throttleActive = _allowZoomBlur && _tileThrottleEnabled;
+  const auto useFallback = _tileUpdateMode != TileUpdateMode::Immediate;
   if (lastContentOffset != _contentOffset || lastZoomScaleInt != _zoomScaleInt) {
     updateMousePosition();
     lastContentOffset = _contentOffset;
@@ -636,19 +636,25 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
       screenTasks.emplace_back(tile, _tileSize, tileRect);
       continue;
     }
-    if (!throttleActive || maxBudget > 0) {
-      // Refine this tile when throttling is disabled, or when the budget still allows it.
-      if (throttleActive) {
+    if (!useFallback || maxBudget > 0) {
+      if (useFallback) {
         maxBudget--;
       }
       dirtyGrids.emplace_back(tileX, tileY);
     } else {
-      hasZoomBlurTiles = true;
       auto fallbackTasks = getFallbackDrawTasks(tileX, tileY, fallbackTileCaches);
       if (!fallbackTasks.empty()) {
+        hasZoomBlurTiles = true;
         screenTasks.insert(screenTasks.end(), fallbackTasks.begin(), fallbackTasks.end());
         continue;
       }
+      if (_tileUpdateMode == TileUpdateMode::Smooth) {
+        // No cached fallback in Smooth mode: rasterize the tile in this frame to keep the result
+        // correct.
+        dirtyGrids.emplace_back(tileX, tileY);
+        continue;
+      }
+      hasZoomBlurTiles = true;
       skippedRects->emplace_back(
           Rect::MakeXYWH(tileX * _tileSize, tileY * _tileSize, _tileSize, _tileSize));
       if (!autoClear) {
@@ -729,7 +735,7 @@ std::vector<std::pair<float, TileCache*>> DisplayList::getSortedTileCaches() con
 
 std::vector<std::pair<float, TileCache*>> DisplayList::getFallbackTileCaches(
     const std::vector<std::pair<float, TileCache*>>& sortedCaches) const {
-  if (!_allowZoomBlur || !_tileThrottleEnabled) {
+  if (_tileUpdateMode == TileUpdateMode::Immediate) {
     return {};
   }
   auto currentZoomScale = ToZoomScaleFloat(_zoomScaleInt, _zoomScalePrecision);

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -585,7 +585,7 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
                                                       std::vector<DrawTask>* throttleScreenTasks,
                                                       bool autoClear) {
   auto maxBudget = _maxTilesRefinedPerFrame;
-  const bool throttleActive = _allowZoomBlur && _tileThrottleEnabled;
+  const auto throttleActive = _allowZoomBlur && _tileThrottleEnabled;
   if (lastContentOffset != _contentOffset || lastZoomScaleInt != _zoomScaleInt) {
     updateMousePosition();
     lastContentOffset = _contentOffset;

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -627,11 +627,7 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
   screenTasks.reserve(tileCount);
   dirtyGrids.reserve(tileCount);
   auto sortedCaches = getSortedTileCaches();
-  // fallbackTileCaches is only consumed inside the throttling branch below; skip building it
-  // when throttling is inactive to avoid unnecessary work.
-  auto fallbackTileCaches = throttleActive
-                                ? getFallbackTileCaches(sortedCaches)
-                                : std::vector<std::pair<float, TileCache*>>{};
+  auto fallbackTileCaches = getFallbackTileCaches(sortedCaches);
   auto sortedTiles = GetSortedTiles(startX, endX, startY, endY, _tileSize, mousePosition);
   for (const auto& [tileX, tileY] : sortedTiles) {
     auto tile = currentTileCache->getTile(tileX, tileY);
@@ -733,7 +729,7 @@ std::vector<std::pair<float, TileCache*>> DisplayList::getSortedTileCaches() con
 
 std::vector<std::pair<float, TileCache*>> DisplayList::getFallbackTileCaches(
     const std::vector<std::pair<float, TileCache*>>& sortedCaches) const {
-  if (!_allowZoomBlur) {
+  if (!_allowZoomBlur || !_tileThrottleEnabled) {
     return {};
   }
   auto currentZoomScale = ToZoomScaleFloat(_zoomScaleInt, _zoomScalePrecision);

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -627,7 +627,11 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
   screenTasks.reserve(tileCount);
   dirtyGrids.reserve(tileCount);
   auto sortedCaches = getSortedTileCaches();
-  auto fallbackTileCaches = getFallbackTileCaches(sortedCaches);
+  // fallbackTileCaches is only consumed inside the throttling branch below; skip building it
+  // when throttling is inactive to avoid unnecessary work.
+  auto fallbackTileCaches = throttleActive
+                                ? getFallbackTileCaches(sortedCaches)
+                                : std::vector<std::pair<float, TileCache*>>{};
   auto sortedTiles = GetSortedTiles(startX, endX, startY, endY, _tileSize, mousePosition);
   for (const auto& [tileX, tileY] : sortedTiles) {
     auto tile = currentTileCache->getTile(tileX, tileY);

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -635,10 +635,9 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
       screenTasks.emplace_back(tile, _tileSize, tileRect);
       continue;
     }
-    if (!_allowZoomBlur || maxBudget > 0) {
-      // Either zoom-blur is disabled (no throttling) or the budget still allows rasterizing
-      // this tile. Either way, schedule it for refinement.
-      if (_allowZoomBlur) {
+    if (!_allowZoomBlur || !_tileThrottleEnabled || maxBudget > 0) {
+      // Refine this tile when throttling is disabled, or when the budget still allows it.
+      if (_allowZoomBlur && _tileThrottleEnabled) {
         maxBudget--;
       }
       dirtyGrids.emplace_back(tileX, tileY);

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -585,6 +585,7 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
                                                       std::vector<DrawTask>* throttleScreenTasks,
                                                       bool autoClear) {
   auto maxBudget = _maxTilesRefinedPerFrame;
+  const bool throttleActive = _allowZoomBlur && _tileThrottleEnabled;
   if (lastContentOffset != _contentOffset || lastZoomScaleInt != _zoomScaleInt) {
     updateMousePosition();
     lastContentOffset = _contentOffset;
@@ -635,9 +636,9 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
       screenTasks.emplace_back(tile, _tileSize, tileRect);
       continue;
     }
-    if (!_allowZoomBlur || !_tileThrottleEnabled || maxBudget > 0) {
+    if (!throttleActive || maxBudget > 0) {
       // Refine this tile when throttling is disabled, or when the budget still allows it.
-      if (_allowZoomBlur && _tileThrottleEnabled) {
+      if (throttleActive) {
         maxBudget--;
       }
       dirtyGrids.emplace_back(tileX, tileY);

--- a/test/src/LayerCacheTest.cpp
+++ b/test/src/LayerCacheTest.cpp
@@ -708,8 +708,7 @@ TGFX_TEST_PRIVATE(LayerCacheTest, DirtyRegionTest) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerCacheTest/DirtyRegionTest5"));
 
   displayList->setRenderMode(RenderMode::Tiled);
-  displayList->setAllowZoomBlur(true);
-  displayList->setTileThrottleEnabled(true);
+  displayList->setTileUpdateMode(TileUpdateMode::Fast);
   displayList->setMaxTileCount(512);
   displayList->render(surface.get());
   // Clear the previous dirty regions.

--- a/test/src/LayerCacheTest.cpp
+++ b/test/src/LayerCacheTest.cpp
@@ -709,6 +709,7 @@ TGFX_TEST_PRIVATE(LayerCacheTest, DirtyRegionTest) {
 
   displayList->setRenderMode(RenderMode::Tiled);
   displayList->setAllowZoomBlur(true);
+  displayList->setTileThrottleEnabled(true);
   displayList->setMaxTileCount(512);
   displayList->render(surface.get());
   // Clear the previous dirty regions.

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -746,7 +746,7 @@ TGFX_TEST(LayerMaskTest, RoundRectMaskWithTiledRender) {
   displayList.setRenderMode(RenderMode::Tiled);
   displayList.render(surface.get());
   displayList.setZoomScale(1.603f);
-  displayList.setAllowZoomBlur(false);
+  displayList.setTileUpdateMode(TileUpdateMode::Immediate);
   displayList.setContentOffset(-200.179016f, -221.704529f);
   displayList.render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/RoundRectMaskWithTiledRender"));

--- a/web/demo/src/TGFXBaseView.cpp
+++ b/web/demo/src/TGFXBaseView.cpp
@@ -28,7 +28,7 @@ namespace hello2d {
 TGFXBaseView::TGFXBaseView(const std::string& canvasID) : canvasID(canvasID) {
   appHost = std::make_shared<hello2d::AppHost>();
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
 }
 

--- a/win/vulkan/TGFXWindow.cpp
+++ b/win/vulkan/TGFXWindow.cpp
@@ -285,7 +285,7 @@ void TGFXWindow::createAppHost() {
   appHost = std::make_unique<hello2d::AppHost>();
 
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
 
   std::filesystem::path filePath = __FILE__;

--- a/win/wgl/TGFXWindow.cpp
+++ b/win/wgl/TGFXWindow.cpp
@@ -285,7 +285,7 @@ void TGFXWindow::createAppHost() {
   appHost = std::make_unique<hello2d::AppHost>();
 
   displayList.setRenderMode(tgfx::RenderMode::Tiled);
-  displayList.setAllowZoomBlur(true);
+  displayList.setTileUpdateMode(tgfx::TileUpdateMode::Smooth);
   displayList.setMaxTileCount(512);
 
   std::filesystem::path filePath = __FILE__;


### PR DESCRIPTION
为 DisplayList 引入 TileUpdateMode 三态枚举，替换之前 allowZoomBlur 和 tileThrottleEnabled 两个 bool 开关。三种模式语义分别为：

- Immediate（默认）：缺失 tile 当帧光栅化，不复用其他 zoom scale 缓存。最高画质，zoom/pan 时可能掉帧。等价于以前的 allowZoomBlur=false。
- Smooth：缺失 tile 优先用其他 zoom scale 的缓存做临时 fallback（短暂 zoom blur），无 fallback 时仍当帧光栅化。zoom 体验流畅且画面始终正确。等价于 commit fef288e0 之前 allowZoomBlur=true 的行为。
- Fast：每帧光栅化数量受 maxTilesRefinedPerFrame 限制，超出部分用 fallback 或背景色填充。帧率稳定，可能持续显示低分辨率或背景区域。等价于 commit fef288e0 之后 allowZoomBlur=true 的行为。

API 变更：
- 新增 enum class TileUpdateMode { Immediate, Smooth, Fast }
- 新增 setTileUpdateMode / tileUpdateMode
- 移除 setAllowZoomBlur / allowZoomBlur
- maxTilesRefinedPerFrame 保留，注释更新以说明三种模式下的实际效果

Breaking change：使用 setAllowZoomBlur(true) 的代码需迁移到 setTileUpdateMode(TileUpdateMode::Smooth)（保持 fef288e0 之前的体验）或 setTileUpdateMode(TileUpdateMode::Fast)（保持 fef288e0 之后的体验）。本 PR 已同步更新所有平台 demo（android/ios/mac/qt/win/web/ohos）使用 Smooth 模式以保留现有视觉行为。

实现要点：
- collectScreenTasks 用 useFallback 局部变量统一表达 Smooth/Fast 共享的 fallback 路径入口
- getFallbackTileCaches 在 Immediate 模式下短路返回空，避免无谓开销
- Smooth 模式在 fallback 缺失时回退到当帧 refine，保证画面正确性

测试：LayerCacheTest::DirtyRegionTest 沿用节流场景，已切换为 TileUpdateMode::Fast 维持原有覆盖。