### PR TITLE
Replace SurfaceTextureReader::getInputSurface with createInputSurface

### DIFF
--- a/include/tgfx/platform/android/SurfaceTextureReader.h
+++ b/include/tgfx/platform/android/SurfaceTextureReader.h
@@ -40,10 +40,12 @@ class SurfaceTextureReader : public ImageReader {
   static std::shared_ptr<SurfaceTextureReader> Make(int width, int height, jobject listener);
 
   /**
-   * Returns the Surface object used as the input to the SurfaceTextureReader. The release() method
-   * of the returned Surface will be called when the SurfaceTextureReader is released.
+   * Creates a new Java Surface object connected to the underlying SurfaceTexture. Each call returns
+   * a fresh Surface as a JNI local reference. The caller owns the returned reference and is
+   * responsible for calling Surface.release() when done, following the standard Android Surface
+   * ownership convention.
    */
-  jobject getInputSurface() const;
+  jobject createInputSurface() const;
 
   /**
    * Notifies that the previously returned ImageBuffer is now available for texture generation.

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -42,7 +42,6 @@ static jmethodID SurfaceTexture_release;
 static jmethodID SurfaceTexture_getDataSpace;
 static Global<jclass> SurfaceClass;
 static jmethodID Surface_Constructor;
-static jmethodID Surface_release;
 static Global<jclass> HandlerClass;
 static jmethodID Handler_Constructor;
 static Global<jclass> EventHandlerClass;
@@ -95,7 +94,6 @@ void SurfaceTexture::JNIInit(JNIEnv* env) {
   SurfaceClass = env->FindClass("android/view/Surface");
   Surface_Constructor =
       env->GetMethodID(SurfaceClass.get(), "<init>", "(Landroid/graphics/SurfaceTexture;)V");
-  Surface_release = env->GetMethodID(SurfaceClass.get(), "release", "()V");
   DataSpaceClass = env->FindClass("android/hardware/DataSpace");
   if (DataSpaceClass.get() != nullptr) {
     DataSpaceClass_getStandard =
@@ -172,10 +170,9 @@ std::shared_ptr<SurfaceTexture> SurfaceTexture::Make(int width, int height, jobj
   return std::shared_ptr<SurfaceTexture>(new SurfaceTexture(width, height, env, stObject));
 }
 
-SurfaceTexture::SurfaceTexture(int width, int height, JNIEnv* env, jobject st)
+SurfaceTexture::SurfaceTexture(int width, int height, JNIEnv*, jobject st)
     : ImageStream(width, height) {
   surfaceTexture = st;
-  surface = env->NewObject(SurfaceClass.get(), Surface_Constructor, st);
 }
 
 SurfaceTexture::~SurfaceTexture() {
@@ -184,12 +181,16 @@ SurfaceTexture::~SurfaceTexture() {
   if (env == nullptr) {
     return;
   }
-  env->CallVoidMethod(surface.get(), Surface_release);
   env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_release);
 }
 
-jobject SurfaceTexture::getInputSurface() const {
-  return surface.get();
+jobject SurfaceTexture::createInputSurface() const {
+  JNIEnvironment environment;
+  auto env = environment.current();
+  if (env == nullptr) {
+    return nullptr;
+  }
+  return env->NewObject(SurfaceClass.get(), Surface_Constructor, surfaceTexture.get());
 }
 
 void SurfaceTexture::notifyFrameAvailable() {

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -44,10 +44,10 @@ class SurfaceTexture : public ImageStream {
   ~SurfaceTexture() override;
 
   /**
-   * Returns the Surface object used as the input to the SurfaceTexture. The release() method of
-   * the returned Surface will be called when the SurfaceTexture is released.
+   * Creates a new Java Surface object connected to this SurfaceTexture. Each call returns a fresh
+   * Surface as a JNI local reference; the caller owns it and must call Surface.release() when done.
    */
-  jobject getInputSurface() const;
+  jobject createInputSurface() const;
 
   /**
    * Notifies the previously returned ImageBuffer is available for generating textures. The method
@@ -67,7 +67,6 @@ class SurfaceTexture : public ImageStream {
  private:
   std::mutex locker = {};
   std::condition_variable condition = {};
-  Global<jobject> surface;
   Global<jobject> surfaceTexture;
   bool frameAvailable = false;
   std::shared_ptr<ColorSpace> _colorSpace = nullptr;

--- a/src/platform/android/SurfaceTextureReader.cpp
+++ b/src/platform/android/SurfaceTextureReader.cpp
@@ -28,7 +28,7 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::getInputSurface() const {
+jobject SurfaceTextureReader::createInputSurface() const {
   return nullptr;
 }
 
@@ -60,8 +60,8 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::getInputSurface() const {
-  return std::static_pointer_cast<SurfaceTexture>(stream)->getInputSurface();
+jobject SurfaceTextureReader::createInputSurface() const {
+  return std::static_pointer_cast<SurfaceTexture>(stream)->createInputSurface();
 }
 
 void SurfaceTextureReader::notifyFrameAvailable() {


### PR DESCRIPTION
将 SurfaceTextureReader 的 Java Surface 所有权移交给调用方，从源头消除 tgfx worker 线程上调用 Surface.release() 引发的野指针 crash。

背景
libpag 4.5.75 在 Android 后台场景出现 SIGSEGV 崩溃：tgfx worker 线程执行 ~SurfaceTexture 时调用 Java Surface.release()，此时底层 android::Surface 已被 MediaCodec 异步释放，导致野指针访问触发 SEGV_MAPERR。

改动
1) SurfaceTextureReader 接口从 getInputSurface() 更名为 createInputSurface()，明确"调用方创建、调用方 release"的所有权约定，符合 Android 标准 Surface 生命周期语义。
2) SurfaceTexture 内部不再长期持有 Java Surface：删除 Global jobject surface 成员，构造函数不再 NewObject，析构函数不再调 Surface.release()。
3) createInputSurface() 每次基于底层 SurfaceTexture 创建一个新的 Java Surface 并作为 JNI local ref 返回。调用方拿到后应立即通过 ANativeWindow_fromSurface 转换为 native 引用（tag ANativeWindow_acquire），随后即可 release Java Surface，native android::Surface 生命周期完全由 ANativeWindow 引用管理，与 Java Surface 及 Framework 时序解耦。

安全性
ANativeWindow_fromSurface 内部使用独立 tag 增加强引用，与 Java Surface 的 sRefBaseOwner 引用互不干扰。调用方在 initDecoder 内立即 release，此时 MediaCodec 尚未 configure，无其他持有者，无并发风险。crash 代码路径从源码中消失，不再依赖任何运行时线程时序。