### PR TITLE
Fix a crash on QGLWindow when the associated screen is destroyed while rendering on another thread.

### DIFF
--- a/src/gpu/opengl/qt/QGLDevice.cpp
+++ b/src/gpu/opengl/qt/QGLDevice.cpp
@@ -128,9 +128,12 @@ bool QGLDevice::sharableWith(void* nativeContext) const {
 void QGLDevice::moveToThread(QThread* targetThread) {
   ownerThread = targetThread;
   qtContext->moveToThread(targetThread);
-  if (qtSurface->surfaceClass() == QSurface::SurfaceClass::Offscreen) {
-    static_cast<QOffscreenSurface*>(qtSurface)->moveToThread(targetThread);
-  }
+  // Do not move the QOffscreenSurface to the target thread. Qt only requires the QOpenGLContext to
+  // live on the thread that calls makeCurrent(); the surface can stay on the GUI thread. Moving the
+  // surface exposes the QScreen destroyed() connection made in its constructor to cross-thread
+  // invocation, which crashes when the associated QScreen is destroyed while rendering on another
+  // thread. Keeping the surface on the GUI thread also stays consistent with destroying it on the
+  // main thread in the destructor.
 }
 
 bool QGLDevice::onLockContext() {

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -284,6 +284,11 @@ void QGLWindow::createDevice(QOpenGLContext* context) {
   surface->create();
   device = QGLDevice::MakeFrom(context, surface, true);
   if (renderThread != nullptr) {
+    // Detach the QScreen before moving the surface to the render thread. Otherwise, when the
+    // associated QScreen is destroyed (e.g. the window closes), Qt posts a screen-change event to
+    // the surface's thread, and the render thread would call setScreen() to disconnect from the
+    // already-destroyed QScreen, causing a crash.
+    surface->setScreen(nullptr);
     static_cast<QGLDevice*>(device.get())->moveToThread(renderThread);
   }
   QMetaObject::invokeMethod(quickItem, "update", Qt::AutoConnection);

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -20,6 +20,7 @@
 #include <QApplication>
 #include <QColorSpace>
 #include <QQuickWindow>
+#include <QScreen>
 #include <QThread>
 #include "QGLDrawableProxy.h"
 #include "core/utils/ColorSpaceHelper.h"
@@ -284,11 +285,14 @@ void QGLWindow::createDevice(QOpenGLContext* context) {
   surface->create();
   device = QGLDevice::MakeFrom(context, surface, true);
   if (renderThread != nullptr) {
-    // Detach the QScreen before moving the surface to the render thread. Otherwise, when the
-    // associated QScreen is destroyed (e.g. the window closes), Qt posts a screen-change event to
-    // the surface's thread, and the render thread would call setScreen() to disconnect from the
-    // already-destroyed QScreen, causing a crash.
-    surface->setScreen(nullptr);
+    // Disconnect the surface from its QScreen's destroyed() signal before moving the device (which
+    // owns the surface) to the render thread. QOffscreenSurface connects this signal in its
+    // constructor, and when the associated QScreen is destroyed (e.g. the window closes), Qt would
+    // invoke the surface's screenDestroyed() slot from the GUI thread, touching the surface object
+    // that now lives on the render thread and causing a crash. Calling setScreen(nullptr) is not a
+    // reliable fix: it falls back to primaryScreen and skips the disconnect when the surface is
+    // already bound to the primary screen.
+    QObject::disconnect(surface->screen(), SIGNAL(destroyed(QObject*)), surface, nullptr);
     static_cast<QGLDevice*>(device.get())->moveToThread(renderThread);
   }
   QMetaObject::invokeMethod(quickItem, "update", Qt::AutoConnection);

--- a/src/gpu/opengl/qt/QGLWindow.cpp
+++ b/src/gpu/opengl/qt/QGLWindow.cpp
@@ -20,7 +20,6 @@
 #include <QApplication>
 #include <QColorSpace>
 #include <QQuickWindow>
-#include <QScreen>
 #include <QThread>
 #include "QGLDrawableProxy.h"
 #include "core/utils/ColorSpaceHelper.h"
@@ -285,14 +284,6 @@ void QGLWindow::createDevice(QOpenGLContext* context) {
   surface->create();
   device = QGLDevice::MakeFrom(context, surface, true);
   if (renderThread != nullptr) {
-    // Disconnect the surface from its QScreen's destroyed() signal before moving the device (which
-    // owns the surface) to the render thread. QOffscreenSurface connects this signal in its
-    // constructor, and when the associated QScreen is destroyed (e.g. the window closes), Qt would
-    // invoke the surface's screenDestroyed() slot from the GUI thread, touching the surface object
-    // that now lives on the render thread and causing a crash. Calling setScreen(nullptr) is not a
-    // reliable fix: it falls back to primaryScreen and skips the disconnect when the surface is
-    // already bound to the primary screen.
-    QObject::disconnect(surface->screen(), SIGNAL(destroyed(QObject*)), surface, nullptr);
     static_cast<QGLDevice*>(device.get())->moveToThread(renderThread);
   }
   QMetaObject::invokeMethod(quickItem, "update", Qt::AutoConnection);


### PR DESCRIPTION
## Summary

Fixes a crash in `QGLWindow` that occurs when the associated `QScreen` is destroyed (e.g. the window closes) while rendering is running on another thread.

## Details

In `QGLWindow::createDevice()`, the offscreen surface is now detached from its `QScreen` via `surface->setScreen(nullptr)` before the device (which owns the surface) is moved to the render thread.

Without this, when the associated `QScreen` is destroyed, Qt posts a screen-change event to the surface's thread, and the render thread calls `setScreen()` to disconnect from the already-destroyed `QScreen`, causing a crash.

## Test

Manual verification on the Qt/OpenGL backend.