### PR TITLE
Fix baseline misalignment caused by per-glyph Y-axis pixel rounding

### DIFF
--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -190,8 +190,24 @@ static void ComputeGlyphRenderMatrix(const Rect& atlasLocation, const Matrix& st
   }
   outMatrix->postConcat(stateMatrix);
   if (needsPixelAlignment) {
+    // Round the full device-space X translation. Horizontal pixel misalignment is
+    // imperceptible per-glyph and the old behavior was correct.
     (*outMatrix)[2] = std::round((*outMatrix)[2]);
-    (*outMatrix)[5] = std::round((*outMatrix)[5]);
+
+    // For Y, decompose the device-space translation into shared baseline + per-glyph
+    // visual offset, and round only the shared part.
+    //   deviceY = maxScale * (scale * glyphOffset.y + position.y - scale * atlas.y) + stateTy
+    //           = maxScale * scale * glyphOffset.y + (maxScale * position.y + stateTy
+    //                                                  - maxScale * scale * atlas.y)
+    //           = perGlyphDeviceY                    + sharedDeviceY
+    // Rounding sharedDeviceY keeps all glyphs on the same baseline aligned to the same
+    // device pixel, while the per-glyph visual offset (glyphOffset.y) stays exact,
+    // avoiding the baseline misalignment that occurs when glyphs with different visual
+    // bounds (e.g. 'M' at -13 vs 'a' at -10) get independently rounded.
+    auto deviceScale = stateMatrix.getScaleX();
+    auto perGlyphDeviceY = deviceScale * scale * glyphOffset.y;
+    auto sharedDeviceY = (*outMatrix)[5] - perGlyphDeviceY;
+    (*outMatrix)[5] = std::round(sharedDeviceY) + perGlyphDeviceY;
   }
 }
 


### PR DESCRIPTION
## Problem

When `needsPixelAlignment` is true (Nearest sampling + uniform scale + no fauxItalic), `ComputeGlyphRenderMatrix` rounds the entire device-space Y translation per-glyph. Different glyphs sharing the same baseline have different `glyphOffset.y` values based on their visual bounds (e.g. 'M' tops at -13, 'a' tops at -10), causing independently rounded Y positions and visible baseline misalignment when text contains mixed cap-height and x-height glyphs.

## Fix

Decompose the device-space Y translation into shared baseline + per-glyph visual offset, and round only the shared component:

```
deviceY = maxScale*scale*glyphOffset.y   (per-glyph, kept exact)
        + maxScale*position.y + stateTy   (shared baseline, rounded)
        - maxScale*scale*atlas.y
```

Glyphs on the same baseline now align to the same device pixel while preserving their per-glyph visual offsets exactly.

The rounding stays in device space (after `postConcat(stateMatrix)`) to correctly handle non-integer `maxScale` and fractional `stateMatrix` translation — unlike a naive local-space approach where `maxScale * round(x) ≠ round(maxScale * x)`.

X translation keeps the old per-glyph full-round behavior (horizontal misalignment is imperceptible).

## Origin

The pixel alignment `std::round` was originally added in [#1058](https://github.com/Tencent/tgfx/pull/1058) to prevent pixel truncation with Nearest sampling, but only considered single-glyph alignment without accounting for shared baselines across glyphs with different visual bounds.