### PR TITLE
Fix baseline misalignment in glyph pixel alignment

### DIFF
--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -190,24 +190,16 @@ static void ComputeGlyphRenderMatrix(const Rect& atlasLocation, const Matrix& st
   }
   outMatrix->postConcat(stateMatrix);
   if (needsPixelAlignment) {
-    // Round the full device-space X translation. Horizontal pixel misalignment is
-    // imperceptible per-glyph and the old behavior was correct.
     (*outMatrix)[2] = std::round((*outMatrix)[2]);
-
-    // For Y, decompose the device-space translation into shared baseline + per-glyph
-    // visual offset, and round only the shared part.
-    //   deviceY = maxScale * (scale * glyphOffset.y + position.y - scale * atlas.y) + stateTy
-    //           = maxScale * scale * glyphOffset.y + (maxScale * position.y + stateTy
-    //                                                  - maxScale * scale * atlas.y)
-    //           = perGlyphDeviceY                    + sharedDeviceY
-    // Rounding sharedDeviceY keeps all glyphs on the same baseline aligned to the same
-    // device pixel, while the per-glyph visual offset (glyphOffset.y) stays exact,
-    // avoiding the baseline misalignment that occurs when glyphs with different visual
-    // bounds (e.g. 'M' at -13 vs 'a' at -10) get independently rounded.
-    auto deviceScale = stateMatrix.getScaleX();
-    auto perGlyphDeviceY = deviceScale * scale * glyphOffset.y;
-    auto sharedDeviceY = (*outMatrix)[5] - perGlyphDeviceY;
-    (*outMatrix)[5] = std::round(sharedDeviceY) + perGlyphDeviceY;
+    if (HasComplexTransform(run)) {
+      (*outMatrix)[5] = std::round((*outMatrix)[5]);
+    } else {
+      auto position = GetGlyphPosition(run, index);
+      auto deviceScale = stateMatrix.getScaleX();
+      auto sharedDeviceY = deviceScale * position.y + stateMatrix.getTranslateY();
+      auto perGlyphDeviceY = deviceScale * scale * (glyphOffset.y - atlasLocation.y());
+      (*outMatrix)[5] = std::round(sharedDeviceY) + std::round(perGlyphDeviceY);
+    }
   }
 }
 

--- a/src/gpu/RenderContext.cpp
+++ b/src/gpu/RenderContext.cpp
@@ -190,8 +190,24 @@ static void ComputeGlyphRenderMatrix(const Rect& atlasLocation, const Matrix& st
   }
   outMatrix->postConcat(stateMatrix);
   if (needsPixelAlignment) {
+    // Round the full device-space X translation. Horizontal pixel misalignment is
+    // imperceptible per-glyph and the old behavior was correct.
     (*outMatrix)[2] = std::round((*outMatrix)[2]);
-    (*outMatrix)[5] = std::round((*outMatrix)[5]);
+
+    // For Y, decompose the device-space translation into shared baseline + per-glyph
+    // visual offset, and round only the shared part.
+    //   deviceY = maxScale * (scale * glyphOffset.y + position.y - scale * atlas.y) + stateTy
+    //           = maxScale * scale * glyphOffset.y + (maxScale * position.y + stateTy
+    //                                                  - maxScale * scale * atlas.y)
+    //           = perGlyphDeviceY                    + sharedDeviceY
+    // Rounding sharedDeviceY keeps all glyphs on the same baseline aligned to the same
+    // device pixel, while the per-glyph visual offset (glyphOffset.y) stays exact,
+    // avoiding the baseline misalignment that occurs when glyphs with different visual
+    // bounds (e.g. 'M' at -13 vs 'a' at -10) get independently rounded.
+    auto deviceScale = stateMatrix.getScaleX();
+    auto perGlyphDeviceY = deviceScale * scale * glyphOffset.y;
+    auto sharedDeviceY = (*outMatrix)[5] - perGlyphDeviceY;
+    (*outMatrix)[5] = std::round(sharedDeviceY) + perGlyphDeviceY;
   }
 }
 

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -59,6 +59,7 @@
         "DrawTextBlob": "29dde9e0",
         "EmptyRectStroke": "dc886da3",
         "FractalNoiseFreqOne": "a8bfb235",
