### PR TITLE
Add Task::waitFor timeout variant to avoid indefinite hangs on stuck async tasks.

### DIFF
--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <functional>
 #include <memory>
@@ -119,6 +120,16 @@ class Task {
    * canceled and still in the queue.
    */
   void wait();
+
+  /**
+   * Blocks the current thread until the Task finishes its execution or the specified timeout
+   * elapses. Returns true if the Task finished or was canceled before the timeout, false if it
+   * timed out. The task may be executed on the calling thread if it is not canceled and still in
+   * the queue, in which case the timeout is not applied.
+   * @param timeout The maximum duration to wait for the Task to finish.
+   * @return true if the Task finished or was canceled before the timeout, false if it timed out.
+   */
+  bool waitFor(std::chrono::milliseconds timeout);
 
  protected:
   /**

--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -115,21 +115,15 @@ class Task {
   void cancel();
 
   /**
-   * Blocks the current thread until the Task finishes its execution. Returns immediately if the
-   * Task is finished or canceled. The task may be executed on the calling thread if it is not
-   * canceled and still in the queue.
-   */
-  void wait();
-
-  /**
    * Blocks the current thread until the Task finishes its execution or the specified timeout
-   * elapses. Returns true if the Task finished or was canceled before the timeout, false if it
-   * timed out. The task may be executed on the calling thread if it is not canceled and still in
-   * the queue, in which case the timeout is not applied.
-   * @param timeout The maximum duration to wait for the Task to finish.
-   * @return true if the Task finished or was canceled before the timeout, false if it timed out.
+   * elapses. Returns immediately if the Task is finished or canceled. The task may be executed on
+   * the calling thread if it is not canceled and still in the queue, in which case the timeout is
+   * not applied. If the timeout is zero, this method blocks indefinitely until the Task finishes.
+   * @param timeout The maximum duration to wait for the Task to finish. The default is 0ms, which
+   * means the method will block indefinitely.
+   * @return true if the Task finished or was canceled, false if it timed out.
    */
-  bool waitFor(std::chrono::milliseconds timeout);
+  bool wait(std::chrono::milliseconds timeout = std::chrono::milliseconds(0));
 
  protected:
   /**

--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -19,8 +19,8 @@
 #pragma once
 
 #include <atomic>
-#include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -119,11 +119,11 @@ class Task {
    * elapses. Returns immediately if the Task is finished or canceled. The task may be executed on
    * the calling thread if it is not canceled and still in the queue, in which case the timeout is
    * not applied. If the timeout is zero, this method blocks indefinitely until the Task finishes.
-   * @param timeout The maximum duration to wait for the Task to finish. The default is 0ms, which
-   * means the method will block indefinitely.
+   * @param timeout The maximum duration in milliseconds to wait for the Task to finish. The default
+   * is 0ms, which means the method will block indefinitely.
    * @return true if the Task finished or was canceled, false if it timed out.
    */
-  bool wait(std::chrono::milliseconds timeout = std::chrono::milliseconds(0));
+  bool wait(uint64_t timeout = 0);
 
  protected:
   /**

--- a/src/core/utils/Task.cpp
+++ b/src/core/utils/Task.cpp
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "tgfx/core/Task.h"
+#include <chrono>
 #include "core/utils/TaskGroup.h"
 
 namespace tgfx {
@@ -66,7 +67,7 @@ void Task::cancel() {
   }
 }
 
-bool Task::wait(std::chrono::milliseconds timeout) {
+bool Task::wait(uint64_t timeout) {
   auto oldStatus = _status.load(std::memory_order_acquire);
   if (oldStatus == TaskStatus::Canceled || oldStatus == TaskStatus::Finished) {
     return true;
@@ -86,11 +87,12 @@ bool Task::wait(std::chrono::milliseconds timeout) {
   }
   std::unique_lock<std::mutex> autoLock(locker);
   if (_status.load(std::memory_order_acquire) == TaskStatus::Executing) {
-    if (timeout == std::chrono::milliseconds(0)) {
+    if (timeout == 0) {
       condition.wait(autoLock);
       return true;
     }
-    return condition.wait_for(autoLock, timeout) == std::cv_status::no_timeout;
+    auto chronoTimeout = std::chrono::milliseconds(timeout);
+    return condition.wait_for(autoLock, chronoTimeout) == std::cv_status::no_timeout;
   }
   return true;
 }

--- a/src/core/utils/Task.cpp
+++ b/src/core/utils/Task.cpp
@@ -90,6 +90,32 @@ void Task::wait() {
   }
 }
 
+bool Task::waitFor(std::chrono::milliseconds timeout) {
+  auto oldStatus = _status.load(std::memory_order_acquire);
+  if (oldStatus == TaskStatus::Canceled || oldStatus == TaskStatus::Finished) {
+    return true;
+  }
+  // If waitFor() is called from the thread pool, all threads might block, leaving no thread to
+  // execute this task. To avoid deadlock, execute the task directly on the current thread if it's
+  // queued.
+  if (oldStatus == TaskStatus::Queueing) {
+    if (_status.compare_exchange_strong(oldStatus, TaskStatus::Executing, std::memory_order_acq_rel,
+                                        std::memory_order_relaxed)) {
+      onExecute();
+      oldStatus = TaskStatus::Executing;
+      while (!_status.compare_exchange_weak(oldStatus, TaskStatus::Finished,
+                                            std::memory_order_acq_rel, std::memory_order_relaxed)) {
+      }
+      return true;
+    }
+  }
+  std::unique_lock<std::mutex> autoLock(locker);
+  if (_status.load(std::memory_order_acquire) == TaskStatus::Executing) {
+    return condition.wait_for(autoLock, timeout) == std::cv_status::no_timeout;
+  }
+  return true;
+}
+
 void Task::execute() {
   auto oldStatus = _status.load(std::memory_order_acquire);
   if (oldStatus == TaskStatus::Queueing &&

--- a/src/core/utils/Task.cpp
+++ b/src/core/utils/Task.cpp
@@ -66,38 +66,13 @@ void Task::cancel() {
   }
 }
 
-void Task::wait() {
-  auto oldStatus = _status.load(std::memory_order_acquire);
-  if (oldStatus == TaskStatus::Canceled || oldStatus == TaskStatus::Finished) {
-    return;
-  }
-  // If wait() is called from the thread pool, all threads might block, leaving no thread to execute
-  // this task. To avoid deadlock, execute the task directly on the current thread if it's queued.
-  if (oldStatus == TaskStatus::Queueing) {
-    if (_status.compare_exchange_strong(oldStatus, TaskStatus::Executing, std::memory_order_acq_rel,
-                                        std::memory_order_relaxed)) {
-      onExecute();
-      oldStatus = TaskStatus::Executing;
-      while (!_status.compare_exchange_weak(oldStatus, TaskStatus::Finished,
-                                            std::memory_order_acq_rel, std::memory_order_relaxed)) {
-      }
-      return;
-    }
-  }
-  std::unique_lock<std::mutex> autoLock(locker);
-  if (_status.load(std::memory_order_acquire) == TaskStatus::Executing) {
-    condition.wait(autoLock);
-  }
-}
-
-bool Task::waitFor(std::chrono::milliseconds timeout) {
+bool Task::wait(std::chrono::milliseconds timeout) {
   auto oldStatus = _status.load(std::memory_order_acquire);
   if (oldStatus == TaskStatus::Canceled || oldStatus == TaskStatus::Finished) {
     return true;
   }
-  // If waitFor() is called from the thread pool, all threads might block, leaving no thread to
-  // execute this task. To avoid deadlock, execute the task directly on the current thread if it's
-  // queued.
+  // If wait() is called from the thread pool, all threads might block, leaving no thread to execute
+  // this task. To avoid deadlock, execute the task directly on the current thread if it's queued.
   if (oldStatus == TaskStatus::Queueing) {
     if (_status.compare_exchange_strong(oldStatus, TaskStatus::Executing, std::memory_order_acq_rel,
                                         std::memory_order_relaxed)) {
@@ -111,6 +86,10 @@ bool Task::waitFor(std::chrono::milliseconds timeout) {
   }
   std::unique_lock<std::mutex> autoLock(locker);
   if (_status.load(std::memory_order_acquire) == TaskStatus::Executing) {
+    if (timeout == std::chrono::milliseconds(0)) {
+      condition.wait(autoLock);
+      return true;
+    }
     return condition.wait_for(autoLock, timeout) == std::cv_status::no_timeout;
   }
   return true;


### PR DESCRIPTION
为 Task 增加带超时的 waitFor(std::chrono::milliseconds) 变体，避免主线程或线程池调用方在异步任务卡住时无限阻塞。

行为说明：
- 任务已 Canceled/Finished 时立即返回 true。
- 任务仍在 Queueing 状态时，直接在当前线程执行，防止在线程池内调用 waitFor 导致所有线程互相等待造成死锁；此路径不受超时约束。
- 任务处于 Executing 状态时，使用 condition_variable::wait_for 等待，超时返回 false，否则返回 true。