### PR TITLE
Add Text::setTextBlob for in-place text blob replacement

### DIFF
--- a/include/tgfx/layers/vectors/Text.h
+++ b/include/tgfx/layers/vectors/Text.h
@@ -49,6 +49,15 @@ class Text : public VectorElement {
   }
 
   /**
+   * Replaces the text blob to render, keeping this Text object's identity so parents holding it
+   * stay valid. Passing null leaves the current blob unchanged. anchors are the per-glyph offsets
+   * for the new blob (relative to each glyph's default anchor at advance * 0.5, 0); pass an empty
+   * vector to clear them. If the vector length does not match the new glyph count, it is resized
+   * (padded with zeros or truncated) and a warning is logged.
+   */
+  void setTextBlob(std::shared_ptr<TextBlob> textBlob, std::vector<Point> anchors = {});
+
+  /**
    * Returns the position of the text blob.
    */
   Point position() const {

--- a/src/layers/vectors/Text.cpp
+++ b/src/layers/vectors/Text.cpp
@@ -48,6 +48,24 @@ void Text::setPosition(const Point& value) {
   invalidateContent();
 }
 
+void Text::setTextBlob(std::shared_ptr<TextBlob> textBlob, std::vector<Point> anchors) {
+  if (textBlob == nullptr) {
+    return;
+  }
+  size_t glyphCount = 0;
+  for (auto run : *textBlob) {
+    glyphCount += run.glyphCount;
+  }
+  if (!anchors.empty() && anchors.size() != glyphCount) {
+    LOGE("Text::setTextBlob: anchors size (%zu) does not match glyph count (%zu)", anchors.size(),
+         glyphCount);
+    anchors.resize(glyphCount, Point::Zero());
+  }
+  _textBlob = std::move(textBlob);
+  _anchors = std::move(anchors);
+  invalidateContent();
+}
+
 void Text::apply(VectorContext* context) {
   DEBUG_ASSERT(context != nullptr);
   if (_textBlob == nullptr) {

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -702,6 +702,7 @@
         "TextPath": "ef78ecb3",
         "TextPathWithTrimPath": "4df17714",
         "TextSelector": "ec49a65b",
+        "TextSetTextBlob": "91b64da3e",
         "TextStyles": "48b78e36",
         "TextWithGroup": "48b78e36",
         "TextWithPathModifiers": "48b78e36",

--- a/test/src/VectorLayerTest.cpp
+++ b/test/src/VectorLayerTest.cpp
@@ -5414,4 +5414,47 @@ TGFX_TEST(VectorLayerTest, DegenerateStroke) {
   EXPECT_TRUE(Baseline::Compare(surface, "VectorLayerTest/DegenerateStroke"));
 }
 
+/**
+ * Test Text::setTextBlob: replacing a Text's blob in place must update the rendered output on the
+ * next draw, even though the parent VectorLayer keeps holding the same Text object. This verifies
+ * the in-place blob swap (used by runtime text reshaping) invalidates the layer content correctly
+ * without re-parenting or replacing the element.
+ */
+TGFX_TEST(VectorLayerTest, TextSetTextBlob) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 291, 120);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+
+  auto displayList = std::make_unique<DisplayList>();
+  auto vectorLayer = VectorLayer::Make();
+
+  auto typeface = GetTestTypeface();
+  if (typeface == nullptr) {
+    return;
+  }
+  Font font(typeface, 36.0f);
+
+  auto blob = TextBlob::MakeFrom("Hello", font);
+  auto textSpan = Text::Make(blob);
+  textSpan->setPosition({50, 80});
+  auto fill = MakeFillStyle(Color::Black());
+  vectorLayer->setContents({textSpan, fill});
+  displayList->root()->addChild(vectorLayer);
+
+  // First render establishes the parent VectorLayer's hold on the Text object with "Hello".
+  displayList->render(surface.get());
+
+  // Swap the blob in place. The parent still holds the same textSpan object; only its blob changes.
+  auto reshaped = TextBlob::MakeFrom("Reshaped", font);
+  textSpan->setTextBlob(reshaped);
+  ASSERT_EQ(textSpan->textBlob(), reshaped);
+
+  displayList->render(surface.get());
+
+  EXPECT_TRUE(Baseline::Compare(surface, "VectorLayerTest/TextSetTextBlob"));
+}
+
 }  // namespace tgfx


### PR DESCRIPTION
## Motivation

`tgfx::Text` is currently immutable after `Make` — there is no way to change its blob. Callers that need to update rendered text at runtime (e.g. libpag's ViewModel/Animation-driven text reshaping) must build a new `Text` object and swap it. But because parent containers (`VectorLayer`/`VectorGroup`) retain the child element by `shared_ptr`, swapping the object in a side map does not update the render tree, so the old text keeps rendering.

## Change

Add `Text::setTextBlob(std::shared_ptr<TextBlob>, std::vector<Point> anchors = {})`:
- Replaces `_textBlob` / `_anchors` in place and calls `invalidateContent()`, mirroring the existing `setPosition` pattern.
- Keeps the `Text` object identity, so parents holding it stay valid and the next draw reflects the new blob — no re-parenting or element replacement.
- Validates/resizes anchors against the new glyph count, same as `Make`. Passing an empty vector clears per-glyph anchor offsets (correct when the glyph set changes).
- Passing null leaves the current blob unchanged.

## Test

`VectorLayerTest.TextSetTextBlob` (baseline): renders a `Text` ("Hello") held by a `VectorLayer`, calls `setTextBlob` with a new blob ("Reshaped"), renders again, and baseline-compares the output — verifying the in-place swap updates the render tree while the parent keeps the same object.