### PR TITLE
Use highp precision for coordinate and coverage computations in fragment shaders to fix hollow fills on OpenGL ES.

### DIFF
--- a/src/gpu/ProgramBuilder.cpp
+++ b/src/gpu/ProgramBuilder.cpp
@@ -189,7 +189,14 @@ void ProgramBuilder::nameExpression(std::string* output, const std::string& base
   } else {
     outName = nameVariable(baseName);
   }
-  fragmentShaderBuilder()->codeAppendf("vec4 %s;", outName.c_str());
+  // Coverage is a geometric quantity (AA edge / clip / mask) that is sensitive to precision; a
+  // mediump carrier can collapse interior coverage to zero on some ES GPUs. Declare the coverage
+  // stage result as highp while keeping color at the default precision.
+  if (getContext()->shaderCaps()->usesPrecisionModifiers && baseName == "outputCoverage") {
+    fragmentShaderBuilder()->codeAppendf("highp vec4 %s;", outName.c_str());
+  } else {
+    fragmentShaderBuilder()->codeAppendf("vec4 %s;", outName.c_str());
+  }
   *output = outName;
 }
 

--- a/src/gpu/glsl/GLSLVertexShaderBuilder.cpp
+++ b/src/gpu/glsl/GLSLVertexShaderBuilder.cpp
@@ -39,8 +39,8 @@ void GLSLVertexShaderBuilder::emitTransformedPoint(const std::string& dstPointNa
                                                    const std::string& transformName,
                                                    bool hasPerspective) {
   if (hasPerspective) {
-    codeAppendf("vec3 %sTemp = %s * vec3(%s, 1.0);", dstPointName.c_str(), transformName.c_str(),
-                srcPointName.c_str());
+    codeAppendf("highp vec3 %sTemp = %s * vec3(%s, 1.0);", dstPointName.c_str(),
+                transformName.c_str(), srcPointName.c_str());
     codeAppendf("highp vec2 %s = %sTemp.xy / %sTemp.z;", dstPointName.c_str(), dstPointName.c_str(),
                 dstPointName.c_str());
   } else {

--- a/src/gpu/glsl/processors/GLSLAARectEffect.cpp
+++ b/src/gpu/glsl/processors/GLSLAARectEffect.cpp
@@ -32,10 +32,11 @@ void GLSLAARectEffect::emitCode(EmitArgs& args) const {
 
   auto rectName = uniformHandler->addUniform("Rect", UniformFormat::Float4, ShaderStage::Fragment);
   fragBuilder->codeAppendf(
-      "vec4 dists4 = clamp(vec4(1.0, 1.0, -1.0, -1.0) * vec4(gl_FragCoord.xyxy - %s), 0.0, 1.0);",
+      "highp vec4 dists4 = clamp(vec4(1.0, 1.0, -1.0, -1.0) * vec4(gl_FragCoord.xyxy - %s), 0.0, "
+      "1.0);",
       rectName.c_str());
-  fragBuilder->codeAppend("vec2 dists2 = dists4.xy + dists4.zw - 1.0;");
-  fragBuilder->codeAppend("float coverage = dists2.x * dists2.y;");
+  fragBuilder->codeAppend("highp vec2 dists2 = dists4.xy + dists4.zw - 1.0;");
+  fragBuilder->codeAppend("highp float coverage = dists2.x * dists2.y;");
   fragBuilder->codeAppendf("%s = %s * coverage;", args.outputColor.c_str(),
                            args.inputColor.c_str());
 }

--- a/src/gpu/glsl/processors/GLSLComplexEllipseGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLComplexEllipseGeometryProcessor.cpp
@@ -89,23 +89,24 @@ void GLSLComplexEllipseGeometryProcessor::emitCode(EmitArgs& args) const {
   // In the corner branch, offset is clamped to a small minimum before the ellipse computation
   // to avoid division-by-zero in inversesqrt().
 
-  fragBuilder->codeAppendf("vec2 offset = %s.xy;", ellipseOffsets.fsIn().c_str());
-  fragBuilder->codeAppendf("vec2 eDist = %s;", edgeDist.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 offset = %s.xy;", ellipseOffsets.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 eDist = %s;", edgeDist.fsIn().c_str());
 
   fragBuilder->codeAppend("bool hasXCurve = offset.x > 0.0;");
   fragBuilder->codeAppend("bool hasYCurve = offset.y > 0.0;");
 
-  fragBuilder->codeAppend("float outerAlpha;");
+  fragBuilder->codeAppend("highp float outerAlpha;");
   fragBuilder->codeAppend("if (hasXCurve && hasYCurve) {");
   // Corner region: clamp offset to avoid zero in gradient computation
-  fragBuilder->codeAppend("  vec2 safeOffset = max(offset, vec2(1.0/4096.0));");
+  fragBuilder->codeAppend("  highp vec2 safeOffset = max(offset, vec2(1.0/4096.0));");
   if (stroke) {
     fragBuilder->codeAppendf("  safeOffset *= %s.xy;", ellipseRadii.fsIn().c_str());
   }
-  fragBuilder->codeAppend("  float test = dot(safeOffset, safeOffset) - 1.0;");
-  fragBuilder->codeAppendf("  vec2 grad = 2.0*safeOffset*%s.xy;", ellipseRadii.fsIn().c_str());
-  fragBuilder->codeAppend("  float gradDot = max(dot(grad, grad), 1.1755e-38);");
-  fragBuilder->codeAppend("  float invlen = inversesqrt(gradDot);");
+  fragBuilder->codeAppend("  highp float test = dot(safeOffset, safeOffset) - 1.0;");
+  fragBuilder->codeAppendf("  highp vec2 grad = 2.0*safeOffset*%s.xy;",
+                           ellipseRadii.fsIn().c_str());
+  fragBuilder->codeAppend("  highp float gradDot = max(dot(grad, grad), 1.1755e-38);");
+  fragBuilder->codeAppend("  highp float invlen = inversesqrt(gradDot);");
   fragBuilder->codeAppend("  outerAlpha = clamp(0.5-test*invlen, 0.0, 1.0);");
   fragBuilder->codeAppend("} else if (hasYCurve) {");
   // Horizontal edge region (top/bottom): use vertical edge distance
@@ -120,17 +121,18 @@ void GLSLComplexEllipseGeometryProcessor::emitCode(EmitArgs& args) const {
 
   // Inner ellipse (stroke mode)
   if (stroke) {
-    fragBuilder->codeAppendf("vec2 sw = %s;", strokeWidthVarying.fsIn().c_str());
-    fragBuilder->codeAppend("float innerAlpha;");
+    fragBuilder->codeAppendf("highp vec2 sw = %s;", strokeWidthVarying.fsIn().c_str());
+    fragBuilder->codeAppend("highp float innerAlpha;");
     fragBuilder->codeAppend("if (hasXCurve && hasYCurve) {");
     // Corner region: inner ellipse Sampson distance
-    fragBuilder->codeAppendf("  vec2 innerOffset = max(offset, vec2(1.0/4096.0)) * %s.zw;",
+    fragBuilder->codeAppendf("  highp vec2 innerOffset = max(offset, vec2(1.0/4096.0)) * %s.zw;",
                              ellipseRadii.fsIn().c_str());
-    fragBuilder->codeAppend("  float innerTest = dot(innerOffset, innerOffset) - 1.0;");
-    fragBuilder->codeAppendf("  vec2 innerGrad = 2.0*innerOffset*%s.zw;",
+    fragBuilder->codeAppend("  highp float innerTest = dot(innerOffset, innerOffset) - 1.0;");
+    fragBuilder->codeAppendf("  highp vec2 innerGrad = 2.0*innerOffset*%s.zw;",
                              ellipseRadii.fsIn().c_str());
-    fragBuilder->codeAppend("  float innerGradDot = max(dot(innerGrad, innerGrad), 1.1755e-38);");
-    fragBuilder->codeAppend("  float innerInvlen = inversesqrt(innerGradDot);");
+    fragBuilder->codeAppend(
+        "  highp float innerGradDot = max(dot(innerGrad, innerGrad), 1.1755e-38);");
+    fragBuilder->codeAppend("  highp float innerInvlen = inversesqrt(innerGradDot);");
     fragBuilder->codeAppend("  innerAlpha = clamp(0.5+innerTest*innerInvlen, 0.0, 1.0);");
     fragBuilder->codeAppend("} else if (hasYCurve) {");
     // Horizontal edge: inner coverage from edgeDist.y minus full stroke width
@@ -140,8 +142,8 @@ void GLSLComplexEllipseGeometryProcessor::emitCode(EmitArgs& args) const {
     fragBuilder->codeAppend("  innerAlpha = clamp(0.5 - (eDist.x - 2.0*sw.x), 0.0, 1.0);");
     fragBuilder->codeAppend("} else {");
     // Center region: use min of both inner edge distances
-    fragBuilder->codeAppend("  float innerEdgeX = eDist.x - 2.0*sw.x;");
-    fragBuilder->codeAppend("  float innerEdgeY = eDist.y - 2.0*sw.y;");
+    fragBuilder->codeAppend("  highp float innerEdgeX = eDist.x - 2.0*sw.x;");
+    fragBuilder->codeAppend("  highp float innerEdgeY = eDist.y - 2.0*sw.y;");
     fragBuilder->codeAppend("  innerAlpha = clamp(0.5 - min(innerEdgeX, innerEdgeY), 0.0, 1.0);");
     fragBuilder->codeAppend("}");
     fragBuilder->codeAppend("outerAlpha *= innerAlpha;");

--- a/src/gpu/glsl/processors/GLSLComplexNonAARRectGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLComplexNonAARRectGeometryProcessor.cpp
@@ -82,10 +82,10 @@ void GLSLComplexNonAARRectGeometryProcessor::emitCode(EmitArgs& args) const {
                  ShaderVar(inPosition.name(), SLType::Float2));
 
   // Fragment shader - evaluate round rect shape using SDF with per-corner radii
-  fragBuilder->codeAppendf("vec2 localCoord = %s;", localCoordVarying.fsIn().c_str());
-  fragBuilder->codeAppendf("vec4 xR = %s;", xRadiiVarying.fsIn().c_str());
-  fragBuilder->codeAppendf("vec4 yR = %s;", yRadiiVarying.fsIn().c_str());
-  fragBuilder->codeAppendf("vec4 bounds = %s;", boundsVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 localCoord = %s;", localCoordVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec4 xR = %s;", xRadiiVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec4 yR = %s;", yRadiiVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec4 bounds = %s;", boundsVarying.fsIn().c_str());
 
   // For each corner, test whether the fragment lies in the axis-aligned box spanning from the
   // rect corner to that corner's arc center. Adjacent boxes can touch on a seam when two radii
@@ -93,55 +93,58 @@ void GLSLComplexNonAARRectGeometryProcessor::emitCode(EmitArgs& args) const {
   // must guarantee that diagonal corner boxes do not overlap. Collapse inBox to one-hot so the
   // downstream dot() products read a single corner's center and radii.
   // xR/yR order: [TL, TR, BR, BL].
-  fragBuilder->codeAppend("vec4 cornersX = vec4(bounds.x, bounds.z, bounds.z, bounds.x);");
-  fragBuilder->codeAppend("vec4 cornersY = vec4(bounds.y, bounds.y, bounds.w, bounds.w);");
-  fragBuilder->codeAppend("vec4 signsX = vec4(1.0, -1.0, -1.0, 1.0);");
-  fragBuilder->codeAppend("vec4 signsY = vec4(1.0, 1.0, -1.0, -1.0);");
-  fragBuilder->codeAppend("vec4 dx = (vec4(localCoord.x) - cornersX) * signsX;");
-  fragBuilder->codeAppend("vec4 dy = (vec4(localCoord.y) - cornersY) * signsY;");
+  fragBuilder->codeAppend("highp vec4 cornersX = vec4(bounds.x, bounds.z, bounds.z, bounds.x);");
+  fragBuilder->codeAppend("highp vec4 cornersY = vec4(bounds.y, bounds.y, bounds.w, bounds.w);");
+  fragBuilder->codeAppend("highp vec4 signsX = vec4(1.0, -1.0, -1.0, 1.0);");
+  fragBuilder->codeAppend("highp vec4 signsY = vec4(1.0, 1.0, -1.0, -1.0);");
+  fragBuilder->codeAppend("highp vec4 dx = (vec4(localCoord.x) - cornersX) * signsX;");
+  fragBuilder->codeAppend("highp vec4 dy = (vec4(localCoord.y) - cornersY) * signsY;");
   // dx and dy are always non-negative because the quad covers exactly the (possibly
   // stroke-outset) rect, so the lower bound checks are omitted.
-  fragBuilder->codeAppend("vec4 inBox = step(dx, xR) * step(dy, yR);");
+  fragBuilder->codeAppend("highp vec4 inBox = step(dx, xR) * step(dy, yR);");
   // One-hot collapse: keep the first 1 in inBox and zero the rest. A slot stays 1 only when
   // the prefix sum of previous slots is still 0.
   fragBuilder->codeAppend(
-      "vec4 prefixSum = vec4(0.0, inBox.x, inBox.x + inBox.y, inBox.x + inBox.y + inBox.z);");
+      "highp vec4 prefixSum = vec4(0.0, inBox.x, inBox.x + inBox.y, inBox.x + inBox.y + inBox.z);");
   fragBuilder->codeAppend("inBox *= step(prefixSum, vec4(0.5));");
-  fragBuilder->codeAppend("float inAnyCorner = dot(inBox, vec4(1.0));");
+  fragBuilder->codeAppend("highp float inAnyCorner = dot(inBox, vec4(1.0));");
   // Selected corner's arc center and radii (in local coordinates).
-  fragBuilder->codeAppend("vec4 arcCentersX = cornersX + signsX * xR;");
-  fragBuilder->codeAppend("vec4 arcCentersY = cornersY + signsY * yR;");
+  fragBuilder->codeAppend("highp vec4 arcCentersX = cornersX + signsX * xR;");
+  fragBuilder->codeAppend("highp vec4 arcCentersY = cornersY + signsY * yR;");
   fragBuilder->codeAppend(
-      "vec2 arcCenter = vec2(dot(inBox, arcCentersX), dot(inBox, arcCentersY));");
-  fragBuilder->codeAppend("vec2 radii = max(vec2(dot(inBox, xR), dot(inBox, yR)), vec2(1e-6));");
+      "highp vec2 arcCenter = vec2(dot(inBox, arcCentersX), dot(inBox, arcCentersY));");
+  fragBuilder->codeAppend(
+      "highp vec2 radii = max(vec2(dot(inBox, xR), dot(inBox, yR)), vec2(1e-6));");
 
   // Outer coverage: inside the owning corner ellipse, or anywhere outside all corner boxes
   // (edge/center region).
-  fragBuilder->codeAppend("vec2 ellipseOffset = (localCoord - arcCenter) / radii;");
-  fragBuilder->codeAppend("float insideEllipse = step(dot(ellipseOffset, ellipseOffset), 1.0);");
-  fragBuilder->codeAppend("float outerCoverage = mix(1.0, insideEllipse, inAnyCorner);");
+  fragBuilder->codeAppend("highp vec2 ellipseOffset = (localCoord - arcCenter) / radii;");
+  fragBuilder->codeAppend(
+      "highp float insideEllipse = step(dot(ellipseOffset, ellipseOffset), 1.0);");
+  fragBuilder->codeAppend("highp float outerCoverage = mix(1.0, insideEllipse, inAnyCorner);");
 
   if (stroke) {
-    fragBuilder->codeAppendf("vec2 sw = %s;", strokeWidthVarying.fsIn().c_str());
+    fragBuilder->codeAppendf("highp vec2 sw = %s;", strokeWidthVarying.fsIn().c_str());
     // Inner coverage: for corner fragments, test the inner ellipse (same center, radii
     // shrunk by the full stroke width); for edge/center fragments, test the inner rect
     // (rect shrunk by the full stroke width on each side).
-    fragBuilder->codeAppend("vec2 innerRadii = max(radii - 2.0 * sw, vec2(1e-6));");
-    fragBuilder->codeAppend("vec2 innerEllipseOffset = (localCoord - arcCenter) / innerRadii;");
+    fragBuilder->codeAppend("highp vec2 innerRadii = max(radii - 2.0 * sw, vec2(1e-6));");
     fragBuilder->codeAppend(
-        "float insideInnerEllipse = step(dot(innerEllipseOffset, innerEllipseOffset), 1.0);");
-    fragBuilder->codeAppend("vec2 center = (bounds.xy + bounds.zw) * 0.5;");
-    fragBuilder->codeAppend("vec2 halfSize = (bounds.zw - bounds.xy) * 0.5;");
-    fragBuilder->codeAppend("vec2 innerHalfSize = halfSize - 2.0 * sw;");
-    fragBuilder->codeAppend("vec2 p = abs(localCoord - center);");
+        "highp vec2 innerEllipseOffset = (localCoord - arcCenter) / innerRadii;");
     fragBuilder->codeAppend(
-        "float insideInnerRect = step(0.0, innerHalfSize.x) * step(0.0, innerHalfSize.y)"
+        "highp float insideInnerEllipse = step(dot(innerEllipseOffset, innerEllipseOffset), 1.0);");
+    fragBuilder->codeAppend("highp vec2 center = (bounds.xy + bounds.zw) * 0.5;");
+    fragBuilder->codeAppend("highp vec2 halfSize = (bounds.zw - bounds.xy) * 0.5;");
+    fragBuilder->codeAppend("highp vec2 innerHalfSize = halfSize - 2.0 * sw;");
+    fragBuilder->codeAppend("highp vec2 p = abs(localCoord - center);");
+    fragBuilder->codeAppend(
+        "highp float insideInnerRect = step(0.0, innerHalfSize.x) * step(0.0, innerHalfSize.y)"
         " * step(p.x, innerHalfSize.x) * step(p.y, innerHalfSize.y);");
     fragBuilder->codeAppend(
-        "float innerCoverage = mix(insideInnerRect, insideInnerEllipse, inAnyCorner);");
-    fragBuilder->codeAppend("float coverage = outerCoverage * (1.0 - innerCoverage);");
+        "highp float innerCoverage = mix(insideInnerRect, insideInnerEllipse, inAnyCorner);");
+    fragBuilder->codeAppend("highp float coverage = outerCoverage * (1.0 - innerCoverage);");
   } else {
-    fragBuilder->codeAppend("float coverage = outerCoverage;");
+    fragBuilder->codeAppend("highp float coverage = outerCoverage;");
   }
 
   fragBuilder->codeAppendf("%s = vec4(coverage);", args.outputCoverage.c_str());

--- a/src/gpu/glsl/processors/GLSLConicGradientLayout.cpp
+++ b/src/gpu/glsl/processors/GLSLConicGradientLayout.cpp
@@ -35,9 +35,9 @@ void GLSLConicGradientLayout::emitCode(EmitArgs& args) const {
   auto biasName = uniformHandler->addUniform("Bias", UniformFormat::Float, ShaderStage::Fragment);
   auto scaleName = uniformHandler->addUniform("Scale", UniformFormat::Float, ShaderStage::Fragment);
   const auto coordName = fragBuilder->emitPerspTextCoord((*args.transformedCoords)[0]);
-  fragBuilder->codeAppendf("float angle = atan(-%s.y, -%s.x);", coordName.c_str(),
+  fragBuilder->codeAppendf("highp float angle = atan(-%s.y, -%s.x);", coordName.c_str(),
                            coordName.c_str());
-  fragBuilder->codeAppendf("float t = ((angle * 0.15915494309180001 + 0.5) + %s) * %s;",
+  fragBuilder->codeAppendf("highp float t = ((angle * 0.15915494309180001 + 0.5) + %s) * %s;",
                            biasName.c_str(), scaleName.c_str());
   fragBuilder->codeAppendf("%s = vec4(t, 1.0, 0.0, 0.0);", args.outputColor.c_str());
 }

--- a/src/gpu/glsl/processors/GLSLDeviceSpaceTextureEffect.cpp
+++ b/src/gpu/glsl/processors/GLSLDeviceSpaceTextureEffect.cpp
@@ -37,7 +37,7 @@ void GLSLDeviceSpaceTextureEffect::emitCode(EmitArgs& args) const {
   auto uniformHandler = args.uniformHandler;
   auto deviceCoordMatrixName = uniformHandler->addUniform(
       "DeviceCoordMatrix", UniformFormat::Float3x3, ShaderStage::Fragment);
-  fragBuilder->codeAppendf("vec3 deviceCoord = %s * vec3(gl_FragCoord.xy, 1.0);",
+  fragBuilder->codeAppendf("highp vec3 deviceCoord = %s * vec3(gl_FragCoord.xy, 1.0);",
                            deviceCoordMatrixName.c_str());
   std::string coordName = "deviceCoord.xy";
   fragBuilder->codeAppendf("%s = ", args.outputColor.c_str());

--- a/src/gpu/glsl/processors/GLSLDiamondGradientLayout.cpp
+++ b/src/gpu/glsl/processors/GLSLDiamondGradientLayout.cpp
@@ -31,8 +31,8 @@ GLSLDiamondGradientLayout::GLSLDiamondGradientLayout(Matrix matrix)
 void GLSLDiamondGradientLayout::emitCode(EmitArgs& args) const {
   auto fragBuilder = args.fragBuilder;
   const auto coordName = fragBuilder->emitPerspTextCoord((*args.transformedCoords)[0]);
-  fragBuilder->codeAppendf("vec2 rotated = %s;", coordName.c_str());
-  fragBuilder->codeAppendf("float t = max(abs(rotated.x), abs(rotated.y));");
+  fragBuilder->codeAppendf("highp vec2 rotated = %s;", coordName.c_str());
+  fragBuilder->codeAppendf("highp float t = max(abs(rotated.x), abs(rotated.y));");
   fragBuilder->codeAppendf("%s = vec4(t, 1.0, 0.0, 0.0);", args.outputColor.c_str());
 }
 

--- a/src/gpu/glsl/processors/GLSLEllipseGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLEllipseGeometryProcessor.cpp
@@ -73,16 +73,16 @@ void GLSLEllipseGeometryProcessor::emitCode(EmitArgs& args) const {
   // by zero, then we scale the result back.
 
   // for outer curve
-  fragBuilder->codeAppendf("vec2 offset = %s.xy;", ellipseOffsets.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 offset = %s.xy;", ellipseOffsets.fsIn().c_str());
   if (stroke) {
     fragBuilder->codeAppendf("offset *= %s.xy;", ellipseRadii.fsIn().c_str());
   }
-  fragBuilder->codeAppend("float test = dot(offset, offset) - 1.0;");
-  fragBuilder->codeAppendf("vec2 grad = 2.0*offset*%s.xy;", ellipseRadii.fsIn().c_str());
-  fragBuilder->codeAppend("float grad_dot = dot(grad, grad);");
+  fragBuilder->codeAppend("highp float test = dot(offset, offset) - 1.0;");
+  fragBuilder->codeAppendf("highp vec2 grad = 2.0*offset*%s.xy;", ellipseRadii.fsIn().c_str());
+  fragBuilder->codeAppend("highp float grad_dot = dot(grad, grad);");
   fragBuilder->codeAppend("grad_dot = max(grad_dot, 1.1755e-38);");
-  fragBuilder->codeAppend("float invlen = inversesqrt(grad_dot);");
-  fragBuilder->codeAppend("float edgeAlpha = clamp(0.5-test*invlen, 0.0, 1.0);");
+  fragBuilder->codeAppend("highp float invlen = inversesqrt(grad_dot);");
+  fragBuilder->codeAppend("highp float edgeAlpha = clamp(0.5-test*invlen, 0.0, 1.0);");
 
   // for inner curve
   if (stroke) {

--- a/src/gpu/glsl/processors/GLSLHairlineLineGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLHairlineLineGeometryProcessor.cpp
@@ -48,7 +48,7 @@ void GLSLHairlineLineGeometryProcessor::emitCode(EmitArgs& args) const {
   auto matrixName =
       uniformHandler->addUniform("Matrix", UniformFormat::Float3x3, ShaderStage::Vertex);
   std::string positionName = "transformedPosition";
-  vertBuilder->codeAppendf("vec2 %s = (%s * vec3(%s, 1.0)).xy;", positionName.c_str(),
+  vertBuilder->codeAppendf("highp vec2 %s = (%s * vec3(%s, 1.0)).xy;", positionName.c_str(),
                            matrixName.c_str(), position.name().c_str());
 
   emitTransforms(args, vertBuilder, varyingHandler, uniformHandler,
@@ -58,7 +58,7 @@ void GLSLHairlineLineGeometryProcessor::emitCode(EmitArgs& args) const {
   vertBuilder->codeAppendf("%s = %s;", edgeVarying.vsOut().c_str(), edgeDistance.name().c_str());
 
   // Fragment shader: calculate anti-aliasing based on edge distance
-  fragBuilder->codeAppendf("float edgeAlpha = abs(%s);", edgeVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp float edgeAlpha = abs(%s);", edgeVarying.fsIn().c_str());
   fragBuilder->codeAppend("edgeAlpha = clamp(edgeAlpha, 0.0, 1.0);");
   if (aaType != AAType::Coverage) {
     // Non-coverage anti-aliasing

--- a/src/gpu/glsl/processors/GLSLHairlineQuadGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLHairlineQuadGeometryProcessor.cpp
@@ -48,7 +48,7 @@ void GLSLHairlineQuadGeometryProcessor::emitCode(EmitArgs& args) const {
   auto matrixName =
       uniformHandler->addUniform("Matrix", UniformFormat::Float3x3, ShaderStage::Vertex);
   std::string positionName = "transformedPosition";
-  vertBuilder->codeAppendf("vec2 %s = (%s * vec3(%s, 1.0)).xy;", positionName.c_str(),
+  vertBuilder->codeAppendf("highp vec2 %s = (%s * vec3(%s, 1.0)).xy;", positionName.c_str(),
                            matrixName.c_str(), position.name().c_str());
   emitTransforms(args, vertBuilder, varyingHandler, uniformHandler,
                  ShaderVar(positionName, SLType::Float2));
@@ -61,14 +61,14 @@ void GLSLHairlineQuadGeometryProcessor::emitCode(EmitArgs& args) const {
   // The UV coordinates are set up so that the curve is defined by the implicit equation: u^2 - v = 0
   // Points where u^2 < v are inside the curve, u^2 > v are outside.
   const char* edge = edgeVarying.fsIn().c_str();
-  fragBuilder->codeAppendf("float edgeAlpha;");
+  fragBuilder->codeAppendf("highp float edgeAlpha;");
   // Compute screen-space partial derivatives of UV coordinates for gradient calculation
-  fragBuilder->codeAppendf("vec2 duvdx = vec2(dFdx(%s.xy));", edge);
-  fragBuilder->codeAppendf("vec2 duvdy = vec2(dFdy(%s.xy));", edge);
+  fragBuilder->codeAppendf("highp vec2 duvdx = vec2(dFdx(%s.xy));", edge);
+  fragBuilder->codeAppendf("highp vec2 duvdy = vec2(dFdy(%s.xy));", edge);
   // Compute gradient of the implicit function F(u,v) = u^2 - v
   // gradF = (dF/dx, dF/dy) where dF/dx = 2u * du/dx - dv/dx, dF/dy = 2u * du/dy - dv/dy
   fragBuilder->codeAppendf(
-      "vec2 gF = vec2(2.0 * %s.x * duvdx.x - duvdx.y,"
+      "highp vec2 gF = vec2(2.0 * %s.x * duvdx.x - duvdx.y,"
       "               2.0 * %s.x * duvdy.x - duvdy.y);",
       edge, edge);
   // Evaluate the implicit function: F = u^2 - v (positive outside, negative inside)

--- a/src/gpu/glsl/processors/GLSLLinearGradientLayout.cpp
+++ b/src/gpu/glsl/processors/GLSLLinearGradientLayout.cpp
@@ -30,7 +30,7 @@ GLSLLinearGradientLayout::GLSLLinearGradientLayout(Matrix matrix) : LinearGradie
 void GLSLLinearGradientLayout::emitCode(EmitArgs& args) const {
   auto fragBuilder = args.fragBuilder;
   const auto coordName = fragBuilder->emitPerspTextCoord((*args.transformedCoords)[0]);
-  fragBuilder->codeAppendf("float t = %s.x + 1.0000000000000001e-05;", coordName.c_str());
+  fragBuilder->codeAppendf("highp float t = %s.x + 1.0000000000000001e-05;", coordName.c_str());
   fragBuilder->codeAppendf("%s = vec4(t, 1.0, 0.0, 0.0);", args.outputColor.c_str());
 }
 }  // namespace tgfx

--- a/src/gpu/glsl/processors/GLSLMeshGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLMeshGeometryProcessor.cpp
@@ -47,7 +47,7 @@ void GLSLMeshGeometryProcessor::emitCode(EmitArgs& args) const {
 
   // Transform position by view matrix
   std::string positionName = "position";
-  vertBuilder->codeAppendf("vec2 %s = (%s * vec3(%s, 1.0)).xy;", positionName.c_str(),
+  vertBuilder->codeAppendf("highp vec2 %s = (%s * vec3(%s, 1.0)).xy;", positionName.c_str(),
                            matrixName.c_str(), position.name().c_str());
 
   // Handle texture coordinates for FragmentProcessor

--- a/src/gpu/glsl/processors/GLSLNonAARRectGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLNonAARRectGeometryProcessor.cpp
@@ -79,40 +79,42 @@ void GLSLNonAARRectGeometryProcessor::emitCode(EmitArgs& args) const {
                  ShaderVar(inPosition.name(), SLType::Float2));
 
   // Fragment shader - evaluate round rect shape using SDF
-  fragBuilder->codeAppendf("vec2 localCoord = %s;", localCoordVarying.fsIn().c_str());
-  fragBuilder->codeAppendf("vec2 radii = %s;", radiiVarying.fsIn().c_str());
-  fragBuilder->codeAppendf("vec4 bounds = %s;", boundsVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 localCoord = %s;", localCoordVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 radii = %s;", radiiVarying.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec4 bounds = %s;", boundsVarying.fsIn().c_str());
 
   // Calculate outer round rect coverage using SDF
-  fragBuilder->codeAppend("vec2 center = (bounds.xy + bounds.zw) * 0.5;");
-  fragBuilder->codeAppend("vec2 halfSize = (bounds.zw - bounds.xy) * 0.5;");
-  fragBuilder->codeAppend("vec2 q = abs(localCoord - center) - halfSize + radii;");
+  fragBuilder->codeAppend("highp vec2 center = (bounds.xy + bounds.zw) * 0.5;");
+  fragBuilder->codeAppend("highp vec2 halfSize = (bounds.zw - bounds.xy) * 0.5;");
+  fragBuilder->codeAppend("highp vec2 q = abs(localCoord - center) - halfSize + radii;");
   fragBuilder->codeAppend(
-      "float d = min(max(q.x / radii.x, q.y / radii.y), 0.0) + length(max(q / radii, 0.0)) - 1.0;");
-  fragBuilder->codeAppend("float outerCoverage = step(d, 0.0);");
+      "highp float d = min(max(q.x / radii.x, q.y / radii.y), 0.0) + length(max(q / radii, 0.0)) - "
+      "1.0;");
+  fragBuilder->codeAppend("highp float outerCoverage = step(d, 0.0);");
 
   if (stroke) {
     // Stroke mode: also check inner round rect using SDF
-    fragBuilder->codeAppendf("vec2 sw = %s;", strokeWidthVarying.fsIn().c_str());
-    fragBuilder->codeAppend("vec2 innerHalfSize = halfSize - 2.0 * sw;");
-    fragBuilder->codeAppend("vec2 innerRadii = max(radii - 2.0 * sw, vec2(0.0));");
-    fragBuilder->codeAppend("float innerCoverage = 0.0;");
+    fragBuilder->codeAppendf("highp vec2 sw = %s;", strokeWidthVarying.fsIn().c_str());
+    fragBuilder->codeAppend("highp vec2 innerHalfSize = halfSize - 2.0 * sw;");
+    fragBuilder->codeAppend("highp vec2 innerRadii = max(radii - 2.0 * sw, vec2(0.0));");
+    fragBuilder->codeAppend("highp float innerCoverage = 0.0;");
     // Check if inner rect is valid (not degenerate)
     fragBuilder->codeAppend("if (innerHalfSize.x > 0.0 && innerHalfSize.y > 0.0) {");
-    fragBuilder->codeAppend("  vec2 qi = abs(localCoord - center) - innerHalfSize + innerRadii;");
-    // Use safe division for inner radii (avoid division by zero)
-    fragBuilder->codeAppend("  vec2 safeInnerRadii = max(innerRadii, vec2(0.001));");
     fragBuilder->codeAppend(
-        "  float di = min(max(qi.x / safeInnerRadii.x, qi.y / safeInnerRadii.y), 0.0) + "
+        "  highp vec2 qi = abs(localCoord - center) - innerHalfSize + innerRadii;");
+    // Use safe division for inner radii (avoid division by zero)
+    fragBuilder->codeAppend("  highp vec2 safeInnerRadii = max(innerRadii, vec2(0.001));");
+    fragBuilder->codeAppend(
+        "  highp float di = min(max(qi.x / safeInnerRadii.x, qi.y / safeInnerRadii.y), 0.0) + "
         "length(max(qi / safeInnerRadii, vec2(0.0))) - 1.0;");
     fragBuilder->codeAppend("  innerCoverage = step(di, 0.0);");
     fragBuilder->codeAppend("}");
 
     // Final coverage: inside outer but outside inner
-    fragBuilder->codeAppend("float coverage = outerCoverage * (1.0 - innerCoverage);");
+    fragBuilder->codeAppend("highp float coverage = outerCoverage * (1.0 - innerCoverage);");
   } else {
     // Fill mode: just use outer coverage
-    fragBuilder->codeAppend("float coverage = outerCoverage;");
+    fragBuilder->codeAppend("highp float coverage = outerCoverage;");
   }
 
   fragBuilder->codeAppendf("%s = vec4(coverage);", args.outputCoverage.c_str());

--- a/src/gpu/glsl/processors/GLSLPerlinNoiseFragmentProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLPerlinNoiseFragmentProcessor.cpp
@@ -96,23 +96,23 @@ void GLSLPerlinNoiseFragmentProcessor::emitCode(EmitArgs& args) const {
   // weight in the final accumulation is ratio = 2^-k <= 1/128, contributing < 1% of the total
   // amplitude. With the supported numOctaves <= 8 this is invisible. The exact bias value is
   // not load-bearing — any small non-zero constant breaks the integer-baseFrequency case.
-  fragBuilder->codeAppendf("vec2 noiseVec = %s * %s + vec2(0.0078125);", texCoordName.c_str(),
+  fragBuilder->codeAppendf("highp vec2 noiseVec = %s * %s + vec2(0.0078125);", texCoordName.c_str(),
                            baseFreqName.c_str());
 
   fragBuilder->codeAppend("vec4 color = vec4(0.0);");
 
   if (stitchTiles) {
-    fragBuilder->codeAppendf("vec2 stitchData = %s;", stitchDataName.c_str());
+    fragBuilder->codeAppendf("highp vec2 stitchData = %s;", stitchDataName.c_str());
   }
 
   fragBuilder->codeAppend("float ratio = 1.0;");
 
   fragBuilder->codeAppendf("for (int octave = 0; octave < %d; ++octave) {", numOctaves);
 
-  fragBuilder->codeAppend("vec4 floorVal;");
+  fragBuilder->codeAppend("highp vec4 floorVal;");
   fragBuilder->codeAppend("floorVal.xy = floor(noiseVec);");
   fragBuilder->codeAppend("floorVal.zw = floorVal.xy + vec2(1.0);");
-  fragBuilder->codeAppend("vec2 fractVal = fract(noiseVec);");
+  fragBuilder->codeAppend("highp vec2 fractVal = fract(noiseVec);");
 
   // Hermite interpolation
   fragBuilder->codeAppend("vec2 noiseSmooth = smoothstep(0.0, 1.0, fractVal);");
@@ -127,19 +127,19 @@ void GLSLPerlinNoiseFragmentProcessor::emitCode(EmitArgs& args) const {
 
   // Look up permutation values. Permutations texture is 256x1 A8 (swizzled to RRRR).
   // Texel center: (i + 0.5) / 256.0
-  fragBuilder->codeAppend("float permX = ");
+  fragBuilder->codeAppend("highp float permX = ");
   fragBuilder->appendTextureLookup(permSampler, "vec2((floorVal.x + 0.5) / 256.0, 0.5)");
   fragBuilder->codeAppend(".r;");
 
-  fragBuilder->codeAppend("float permZ = ");
+  fragBuilder->codeAppend("highp float permZ = ");
   fragBuilder->appendTextureLookup(permSampler, "vec2((floorVal.z + 0.5) / 256.0, 0.5)");
   fragBuilder->codeAppend(".r;");
 
   // Recover [0,255] index from [0,1] texture value.
-  fragBuilder->codeAppend("vec2 latticeIdx = floor(vec2(permX, permZ) * 255.0 + 0.5);");
+  fragBuilder->codeAppend("highp vec2 latticeIdx = floor(vec2(permX, permZ) * 255.0 + 0.5);");
 
   // bcoords: (latticeIdx + floorY) mod 256, used to index into noise texture.
-  fragBuilder->codeAppend("vec4 bcoords = mod(latticeIdx.xyxy + floorVal.yyww, 256.0);");
+  fragBuilder->codeAppend("highp vec4 bcoords = mod(latticeIdx.xyxy + floorVal.yyww, 256.0);");
 
   fragBuilder->codeAppend("vec4 noiseResult;");
 

--- a/src/gpu/glsl/processors/GLSLPorterDuffXferProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLPorterDuffXferProcessor.cpp
@@ -57,7 +57,7 @@ void GLSLPorterDuffXferProcessor::emitCode(const EmitArgs& args) const {
 
     fragBuilder->codeAppend("// Read color from copy of the destination.\n");
     std::string dstTexCoord = "_dstTexCoord";
-    fragBuilder->codeAppendf("vec2 %s = (gl_FragCoord.xy - %s) * %s;", dstTexCoord.c_str(),
+    fragBuilder->codeAppendf("highp vec2 %s = (gl_FragCoord.xy - %s) * %s;", dstTexCoord.c_str(),
                              dstTopLeftName.c_str(), dstCoordScaleName.c_str());
 
     fragBuilder->codeAppendf("vec4 %s = ", dstColor.c_str());

--- a/src/gpu/glsl/processors/GLSLRadialGradientLayout.cpp
+++ b/src/gpu/glsl/processors/GLSLRadialGradientLayout.cpp
@@ -30,7 +30,7 @@ GLSLRadialGradientLayout::GLSLRadialGradientLayout(Matrix matrix) : RadialGradie
 void GLSLRadialGradientLayout::emitCode(EmitArgs& args) const {
   auto fragBuilder = args.fragBuilder;
   const auto coordName = fragBuilder->emitPerspTextCoord((*args.transformedCoords)[0]);
-  fragBuilder->codeAppendf("float t = length(%s);", coordName.c_str());
+  fragBuilder->codeAppendf("highp float t = length(%s);", coordName.c_str());
   fragBuilder->codeAppendf("%s = vec4(t, 1.0, 0.0, 0.0);", args.outputColor.c_str());
 }
 }  // namespace tgfx

--- a/src/gpu/glsl/processors/GLSLRoundStrokeRectGeometryProcessor.cpp
+++ b/src/gpu/glsl/processors/GLSLRoundStrokeRectGeometryProcessor.cpp
@@ -68,20 +68,20 @@ void GLSLRoundStrokeRectGeometryProcessor::emitCode(EmitArgs& args) const {
     fragBuilder->codeAppendf("%s = %s;", args.outputColor.c_str(), colorVar.fsIn().c_str());
   }
 
-  fragBuilder->codeAppendf("vec2 offset = %s;", ellipseOffsets.fsIn().c_str());
+  fragBuilder->codeAppendf("highp vec2 offset = %s;", ellipseOffsets.fsIn().c_str());
   if (aaType == AAType::Coverage) {
-    fragBuilder->codeAppend("float test = dot(offset, offset) - 1.0;");
+    fragBuilder->codeAppend("highp float test = dot(offset, offset) - 1.0;");
     fragBuilder->codeAppend("if (test > -0.5) {");
-    fragBuilder->codeAppendf("vec2 grad = 2.0 * offset * %s;", ellipseRadii.fsIn().c_str());
-    fragBuilder->codeAppend("float grad_dot = dot(grad, grad);");
+    fragBuilder->codeAppendf("highp vec2 grad = 2.0 * offset * %s;", ellipseRadii.fsIn().c_str());
+    fragBuilder->codeAppend("highp float grad_dot = dot(grad, grad);");
     fragBuilder->codeAppend("grad_dot = max(grad_dot, 1.1755e-38);");
-    fragBuilder->codeAppend("float invlen = inversesqrt(grad_dot);");
-    fragBuilder->codeAppend("float edgeAlpha = clamp(0.5 - test * invlen, 0.0, 1.0);");
+    fragBuilder->codeAppend("highp float invlen = inversesqrt(grad_dot);");
+    fragBuilder->codeAppend("highp float edgeAlpha = clamp(0.5 - test * invlen, 0.0, 1.0);");
     fragBuilder->codeAppendf("%s *= edgeAlpha;", args.outputCoverage.c_str());
     fragBuilder->codeAppendf("}");
   } else {
-    fragBuilder->codeAppend("float test = dot(offset, offset);");
-    fragBuilder->codeAppend("float edgeAlpha = step(test, 1.0);");
+    fragBuilder->codeAppend("highp float test = dot(offset, offset);");
+    fragBuilder->codeAppend("highp float edgeAlpha = step(test, 1.0);");
     fragBuilder->codeAppendf("%s *= edgeAlpha;", args.outputCoverage.c_str());
   }
 

--- a/src/gpu/glsl/processors/GLSLTextureEffect.cpp
+++ b/src/gpu/glsl/processors/GLSLTextureEffect.cpp
@@ -126,8 +126,8 @@ void GLSLTextureEffect::emitDefaultTextureCode(EmitArgs& args) const {
     auto alphaStartName =
         uniformHandler->addUniform("AlphaStart", UniformFormat::Float2, ShaderStage::Fragment);
     std::string alphaVertexColor = "alphaVertexColor";
-    fragBuilder->codeAppendf("vec2 %s = %s + %s;", alphaVertexColor.c_str(), finalCoordName.c_str(),
-                             alphaStartName.c_str());
+    fragBuilder->codeAppendf("highp vec2 %s = %s + %s;", alphaVertexColor.c_str(),
+                             finalCoordName.c_str(), alphaStartName.c_str());
     fragBuilder->codeAppend("vec4 alpha = ");
     fragBuilder->appendTextureLookup(textureSampler, alphaVertexColor);
     fragBuilder->codeAppend(";");
@@ -186,8 +186,8 @@ void GLSLTextureEffect::emitYUVTextureCode(EmitArgs& args) const {
     auto alphaStartName =
         uniformHandler->addUniform("AlphaStart", UniformFormat::Float2, ShaderStage::Fragment);
     std::string alphaVertexColor = "alphaVertexColor";
-    fragBuilder->codeAppendf("vec2 %s = %s + %s;", alphaVertexColor.c_str(), finalCoordName.c_str(),
-                             alphaStartName.c_str());
+    fragBuilder->codeAppendf("highp vec2 %s = %s + %s;", alphaVertexColor.c_str(),
+                             finalCoordName.c_str(), alphaStartName.c_str());
     fragBuilder->codeAppend("float yuv_a = ");
     fragBuilder->appendTextureLookup(textureSamplers[0], alphaVertexColor);
     fragBuilder->codeAppend(".r;");

--- a/src/gpu/glsl/processors/GLSLTextureGradientColorizer.cpp
+++ b/src/gpu/glsl/processors/GLSLTextureGradientColorizer.cpp
@@ -33,7 +33,7 @@ GLSLTextureGradientColorizer::GLSLTextureGradientColorizer(std::shared_ptr<Textu
 
 void GLSLTextureGradientColorizer::emitCode(EmitArgs& args) const {
   auto fragBuilder = args.fragBuilder;
-  fragBuilder->codeAppendf("vec2 coord = vec2(%s.x, 0.5);", args.inputColor.c_str());
+  fragBuilder->codeAppendf("highp vec2 coord = vec2(%s.x, 0.5);", args.inputColor.c_str());
   fragBuilder->codeAppendf("%s = ", args.outputColor.c_str());
   fragBuilder->appendTextureLookup((*args.textureSamplers)[0], "coord");
   fragBuilder->codeAppend(";");

--- a/src/gpu/glsl/processors/GLSLTiledTextureEffect.cpp
+++ b/src/gpu/glsl/processors/GLSLTiledTextureEffect.cpp
@@ -138,31 +138,31 @@ void GLSLTiledTextureEffect::subsetCoord(EmitArgs& args, TiledTextureEffect::Sha
     case TiledTextureEffect::ShaderMode::RepeatNearestMipmap:
     case TiledTextureEffect::ShaderMode::RepeatLinearMipmap:
       fragBuilder->codeAppend("{");
-      fragBuilder->codeAppendf("float w = %s.%s - %s.%s;", subsetName.c_str(), subsetStopSwizzle,
+      fragBuilder->codeAppendf("highp float w = %s.%s - %s.%s;", subsetName.c_str(),
+                               subsetStopSwizzle, subsetName.c_str(), subsetStartSwizzle);
+      fragBuilder->codeAppendf("highp float w2 = 2.0 * w;");
+      fragBuilder->codeAppendf("highp float d = inCoord.%s - %s.%s;", coordSwizzle,
                                subsetName.c_str(), subsetStartSwizzle);
-      fragBuilder->codeAppendf("float w2 = 2.0 * w;");
-      fragBuilder->codeAppendf("float d = inCoord.%s - %s.%s;", coordSwizzle, subsetName.c_str(),
-                               subsetStartSwizzle);
-      fragBuilder->codeAppend("float m = mod(d, w2);");
-      fragBuilder->codeAppend("float o = mix(m, w2 - m, step(w, m));");
+      fragBuilder->codeAppend("highp float m = mod(d, w2);");
+      fragBuilder->codeAppend("highp float o = mix(m, w2 - m, step(w, m));");
       fragBuilder->codeAppendf("subsetCoord.%s = o + %s.%s;", coordSwizzle, subsetName.c_str(),
                                subsetStartSwizzle);
       fragBuilder->codeAppendf("%s = w - o + %s.%s;", extraCoord, subsetName.c_str(),
                                subsetStartSwizzle);
       // coordWeight is used as the third param of mix() to blend between a sample taken using
       // subsetCoord and a sample at extraCoord.
-      fragBuilder->codeAppend("float hw = w / 2.0;");
-      fragBuilder->codeAppend("float n = mod(d - hw, w2);");
+      fragBuilder->codeAppend("highp float hw = w / 2.0;");
+      fragBuilder->codeAppend("highp float n = mod(d - hw, w2);");
       fragBuilder->codeAppendf("%s = clamp(mix(n, w2 - n, step(w, n)) - hw + 0.5, 0.0, 1.0);",
                                coordWeight);
       fragBuilder->codeAppend("}");
       break;
     case TiledTextureEffect::ShaderMode::MirrorRepeat:
       fragBuilder->codeAppend("{");
-      fragBuilder->codeAppendf("float w = %s.%s - %s.%s;", subsetName.c_str(), subsetStopSwizzle,
-                               subsetName.c_str(), subsetStartSwizzle);
-      fragBuilder->codeAppendf("float w2 = 2.0 * w;");
-      fragBuilder->codeAppendf("float m = mod(inCoord.%s - %s.%s, w2);", coordSwizzle,
+      fragBuilder->codeAppendf("highp float w = %s.%s - %s.%s;", subsetName.c_str(),
+                               subsetStopSwizzle, subsetName.c_str(), subsetStartSwizzle);
+      fragBuilder->codeAppendf("highp float w2 = 2.0 * w;");
+      fragBuilder->codeAppendf("highp float m = mod(inCoord.%s - %s.%s, w2);", coordSwizzle,
                                subsetName.c_str(), subsetStartSwizzle);
       fragBuilder->codeAppendf("subsetCoord.%s = mix(m, w2 - m, step(w, m)) + %s.%s;", coordSwizzle,
                                subsetName.c_str(), subsetStartSwizzle);
@@ -236,7 +236,7 @@ void GLSLTiledTextureEffect::emitCode(EmitArgs& args) const {
     fragBuilder->appendTextureLookup((*args.textureSamplers)[0], texCoordName);
     fragBuilder->codeAppend(";");
   } else {
-    fragBuilder->codeAppendf("vec2 inCoord = %s;", texCoordName.c_str());
+    fragBuilder->codeAppendf("highp vec2 inCoord = %s;", texCoordName.c_str());
     bool useClamp[2] = {ShaderModeUsesClamp(sampling.shaderModeX),
                         ShaderModeUsesClamp(sampling.shaderModeY)};
     auto names = initUniform(args, textureView, sampling, useClamp);
@@ -257,7 +257,7 @@ void GLSLTiledTextureEffect::emitCode(EmitArgs& args) const {
         sampling.shaderModeY == TiledTextureEffect::ShaderMode::RepeatLinearMipmap;
 
     if (mipmapRepeatX || mipmapRepeatY) {
-      fragBuilder->codeAppend("vec2 extraRepeatCoord;");
+      fragBuilder->codeAppend("highp vec2 extraRepeatCoord;");
     }
     if (mipmapRepeatX) {
       fragBuilder->codeAppend("float repeatCoordWeightX;");
@@ -345,16 +345,16 @@ void GLSLTiledTextureEffect::emitCode(EmitArgs& args) const {
     bool repeatY = sampling.shaderModeY == TiledTextureEffect::ShaderMode::RepeatLinearNone ||
                    sampling.shaderModeY == TiledTextureEffect::ShaderMode::RepeatLinearMipmap;
     if (repeatX || sampling.shaderModeX == TiledTextureEffect::ShaderMode::ClampToBorderLinear) {
-      fragBuilder->codeAppend("float errX = subsetCoord.x - clampedCoord.x;");
+      fragBuilder->codeAppend("highp float errX = subsetCoord.x - clampedCoord.x;");
       if (repeatX) {
-        fragBuilder->codeAppendf("float repeatCoordX = errX > 0.0 ? %s.x : %s.z;",
+        fragBuilder->codeAppendf("highp float repeatCoordX = errX > 0.0 ? %s.x : %s.z;",
                                  names.clampName.c_str(), names.clampName.c_str());
       }
     }
     if (repeatY || sampling.shaderModeY == TiledTextureEffect::ShaderMode::ClampToBorderLinear) {
-      fragBuilder->codeAppend("float errY = subsetCoord.y - clampedCoord.y;");
+      fragBuilder->codeAppend("highp float errY = subsetCoord.y - clampedCoord.y;");
       if (repeatY) {
-        fragBuilder->codeAppendf("float repeatCoordY = errY > 0.0 ? %s.y : %s.w;",
+        fragBuilder->codeAppendf("highp float repeatCoordY = errY > 0.0 ? %s.y : %s.w;",
                                  names.clampName.c_str(), names.clampName.c_str());
       }
     }
@@ -411,14 +411,14 @@ void GLSLTiledTextureEffect::emitCode(EmitArgs& args) const {
       fragBuilder->codeAppendf("textureColor = mix(textureColor, vec4(0.0), min(abs(errY), 1.0));");
     }
     if (sampling.shaderModeX == TiledTextureEffect::ShaderMode::ClampToBorderNearest) {
-      fragBuilder->codeAppend("float snappedX = floor(inCoord.x + 0.001) + 0.5;");
+      fragBuilder->codeAppend("highp float snappedX = floor(inCoord.x + 0.001) + 0.5;");
       fragBuilder->codeAppendf("if (snappedX < %s.x || snappedX > %s.z) {",
                                names.subsetName.c_str(), names.subsetName.c_str());
       fragBuilder->codeAppend("textureColor = vec4(0.0);");  // border color
       fragBuilder->codeAppend("}");
     }
     if (sampling.shaderModeY == TiledTextureEffect::ShaderMode::ClampToBorderNearest) {
-      fragBuilder->codeAppend("float snappedY = floor(inCoord.y + 0.001) + 0.5;");
+      fragBuilder->codeAppend("highp float snappedY = floor(inCoord.y + 0.001) + 0.5;");
       fragBuilder->codeAppendf("if (snappedY < %s.y || snappedY > %s.w) {",
                                names.subsetName.c_str(), names.subsetName.c_str());
       fragBuilder->codeAppend("textureColor = vec4(0.0);");  // border color

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3463,47 +3463,4 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyRectStroke"));
 }
 
-// Regression for discussion #1482: a rounded-rect filled with a conic gradient must render a
-// solid fill. On OpenGL ES hardware the default mediump fragment precision could collapse the
-// interior coverage to zero, leaving only the anti-aliased outline (a hollow center). Verifies
-// the interior pixels are fully opaque.
-TGFX_TEST(CanvasTest, ConicGradientFillHollow) {
-  ContextScope scope;
-  auto context = scope.getContext();
-  ASSERT_TRUE(context != nullptr);
-  int size = 200;
-  auto surface = Surface::Make(context, size, size);
-  auto canvas = surface->getCanvas();
-  canvas->clear();
-
-  auto center = Point::Make(size / 2, size / 2);
-  auto conicShader = Shader::MakeConicGradient(
-      center, 0, 360,
-      {Color::FromRGBA(0, 255, 255, 255), Color::FromRGBA(255, 0, 255, 255),
-       Color::FromRGBA(255, 255, 0, 255), Color::FromRGBA(0, 255, 255, 255)},
-      {});
-  Path path = {};
-  path.addRoundRect(Rect::MakeXYWH(20, 20, size - 40, size - 40), 20, 20);
-  Paint paint = {};
-  paint.setShader(conicShader);
-  canvas->drawPath(path, paint);
-  context->flushAndSubmit();
-
-  Bitmap bitmap(size, size, false, false);
-  auto pixels = bitmap.lockPixels();
-  ASSERT_TRUE(surface->readPixels(bitmap.info(), pixels));
-  bitmap.unlockPixels();
-
-  auto addr = static_cast<const uint8_t*>(pixels);
-  // Sample interior points that must be opaque if the fill is solid.
-  auto stride = static_cast<size_t>(size);
-  auto half = static_cast<size_t>(size / 2);
-  int centerAlpha = addr[(half * stride + half) * 4 + 3];
-  int q1 = addr[((half - 30) * stride + (half - 30)) * 4 + 3];
-  int q2 = addr[((half + 30) * stride + (half + 30)) * 4 + 3];
-  EXPECT_GT(centerAlpha, 250);
-  EXPECT_GT(q1, 250);
-  EXPECT_GT(q2, 250);
-}
-
 }  // namespace tgfx

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -3463,4 +3463,47 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyRectStroke"));
 }
 
+// Regression for discussion #1482: a rounded-rect filled with a conic gradient must render a
+// solid fill. On OpenGL ES hardware the default mediump fragment precision could collapse the
+// interior coverage to zero, leaving only the anti-aliased outline (a hollow center). Verifies
+// the interior pixels are fully opaque.
+TGFX_TEST(CanvasTest, ConicGradientFillHollow) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  int size = 200;
+  auto surface = Surface::Make(context, size, size);
+  auto canvas = surface->getCanvas();
+  canvas->clear();
+
+  auto center = Point::Make(size / 2, size / 2);
+  auto conicShader = Shader::MakeConicGradient(
+      center, 0, 360,
+      {Color::FromRGBA(0, 255, 255, 255), Color::FromRGBA(255, 0, 255, 255),
+       Color::FromRGBA(255, 255, 0, 255), Color::FromRGBA(0, 255, 255, 255)},
+      {});
+  Path path = {};
+  path.addRoundRect(Rect::MakeXYWH(20, 20, size - 40, size - 40), 20, 20);
+  Paint paint = {};
+  paint.setShader(conicShader);
+  canvas->drawPath(path, paint);
+  context->flushAndSubmit();
+
+  Bitmap bitmap(size, size, false, false);
+  auto pixels = bitmap.lockPixels();
+  ASSERT_TRUE(surface->readPixels(bitmap.info(), pixels));
+  bitmap.unlockPixels();
+
+  auto addr = static_cast<const uint8_t*>(pixels);
+  // Sample interior points that must be opaque if the fill is solid.
+  auto stride = static_cast<size_t>(size);
+  auto half = static_cast<size_t>(size / 2);
+  int centerAlpha = addr[(half * stride + half) * 4 + 3];
+  int q1 = addr[((half - 30) * stride + (half - 30)) * 4 + 3];
+  int q2 = addr[((half + 30) * stride + (half + 30)) * 4 + 3];
+  EXPECT_GT(centerAlpha, 250);
+  EXPECT_GT(q1, 250);
+  EXPECT_GT(q2, 250);
+}
+
 }  // namespace tgfx


### PR DESCRIPTION
在 OpenGL ES 上，片段着色器中坐标和覆盖率计算默认使用 mediump 精度，精度不足会导致填充区域出现空心（hollow fills）的渲染问题。

本次修改将各类 GLSL 处理器（几何处理器、渐变、纹理、噪声、混合等）中涉及坐标和覆盖率的计算统一改为 highp 精度，从源头修复该精度问题，并在 CanvasTest 中新增对应的测试用例验证。

issues:https://github.com/Tencent/tgfx/discussions/1482