### PR TITLE
Fix black tiles when zooming during animation in tiled rendering Fast mode.

### DIFF
--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -353,10 +353,10 @@ class DisplayList {
 
   void recycleCurrentTileTasks(const std::vector<DrawTask>& tileTasks);
 
-  std::vector<DrawTask> collectScreenTasks(const Surface* surface, std::vector<DrawTask>* tileTasks,
+  std::vector<DrawTask> collectScreenTasks(const Surface* surface, bool hasDirtyRegions,
+                                           bool autoClear, std::vector<DrawTask>* tileTasks,
                                            std::vector<Rect>* skippedRects,
-                                           std::vector<DrawTask>* throttleScreenTasks,
-                                           bool autoClear);
+                                           std::vector<DrawTask>* throttleScreenTasks);
 
   std::vector<std::pair<float, TileCache*>> getSortedTileCaches() const;
 

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -441,8 +441,8 @@ std::vector<Rect> DisplayList::renderTiled(Surface* surface, bool autoClear,
   auto tileTasks = invalidateTileCaches(dirtyRegions);
   std::vector<Rect> skippedRects = {};
   std::vector<DrawTask> throttleScreenTasks = {};
-  auto screenTasks =
-      collectScreenTasks(surface, &tileTasks, &skippedRects, &throttleScreenTasks, autoClear);
+  auto screenTasks = collectScreenTasks(surface, !dirtyRegions.empty(), autoClear, &tileTasks,
+                                        &skippedRects, &throttleScreenTasks);
   // Throttle tasks and skipped rects must keep the tiled path; only fall back when all are empty.
   if (screenTasks.empty() && throttleScreenTasks.empty() && skippedRects.empty()) {
     recycleCurrentTileTasks(tileTasks);
@@ -579,11 +579,11 @@ void DisplayList::invalidateCurrentTileCache(const TileCache* tileCache,
   }
 }
 
-std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
+std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface, bool hasDirtyRegions,
+                                                      bool autoClear,
                                                       std::vector<DrawTask>* tileTasks,
                                                       std::vector<Rect>* skippedRects,
-                                                      std::vector<DrawTask>* throttleScreenTasks,
-                                                      bool autoClear) {
+                                                      std::vector<DrawTask>* throttleScreenTasks) {
   auto maxBudget = _maxTilesRefinedPerFrame;
   const auto useFallback = _tileUpdateMode != TileUpdateMode::Immediate;
   if (lastContentOffset != _contentOffset || lastZoomScaleInt != _zoomScaleInt) {
@@ -648,9 +648,9 @@ std::vector<DrawTask> DisplayList::collectScreenTasks(const Surface* surface,
         screenTasks.insert(screenTasks.end(), fallbackTasks.begin(), fallbackTasks.end());
         continue;
       }
-      if (_tileUpdateMode == TileUpdateMode::Smooth) {
-        // No cached fallback in Smooth mode: rasterize the tile in this frame to keep the result
-        // correct.
+      // Rasterize in Smooth mode, or when this frame has dirty regions: dirty regions also
+      // clear fallback tiles at other scales, so a skipRect would render as background color.
+      if (_tileUpdateMode == TileUpdateMode::Smooth || hasDirtyRegions) {
         dirtyGrids.emplace_back(tileX, tileY);
         continue;
       }


### PR DESCRIPTION
修复 DisplayList Tiled 渲染模式下 Fast/Smooth 模式同时发生缩放和动画时屏幕出现黑色 tile 的问题。

原因：脏区会清除当前 scale 以及其他所有 scale 的相关 tile cache，使得 fallback tile 也不可用。Fast 模式在 maxBudget 用尽 + 无 fallback 时会用背景色 skipRect 覆盖该 tile，导致黑块。

修复：collectScreenTasks 增加 hasDirtyRegions 输入。当本帧存在脏区时，cache miss 的 tile 进入强制重绘路径（与 Smooth 模式一致），不再用 skipRect 兜底。