### PR TITLE
Fix startup crash on Vulkan devices reporting a huge maxUniformBufferRange.

### DIFF
--- a/include/tgfx/gpu/GPULimits.h
+++ b/include/tgfx/gpu/GPULimits.h
@@ -39,7 +39,7 @@ class GPULimits {
   /**
    * Returns the maximum size in bytes of a uniform buffer binding.
    */
-  int maxUniformBufferBindingSize = 0;
+  int64_t maxUniformBufferBindingSize = 0;
 
   /**
    * Returns the minimum required alignment in bytes for uniform buffer offsets.

--- a/src/gpu/GlobalCache.cpp
+++ b/src/gpu/GlobalCache.cpp
@@ -71,23 +71,27 @@ std::shared_ptr<Program> GlobalCache::findProgram(const BytesKey& programKey) {
 
 std::shared_ptr<GPUBuffer> GlobalCache::findOrCreateUniformBuffer(size_t bufferSize,
                                                                   size_t* lastBufferOffset) {
-  auto maxUBOSize =
+  // The device limit only validates the size of a single request. The pool allocation size is
+  // a separate policy fixed at MAX_UNIFORM_BUFFER_SIZE, since some Vulkan devices report a
+  // maxUBOSize of several GB which must not be used as the allocation size.
+  auto maxRequestSize =
       std::max(static_cast<size_t>(context->shaderCaps()->maxUBOSize), MAX_UNIFORM_BUFFER_SIZE);
   auto uboOffsetAlignment = static_cast<size_t>(context->shaderCaps()->uboOffsetAlignment);
 
-  if (maxUBOSize == 0) {
-    LOGE("[GlobalCache::findOrCreateUniformBuffer] maxUBOSize is 0");
-    return nullptr;
-  }
-
   auto alignedBufferSize = AlignTo(bufferSize, uboOffsetAlignment);
 
-  if (bufferSize == 0 || alignedBufferSize > maxUBOSize) {
+  if (bufferSize == 0 || alignedBufferSize > maxRequestSize) {
     LOGE(
         "[GlobalCache::findOrCreateUniformBuffer] invalid request buffer size: %zu, max UBO "
         "size: %zu, %s:%d",
-        bufferSize, maxUBOSize, __FILE__, __LINE__);
+        bufferSize, maxRequestSize, __FILE__, __LINE__);
     return nullptr;
+  }
+
+  // Requests too large to fit in a pool buffer get a dedicated buffer instead.
+  if (alignedBufferSize > MAX_UNIFORM_BUFFER_SIZE) {
+    *lastBufferOffset = 0;
+    return context->gpu()->createBuffer(alignedBufferSize, GPUBufferUsage::UNIFORM);
   }
 
   auto& uniformBufferPacket = *activePacket;
@@ -101,7 +105,7 @@ std::shared_ptr<GPUBuffer> GlobalCache::findOrCreateUniformBuffer(size_t bufferS
   };
 
   if (uniformBufferPacket.gpuBuffers.empty()) {
-    auto buffer = context->gpu()->createBuffer(maxUBOSize, GPUBufferUsage::UNIFORM);
+    auto buffer = context->gpu()->createBuffer(MAX_UNIFORM_BUFFER_SIZE, GPUBufferUsage::UNIFORM);
     if (buffer == nullptr) {
       LOGE(
           "[GlobalCache::findOrCreateUniformBuffer] failed to create initial uniform buffer, "
@@ -130,7 +134,7 @@ std::shared_ptr<GPUBuffer> GlobalCache::findOrCreateUniformBuffer(size_t bufferS
 
   if (uniformBufferPacket.bufferIndex >= uniformBufferPacket.gpuBuffers.size()) {
     // Need to create a new buffer
-    auto buffer = context->gpu()->createBuffer(maxUBOSize, GPUBufferUsage::UNIFORM);
+    auto buffer = context->gpu()->createBuffer(MAX_UNIFORM_BUFFER_SIZE, GPUBufferUsage::UNIFORM);
     if (buffer == nullptr) {
       LOGE(
           "[GlobalCache::findOrCreateUniformBuffer] failed to create uniform buffer, request "

--- a/src/gpu/ShaderCaps.h
+++ b/src/gpu/ShaderCaps.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include "tgfx/gpu/GPU.h"
 
@@ -84,7 +85,7 @@ class ShaderCaps {
    * Returns the maximum size in bytes of a uniform buffer object (UBO) supported by the
    * shader language.
    */
-  int maxUBOSize = 0;
+  int64_t maxUBOSize = 0;
 
   /**
    * Returns the required alignment in bytes for offsets within a uniform buffer object (UBO).

--- a/src/gpu/opengl/GLCaps.cpp
+++ b/src/gpu/opengl/GLCaps.cpp
@@ -153,7 +153,9 @@ GLCaps::GLCaps(const GLInfo& info) {
   _features.stencilAttachmentSupported = standard != GLStandard::None;
   info.getIntegerv(GL_MAX_TEXTURE_SIZE, &_limits.maxTextureDimension2D);
   info.getIntegerv(GL_MAX_TEXTURE_IMAGE_UNITS, &_limits.maxSamplersPerShaderStage);
-  info.getIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &_limits.maxUniformBufferBindingSize);
+  int maxUniformBlockSize = 0;
+  info.getIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &maxUniformBlockSize);
+  _limits.maxUniformBufferBindingSize = maxUniformBlockSize;
   info.getIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &_limits.minUniformBufferOffsetAlignment);
   if (vendor == GLVendor::Qualcomm) {
     // https://skia-review.googlesource.com/c/skia/+/571418

--- a/src/gpu/vulkan/VulkanCaps.cpp
+++ b/src/gpu/vulkan/VulkanCaps.cpp
@@ -91,7 +91,7 @@ void VulkanCaps::initLimits(const VkPhysicalDeviceProperties& properties) {
   _limits.maxTextureDimension2D = static_cast<int>(properties.limits.maxImageDimension2D);
   _limits.maxSamplersPerShaderStage =
       static_cast<int>(properties.limits.maxPerStageDescriptorSamplers);
-  _limits.maxUniformBufferBindingSize = static_cast<int>(properties.limits.maxUniformBufferRange);
+  _limits.maxUniformBufferBindingSize = properties.limits.maxUniformBufferRange;
   _limits.minUniformBufferOffsetAlignment =
       static_cast<int>(properties.limits.minUniformBufferOffsetAlignment);
 }


### PR DESCRIPTION
## Problem

On some Vulkan devices (e.g. OPPO X9, Android 16), the app crashes at startup:

```
VulkanBuffer::Make() vmaCreateBuffer failed: VK_ERROR_OUT_OF_DEVICE_MEMORY
[GlobalCache::findOrCreateUniformBuffer] failed to create initial uniform buffer, request buffer size: 96
```

`GlobalCache::findOrCreateUniformBuffer` used `std::max(device maxUBOSize, 64KB)` as the pool allocation size. Many mobile GPUs report a `maxUniformBufferRange` of 2GB~4GB (uint32), so tgfx tried to allocate a multi-GB uniform buffer at startup and ran out of device memory. The value was also narrowed to `int`, which could overflow.

Close #1509

## Fix

Decouple the two roles the device limit used to play, matching the behavior verified by Skia's DrawBufferManager:

- **Single request limit**: keeps the original `std::max(device, 64KB)` semantics, used only to validate one request's bind range.
- **Pool allocation size**: fixed at `MAX_UNIFORM_BUFFER_SIZE` (64KB), no longer follows the device limit. The pool grows with additional 64KB buffers on demand as before.
- Requests larger than the pool block now get a dedicated buffer instead of being rejected.
- `GPULimits::maxUniformBufferBindingSize` and `ShaderCaps::maxUBOSize` are now `int64_t` so Vulkan's uint32 limit is stored without overflow.

## Verification

- TGFXFullTest_OpenGL: 591/591 passed on macOS.
- Vulkan configuration compiles (running Vulkan tests requires a device with a Vulkan loader).