### PR TITLE
Forward stroke to ElementWriter when exporting rectangles and rounded rectangles to SVG

### DIFF
--- a/src/svg/SVGExportContext.cpp
+++ b/src/svg/SVGExportContext.cpp
@@ -34,6 +34,7 @@
 #include "core/utils/MathExtra.h"
 #include "core/utils/RectToRectMatrix.h"
 #include "core/utils/ShapeUtils.h"
+#include "core/utils/StrokeUtils.h"
 #include "core/utils/Types.h"
 #include "svg/SVGTextBuilder.h"
 #include "tgfx/core/Bitmap.h"
@@ -138,7 +139,7 @@ void SVGExportContext::drawFill(const Brush& brush) {
 }
 
 void SVGExportContext::drawRect(const Rect& rect, const Matrix& matrix, const ClipStack& clip,
-                                const Brush& brush, const Stroke*) {
+                                const Brush& brush, const Stroke* stroke) {
   std::unique_ptr<ElementWriter> svg;
   if (RequiresViewportReset(brush)) {
     svg =
@@ -148,10 +149,14 @@ void SVGExportContext::drawRect(const Rect& rect, const Matrix& matrix, const Cl
     svg->addRectAttributes(rect);
   }
 
-  applyClip(clip, matrix.mapRect(rect));
+  auto contentBounds = rect;
+  if (stroke) {
+    ApplyStrokeToBounds(*stroke, &contentBounds, matrix);
+  }
+  applyClip(clip, matrix.mapRect(contentBounds));
 
   ElementWriter rectElement("rect", context, this, xmlWriter.get(), resourceBucket.get(),
-                            exportFlags & SVGExportFlags::DisableWarnings, matrix, brush, nullptr,
+                            exportFlags & SVGExportFlags::DisableWarnings, matrix, brush, stroke,
                             _targetColorSpace, _assignColorSpace);
 
   if (svg) {
@@ -165,30 +170,41 @@ void SVGExportContext::drawRect(const Rect& rect, const Matrix& matrix, const Cl
 }
 
 void SVGExportContext::drawRRect(const RRect& roundRect, const Matrix& matrix,
-                                 const ClipStack& clip, const Brush& brush, const Stroke*) {
-  applyClip(clip, matrix.mapRect(roundRect.rect()));
+                                 const ClipStack& clip, const Brush& brush, const Stroke* stroke) {
+  if (roundRect.isComplex()) {
+    // SVG <rect> only supports uniform rx/ry; complex RRects must be exported as <path>.
+    // With stroke, route through drawShape so the generic stroker handles it.
+    Path path = {};
+    path.addRRect(roundRect);
+    if (stroke) {
+      drawShape(Shape::MakeFrom(std::move(path)), matrix, clip, brush, stroke);
+    } else {
+      drawPath(path, matrix, clip, brush);
+    }
+    return;
+  }
+
+  auto contentBounds = roundRect.rect();
+  if (stroke) {
+    ApplyStrokeToBounds(*stroke, &contentBounds, matrix);
+  }
+  applyClip(clip, matrix.mapRect(contentBounds));
   if (roundRect.isOval()) {
     if (roundRect.rect().width() == roundRect.rect().height()) {
       ElementWriter circleElement("circle", context, this, xmlWriter.get(), resourceBucket.get(),
                                   exportFlags & SVGExportFlags::DisableWarnings, matrix, brush,
-                                  nullptr, _targetColorSpace, _assignColorSpace);
+                                  stroke, _targetColorSpace, _assignColorSpace);
       circleElement.addCircleAttributes(roundRect.rect());
-      return;
     } else {
       ElementWriter ovalElement("ellipse", context, this, xmlWriter.get(), resourceBucket.get(),
                                 exportFlags & SVGExportFlags::DisableWarnings, matrix, brush,
-                                nullptr, _targetColorSpace, _assignColorSpace);
+                                stroke, _targetColorSpace, _assignColorSpace);
       ovalElement.addEllipseAttributes(roundRect.rect());
     }
-  } else if (roundRect.isComplex()) {
-    // SVG <rect> only supports uniform rx/ry. Complex RRects must be exported as <path>.
-    Path path = {};
-    path.addRRect(roundRect);
-    drawPath(path, matrix, clip, brush);
   } else {
     ElementWriter rrectElement("rect", context, this, xmlWriter.get(), resourceBucket.get(),
-                               exportFlags & SVGExportFlags::DisableWarnings, matrix, brush,
-                               nullptr, _targetColorSpace, _assignColorSpace);
+                               exportFlags & SVGExportFlags::DisableWarnings, matrix, brush, stroke,
+                               _targetColorSpace, _assignColorSpace);
     rrectElement.addRoundRectAttributes(roundRect);
   }
 }

--- a/test/src/SVGExportTest.cpp
+++ b/test/src/SVGExportTest.cpp
@@ -328,7 +328,8 @@ TGFX_TEST(SVGExportTest, StrokeWidth) {
   std::string compareString =
       "<?xml version=\"1.0\" encoding=\"utf-8\" ?><svg xmlns=\"http://www.w3.org/2000/svg\" "
       "xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"200\" height=\"200\"><rect "
-      "fill=\"#F00\" x=\"50\" y=\"50\" width=\"100\" height=\"100\"/></svg>";
+      "fill=\"none\" stroke=\"#F00\" stroke-width=\"5\" x=\"50\" y=\"50\" width=\"100\" "
+      "height=\"100\"/></svg>";
 
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
SVGExportContext 的 drawRect 和 drawRRect 之前直接丢弃了入参中的 Stroke 指针，导致带描边的矩形、椭圆、圆形以及圆角矩形在导出 SVG 时被当作纯填充图形输出（或者错把描边颜色当成填充颜色，详见本 PR 修正的测试基准）。

本次改动将 stroke 透传给 ElementWriter，让 rect、circle、ellipse 以及简单圆角 rect 元素带上正确的 SVG 描边属性；含 stroke 的 complex RRect 改走 drawShape，由通用 stroker 将描边轮廓烘焙进 path 后再输出为 path 元素。

applyClip 的 contentBounds 现在通过 ApplyStrokeToBounds 计算 stroke 外扩后再传入，避免描边超出几何边界时被错误判定为 clip 已包含而丢失 clip wrapper。这里复用了项目内已有的工具函数，同时获得了 hairline 提升、square cap 对角外扩等细节支持。

顺手修正了 SVGExportTest.StrokeWidth 的基准字符串——之前的基准本身就是在 bug 行为下生成的（描边 paint 被导出成 fill 颜色）。

测试验证：TGFXFullTest_OpenGL --gtest_filter='SVGExportTest.*:SVGRenderTest.*' 全部 56 个用例通过。