### PR TITLE
Warn when Apple Window subclasses create a render target off the main thread

### DIFF
--- a/src/gpu/metal/MetalWindow.mm
+++ b/src/gpu/metal/MetalWindow.mm
@@ -17,7 +17,9 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "tgfx/gpu/metal/MetalWindow.h"
+#import <Foundation/Foundation.h>
 #import <MetalKit/MetalKit.h>
+#include "core/utils/Log.h"
 #include "gpu/metal/MetalDefines.h"
 #include "gpu/metal/MetalDrawableProxy.h"
 #include "platform/apple/CGColorSpaceUtil.h"
@@ -89,6 +91,12 @@ MetalWindow::MetalWindow(std::shared_ptr<Device> device, MTKView* view, CAMetalL
 
 std::shared_ptr<RenderTargetProxy> MetalWindow::onCreateRenderTarget(Context* context) {
   if (metalView != nil) {
+    if (![NSThread isMainThread]) {
+      LOGE("MetalWindow::onCreateRenderTarget() must be called on the main thread when the "
+           "window is created from an MTKView, because MTKView is a UIView/NSView subclass "
+           "annotated with @MainActor. Create the Surface on the main thread, then render on "
+           "any thread.");
+    }
     metalLayer.drawableSize = metalView.drawableSize;
   }
   auto drawableSize = metalLayer.drawableSize;

--- a/src/gpu/opengl/cgl/CGLWindow.mm
+++ b/src/gpu/opengl/cgl/CGLWindow.mm
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "tgfx/gpu/opengl/cgl/CGLWindow.h"
+#import <Foundation/Foundation.h>
 #include <thread>
 #include "core/utils/Log.h"
 #include "gpu/opengl/GLDefines.h"
@@ -61,6 +62,11 @@ CGLWindow::~CGLWindow() {
 }
 
 std::shared_ptr<RenderTargetProxy> CGLWindow::onCreateRenderTarget(Context* context) {
+  if (![NSThread isMainThread]) {
+    LOGE("CGLWindow::onCreateRenderTarget() must be called on the main thread because it "
+         "reads NSView geometry and binds the GL context to the view. Create the Surface on "
+         "the main thread, then render on any thread.");
+  }
   auto glContext = static_cast<CGLDevice*>(device.get())->glContext;
   [glContext update];
   CGSize size = [view convertSizeToBacking:view.bounds.size];

--- a/src/gpu/opengl/eagl/EAGLWindow.mm
+++ b/src/gpu/opengl/eagl/EAGLWindow.mm
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "tgfx/gpu/opengl/eagl/EAGLWindow.h"
+#import <Foundation/Foundation.h>
 #include "core/utils/Log.h"
 #include "gpu/opengl/GLFunctions.h"
 #include "gpu/opengl/eagl/EAGLLayerTexture.h"
@@ -49,6 +50,11 @@ EAGLWindow::EAGLWindow(std::shared_ptr<Device> device, CAEAGLLayer* layer,
 }
 
 std::shared_ptr<RenderTargetProxy> EAGLWindow::onCreateRenderTarget(Context* context) {
+  if (![NSThread isMainThread]) {
+    LOGE("EAGLWindow::onCreateRenderTarget() must be called on the main thread because it "
+         "reads CAEAGLLayer geometry. Create the Surface on the main thread, then render on "
+         "any thread.");
+  }
   if (layerTexture != nullptr) {
     // Immediately release the previous layer texture to prevent new texture creation from failing
     // due to repeated binding of the same layer.


### PR DESCRIPTION
Apple 平台 Window（EAGL/CGL/Metal）的 `onCreateRenderTarget` 内部会触碰非线程安全的 UIView/NSView/CAEAGLLayer 几何属性；如果调用方在非主线程创建 Surface，会引发数据竞争甚至 crash（在 Swift 6 严格并发模式下，MTKView 因被 Apple 标注为 `NS_SWIFT_UI_ACTOR` 还会直接触发 main-actor 隔离断言）。

## 方案

不强制阻断、不引入新 API。仅在 Apple 三个 Window 子类的 `onCreateRenderTarget` 入口加 `[NSThread isMainThread]` 检查，非主线程时 `LOGE` 打印明确警告，引导调用方采用「主线程创建 Surface，渲染可在任意线程」的范式：

```cpp
// 主线程
auto context = device->lockContext();
auto surface = Surface::MakeFrom(context, window);   // <- onCreateRenderTarget 在这一刻
device->unlock();

// 渲染可在任意线程（重新 lockContext 即可）
auto context = device->lockContext();
canvas->draw(...);
context->submit();
device->unlock();
```

## 改动

- `EAGLWindow::onCreateRenderTarget`：非主线程时 LOGE，提示需读 CAEAGLLayer geometry。
- `CGLWindow::onCreateRenderTarget`：非主线程时 LOGE，提示需读 NSView geometry 并绑定 GL context 到 view。
- `MetalWindow::onCreateRenderTarget`：仅当 Window 是从 `MTKView` 构造时才检查（CAMetalLayer 直接构造的实例本身线程安全，无需检查）；非主线程时 LOGE，提示 MTKView 是 `@MainActor` 隔离类型。