+        "GlyphBaseline": "18abfa737",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",
         "LumaFilterToSRGB": "82494664",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -50,6 +50,7 @@
 #include "tgfx/core/Stroke.h"
 #include "tgfx/core/Surface.h"
 #include "tgfx/core/TextBlob.h"
+#include "tgfx/core/TextBlobBuilder.h"
 #include "utils/TestUtils.h"
 #include "utils/common.h"
 
@@ -3155,6 +3156,60 @@ TGFX_TEST(CanvasTest, EmptyRectStroke) {
   }
 
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/EmptyRectStroke"));
+}
+
+TGFX_TEST(CanvasTest, GlyphBaselineTear) {
+  auto typeface =
+      Typeface::MakeFromPath(ProjectPath::Absolute("resources/font/NotoSansSC-Regular.otf"));
+  ASSERT_TRUE(typeface != nullptr);
+  Font font(typeface, 16.0f);
+  font.setFauxBold(true);
+
+  constexpr size_t GlyphCount = 7;
+  const std::string text = "MagSafe";
+  GlyphID glyphs[GlyphCount] = {};
+  float positions[GlyphCount] = {};
+  float advance = 0.0f;
+  for (size_t i = 0; i < GlyphCount; i++) {
+    glyphs[i] = font.getGlyphID(std::string(1, text[i]));
+    positions[i] = advance;
+    advance += font.getAdvance(glyphs[i]);
+  }
+  TextBlobBuilder builder;
+  const auto& buffer = builder.allocRunPos(font, GlyphCount);
+  for (size_t i = 0; i < GlyphCount; i++) {
+    buffer.glyphs[i] = glyphs[i];
+    reinterpret_cast<Point*>(buffer.positions)[i] = Point::Make(positions[i], 17.0f);
+  }
+
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  constexpr float Scale = 1.1f;
+  constexpr float TranslateX = 20.0f;
+  constexpr float TranslateY = 0.8f;
+  constexpr int SurfaceWidth = 140;
+  constexpr int SurfaceHeight = 60;
+  auto surface = Surface::Make(context, SurfaceWidth, SurfaceHeight);
+  auto canvas = surface->getCanvas();
+  Paint paint;
+  paint.setColor(Color::Red());
+  auto textBlob = builder.build();
+
+  // Populate the atlas with smaller strikes before rendering the target run. An empty atlas
+  // usually places all target glyphs on the same atlas row, giving them identical atlasLocation.y()
+  // values and hiding the baseline-rounding bug. The real PAGX scene contains many earlier text
+  // runs, so the MagSafe glyphs are distributed across different atlas rows. Stop below the target
+  // scale (1.1) to ensure its strike is created only by the target draw below.
+  for (int scaleIndex = 50; scaleIndex < 110; scaleIndex += 2) {
+    float warmScale = static_cast<float>(scaleIndex) / 100.0f;
+    canvas->setMatrix(Matrix::MakeScale(warmScale));
+    canvas->drawTextBlob(textBlob, 0, 0, paint);
+  }
+  canvas->clear(Color::Transparent());
+  canvas->setMatrix(Matrix::MakeAll(Scale, 0.0f, TranslateX, 0.0f, Scale, TranslateY));
+  canvas->drawTextBlob(textBlob, 0, 0, paint);
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/GlyphBaseline"));
 }
 
 }  // namespace tgfx


### PR DESCRIPTION
将 ComputeGlyphRenderMatrix 的 Y 方向像素对齐从整体 round 改为分别对共享基线和逐字形 Atlas 偏移取整：

- sharedDeviceY = deviceScale * position.y + stateTranslateY（同行所有字形共享）
- perGlyphDeviceY = deviceScale * scale * (glyphOffset.y - atlasLocation.y)（逐字形 Atlas 偏移）
- 最终 Y = round(sharedDeviceY) + round(perGlyphDeviceY)

此前实现只对整体 Y 取整，当共享基线接近 0.5 且不同字形位于不同 atlas 行时，同一基线被取整到不同设备像素行，导致文字上下错位。新增基线对齐回归测试 CanvasTest.GlyphBaselineTear 用于验证修复。

X 方向保持整体取整，复杂字形变换保留原有行为。