### PR TITLE
Cherry-pick: Replace SurfaceTextureReader::getInputSurface with createInputSurface

### DIFF
--- a/include/tgfx/platform/android/SurfaceTextureReader.h
+++ b/include/tgfx/platform/android/SurfaceTextureReader.h
@@ -40,10 +40,12 @@ class SurfaceTextureReader : public ImageReader {
   static std::shared_ptr<SurfaceTextureReader> Make(int width, int height, jobject listener);
 
   /**
-   * Returns the Surface object used as the input to the SurfaceTextureReader. The release() method
-   * of the returned Surface will be called when the SurfaceTextureReader is released.
+   * Creates a new Java Surface object connected to the underlying SurfaceTexture. Each call returns
+   * a fresh Surface as a JNI local reference. The caller owns the returned reference and is
+   * responsible for calling Surface.release() when done, following the standard Android Surface
+   * ownership convention.
    */
-  jobject getInputSurface() const;
+  jobject createInputSurface() const;
 
   /**
    * Notifies that the previously returned ImageBuffer is now available for texture generation.

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -39,7 +39,6 @@ static jmethodID SurfaceTexture_getTransformMatrix;
 static jmethodID SurfaceTexture_release;
 static Global<jclass> SurfaceClass;
 static jmethodID Surface_Constructor;
-static jmethodID Surface_release;
 static Global<jclass> HandlerClass;
 static jmethodID Handler_Constructor;
 static Global<jclass> EventHandlerClass;
@@ -85,7 +84,6 @@ void SurfaceTexture::JNIInit(JNIEnv* env) {
   SurfaceClass = env->FindClass("android/view/Surface");
   Surface_Constructor =
       env->GetMethodID(SurfaceClass.get(), "<init>", "(Landroid/graphics/SurfaceTexture;)V");
-  Surface_release = env->GetMethodID(SurfaceClass.get(), "release", "()V");
 }
 
 static std::mutex threadLocker = {};
@@ -153,10 +151,9 @@ std::shared_ptr<SurfaceTexture> SurfaceTexture::Make(int width, int height, jobj
   return std::shared_ptr<SurfaceTexture>(new SurfaceTexture(width, height, env, stObject));
 }
 
-SurfaceTexture::SurfaceTexture(int width, int height, JNIEnv* env, jobject st)
+SurfaceTexture::SurfaceTexture(int width, int height, JNIEnv*, jobject st)
     : ImageStream(width, height) {
   surfaceTexture = st;
-  surface = env->NewObject(SurfaceClass.get(), Surface_Constructor, st);
 }
 
 SurfaceTexture::~SurfaceTexture() {
@@ -165,12 +162,16 @@ SurfaceTexture::~SurfaceTexture() {
   if (env == nullptr) {
     return;
   }
-  env->CallVoidMethod(surface.get(), Surface_release);
   env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_release);
 }
 
-jobject SurfaceTexture::getInputSurface() const {
-  return surface.get();
+jobject SurfaceTexture::createInputSurface() const {
+  JNIEnvironment environment;
+  auto env = environment.current();
+  if (env == nullptr) {
+    return nullptr;
+  }
+  return env->NewObject(SurfaceClass.get(), Surface_Constructor, surfaceTexture.get());
 }
 
 void SurfaceTexture::notifyFrameAvailable() {

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -44,10 +44,10 @@ class SurfaceTexture : public ImageStream {
   ~SurfaceTexture() override;
 
   /**
-   * Returns the Surface object used as the input to the SurfaceTexture. The release() method of
-   * the returned Surface will be called when the SurfaceTexture is released.
+   * Creates a new Java Surface object connected to this SurfaceTexture. Each call returns a fresh
+   * Surface as a JNI local reference; the caller owns it and must call Surface.release() when done.
    */
-  jobject getInputSurface() const;
+  jobject createInputSurface() const;
 
   /**
    * Notifies the previously returned ImageBuffer is available for generating textures. The method
@@ -63,7 +63,6 @@ class SurfaceTexture : public ImageStream {
  private:
   std::mutex locker = {};
   std::condition_variable condition = {};
-  Global<jobject> surface;
   Global<jobject> surfaceTexture;
   bool frameAvailable = false;
 

--- a/src/platform/android/SurfaceTextureReader.cpp
+++ b/src/platform/android/SurfaceTextureReader.cpp
@@ -40,8 +40,8 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::getInputSurface() const {
-  return std::static_pointer_cast<SurfaceTexture>(stream)->getInputSurface();
+jobject SurfaceTextureReader::createInputSurface() const {
+  return std::static_pointer_cast<SurfaceTexture>(stream)->createInputSurface();
 }
 
 void SurfaceTextureReader::notifyFrameAvailable() {


### PR DESCRIPTION
Cherry-pick #1496 到 release/2.1，修复 Android worker 线程上调用 Java Surface.release() 导致的 SIGSEGV 崩溃。

原始 commit 105f881c6，release/2.1 分支上无 Vulkan 与 DataSpace 相关代码，冲突已按分支实际内容解决。