### PR TITLE
Pass caller JNIEnv to SurfaceTextureReader::createInputSurface

### DIFF
--- a/include/tgfx/platform/android/JNIEnvironment.h
+++ b/include/tgfx/platform/android/JNIEnvironment.h
@@ -61,5 +61,7 @@ class JNIEnvironment {
 
   template <typename T>
   friend class Global;
+
+  friend class SurfaceTexture;
 };
 }  // namespace tgfx

--- a/include/tgfx/platform/android/SurfaceTextureReader.h
+++ b/include/tgfx/platform/android/SurfaceTextureReader.h
@@ -40,13 +40,12 @@ class SurfaceTextureReader : public ImageReader {
   static std::shared_ptr<SurfaceTextureReader> Make(int width, int height, jobject listener);
 
   /**
-   * Creates a new Java Surface object connected to the underlying SurfaceTexture. Returns a JNI
-   * local reference allocated in the caller's JNIEnv frame; the caller owns it and is responsible
-   * for calling Surface.release() and DeleteLocalRef when done, following the standard Android
-   * Surface ownership convention. The caller must pass its own JNIEnv* so that the returned local
-   * reference lives in the caller's local frame.
+   * Creates a new Java Surface object connected to the underlying SurfaceTexture. Each call returns
+   * a fresh Surface as a JNI local reference in the calling thread's current local frame. The
+   * caller owns the returned reference and is responsible for calling Surface.release() when done,
+   * following the standard Android Surface ownership convention.
    */
-  jobject createInputSurface(JNIEnv* env) const;
+  jobject createInputSurface() const;
 
   /**
    * Notifies that the previously returned ImageBuffer is now available for texture generation.

--- a/include/tgfx/platform/android/SurfaceTextureReader.h
+++ b/include/tgfx/platform/android/SurfaceTextureReader.h
@@ -41,9 +41,8 @@ class SurfaceTextureReader : public ImageReader {
 
   /**
    * Creates a new Java Surface object connected to the underlying SurfaceTexture. Each call returns
-   * a fresh Surface as a JNI local reference in the calling thread's current local frame. The
-   * caller owns the returned reference and is responsible for calling Surface.release() when done,
-   * following the standard Android Surface ownership convention.
+   * a fresh Surface as a JNI local reference; the caller owns it and is responsible for calling
+   * Surface.release() when done, following the standard Android Surface ownership convention.
    */
   jobject createInputSurface() const;
 

--- a/include/tgfx/platform/android/SurfaceTextureReader.h
+++ b/include/tgfx/platform/android/SurfaceTextureReader.h
@@ -41,8 +41,7 @@ class SurfaceTextureReader : public ImageReader {
 
   /**
    * Creates a new Java Surface object connected to the underlying SurfaceTexture. Each call returns
-   * a fresh Surface as a JNI local reference; the caller owns it and is responsible for calling
-   * Surface.release() when done, following the standard Android Surface ownership convention.
+   * a fresh Surface. The caller owns the returned object and must call Surface.release() when done.
    */
   jobject createInputSurface() const;
 

--- a/include/tgfx/platform/android/SurfaceTextureReader.h
+++ b/include/tgfx/platform/android/SurfaceTextureReader.h
@@ -40,12 +40,13 @@ class SurfaceTextureReader : public ImageReader {
   static std::shared_ptr<SurfaceTextureReader> Make(int width, int height, jobject listener);
 
   /**
-   * Creates a new Java Surface object connected to the underlying SurfaceTexture. Each call returns
-   * a fresh Surface as a JNI local reference. The caller owns the returned reference and is
-   * responsible for calling Surface.release() when done, following the standard Android Surface
-   * ownership convention.
+   * Creates a new Java Surface object connected to the underlying SurfaceTexture. Returns a JNI
+   * local reference allocated in the caller's JNIEnv frame; the caller owns it and is responsible
+   * for calling Surface.release() and DeleteLocalRef when done, following the standard Android
+   * Surface ownership convention. The caller must pass its own JNIEnv* so that the returned local
+   * reference lives in the caller's local frame.
    */
-  jobject createInputSurface() const;
+  jobject createInputSurface(JNIEnv* env) const;
 
   /**
    * Notifies that the previously returned ImageBuffer is now available for texture generation.

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -184,9 +184,10 @@ SurfaceTexture::~SurfaceTexture() {
   env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_release);
 }
 
-jobject SurfaceTexture::createInputSurface() const {
-  JNIEnvironment environment;
-  auto env = environment.current();
+jobject SurfaceTexture::createInputSurface(JNIEnv* env) const {
+  // Use the caller's JNIEnv directly. Do NOT wrap this in a local JNIEnvironment: its destructor
+  // calls PopLocalFrame(nullptr), which would release the local ref returned by NewObject before
+  // the caller can use it, leaving the caller with a dangling handle.
   if (env == nullptr) {
     return nullptr;
   }

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -184,10 +184,12 @@ SurfaceTexture::~SurfaceTexture() {
   env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_release);
 }
 
-jobject SurfaceTexture::createInputSurface(JNIEnv* env) const {
-  // Use the caller's JNIEnv directly. Do NOT wrap this in a local JNIEnvironment: its destructor
-  // calls PopLocalFrame(nullptr), which would release the local ref returned by NewObject before
-  // the caller can use it, leaving the caller with a dangling handle.
+jobject SurfaceTexture::createInputSurface() const {
+  // Use JNIEnvironment::Current() to fetch the thread-local JNIEnv without pushing a new local
+  // frame. Wrapping this in a stack JNIEnvironment would trigger PopLocalFrame(nullptr) on scope
+  // exit and release the local ref returned by NewObject before the caller can use it. The
+  // returned local ref instead lives in the caller's current local frame.
+  auto env = JNIEnvironment::Current();
   if (env == nullptr) {
     return nullptr;
   }

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -45,8 +45,7 @@ class SurfaceTexture : public ImageStream {
 
   /**
    * Creates a new Java Surface object connected to this SurfaceTexture. Each call returns a fresh
-   * Surface as a JNI local reference in the calling thread's current local frame; the caller owns
-   * it and must call Surface.release() when done.
+   * Surface as a JNI local reference; the caller owns it and must call Surface.release() when done.
    */
   jobject createInputSurface() const;
 

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -44,10 +44,12 @@ class SurfaceTexture : public ImageStream {
   ~SurfaceTexture() override;
 
   /**
-   * Creates a new Java Surface object connected to this SurfaceTexture. Each call returns a fresh
-   * Surface as a JNI local reference; the caller owns it and must call Surface.release() when done.
+   * Creates a new Java Surface object connected to this SurfaceTexture. Returns a JNI local
+   * reference allocated in the caller's local frame; the caller owns it and must call
+   * Surface.release() and DeleteLocalRef when done. Passing the caller's JNIEnv* is required to
+   * ensure the returned local reference lives in the caller's local frame.
    */
-  jobject createInputSurface() const;
+  jobject createInputSurface(JNIEnv* env) const;
 
   /**
    * Notifies the previously returned ImageBuffer is available for generating textures. The method

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -45,7 +45,7 @@ class SurfaceTexture : public ImageStream {
 
   /**
    * Creates a new Java Surface object connected to this SurfaceTexture. Each call returns a fresh
-   * Surface as a JNI local reference; the caller owns it and must call Surface.release() when done.
+   * Surface. The caller owns the returned object and must call Surface.release() when done.
    */
   jobject createInputSurface() const;
 

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -44,12 +44,11 @@ class SurfaceTexture : public ImageStream {
   ~SurfaceTexture() override;
 
   /**
-   * Creates a new Java Surface object connected to this SurfaceTexture. Returns a JNI local
-   * reference allocated in the caller's local frame; the caller owns it and must call
-   * Surface.release() and DeleteLocalRef when done. Passing the caller's JNIEnv* is required to
-   * ensure the returned local reference lives in the caller's local frame.
+   * Creates a new Java Surface object connected to this SurfaceTexture. Each call returns a fresh
+   * Surface as a JNI local reference in the calling thread's current local frame; the caller owns
+   * it and must call Surface.release() when done.
    */
-  jobject createInputSurface(JNIEnv* env) const;
+  jobject createInputSurface() const;
 
   /**
    * Notifies the previously returned ImageBuffer is available for generating textures. The method

--- a/src/platform/android/SurfaceTextureReader.cpp
+++ b/src/platform/android/SurfaceTextureReader.cpp
@@ -28,7 +28,7 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::createInputSurface() const {
+jobject SurfaceTextureReader::createInputSurface(JNIEnv*) const {
   return nullptr;
 }
 
@@ -60,8 +60,8 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::createInputSurface() const {
-  return std::static_pointer_cast<SurfaceTexture>(stream)->createInputSurface();
+jobject SurfaceTextureReader::createInputSurface(JNIEnv* env) const {
+  return std::static_pointer_cast<SurfaceTexture>(stream)->createInputSurface(env);
 }
 
 void SurfaceTextureReader::notifyFrameAvailable() {

--- a/src/platform/android/SurfaceTextureReader.cpp
+++ b/src/platform/android/SurfaceTextureReader.cpp
@@ -28,7 +28,7 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::createInputSurface(JNIEnv*) const {
+jobject SurfaceTextureReader::createInputSurface() const {
   return nullptr;
 }
 
@@ -60,8 +60,8 @@ SurfaceTextureReader::SurfaceTextureReader(std::shared_ptr<ImageStream> stream)
     : ImageReader(std::move(stream)) {
 }
 
-jobject SurfaceTextureReader::createInputSurface(JNIEnv* env) const {
-  return std::static_pointer_cast<SurfaceTexture>(stream)->createInputSurface(env);
+jobject SurfaceTextureReader::createInputSurface() const {
+  return std::static_pointer_cast<SurfaceTexture>(stream)->createInputSurface();
 }
 
 void SurfaceTextureReader::notifyFrameAvailable() {


### PR DESCRIPTION
修复 PR #1496 引入的一个 JNI local frame 生命周期 bug：createInputSurface 内部使用 tgfx 的 JNIEnvironment RAII 包装器时，函数返回时 PopLocalFrame(nullptr) 会立即释放 NewObject 返回的 local ref，导致调用方拿到已失效的 handle，随后访问野对象引发 SIGSEGV。

改动
1) SurfaceTextureReader::createInputSurface 增加 JNIEnv* 参数，头文件注释明确调用方必须传入自己的 env，返回的 local ref 位于调用方的 local frame 里。
2) SurfaceTexture::createInputSurface 同步增加 JNIEnv* 参数，函数内直接使用传入的 env 调 NewObject，不再嵌套 JNIEnvironment。
3) Vulkan 分支的空实现同步更新签名。

验证
真机复现证据：荣耀 PTP-AN00 Android 16，使用 JNIEnvironment 版本时 createInputSurface 返回的 handle 与随后 FindClass 得到的 Surface class handle 完全相同（0x71453b7c01），证明 local ref 表 slot 已被复用；改为接收调用方 env 版本后，handle 独立、mNativeObject 合法、多视频并发和循环播放 30 秒 9 次 HardwareDecoder 构造析构全部正常。

macOS OpenGL 完整编译通过。