### PR TITLE
Fix hardcoded sRGB color space in Context3DCompositor causing wrong colors on non-sRGB surfaces.

### DIFF
--- a/src/layers/compositing3d/Context3DCompositor.cpp
+++ b/src/layers/compositing3d/Context3DCompositor.cpp
@@ -43,9 +43,6 @@ static constexpr unsigned RECT_EDGE_TOP = 0b0001;
 static constexpr unsigned RECT_EDGE_RIGHT = 0b0010;
 static constexpr unsigned RECT_EDGE_BOTTOM = 0b0100;
 
-// The color space used for the compositor's render target.
-static const auto TargetColorSpace = ColorSpace::SRGB;
-
 static inline AAType GetAAType(int sampleCount, bool antiAlias) {
   if (sampleCount > 1) {
     return AAType::MSAA;
@@ -127,8 +124,9 @@ static std::pair<Quad, unsigned> GetQuadAndAAFlags(const Rect& originalRect, AAT
   return {quad, aaFlags};
 }
 
-Context3DCompositor::Context3DCompositor(const Context& context, int width, int height)
-    : _width(width), _height(height) {
+Context3DCompositor::Context3DCompositor(const Context& context, int width, int height,
+                                         std::shared_ptr<ColorSpace> colorSpace)
+    : _width(width), _height(height), _colorSpace(std::move(colorSpace)) {
   _targetColorProxy =
       context.proxyProvider()->createRenderTargetProxy({}, width, height, PixelFormat::RGBA_8888);
   DEBUG_ASSERT(_targetColorProxy != nullptr);
@@ -194,7 +192,7 @@ void Context3DCompositor::drawQuads(const DrawPolygon3D* polygon,
   }
 
   auto vertexProvider =
-      QuadsVertexProvider::MakeFrom(allocator, std::move(quadRecords), aaType, TargetColorSpace());
+      QuadsVertexProvider::MakeFrom(allocator, std::move(quadRecords), aaType, _colorSpace);
   auto drawOp = Quads3DDrawOp::Make(context, std::move(vertexProvider), 0);
 
   const SamplingArgs samplingArgs = {TileMode::Clamp, TileMode::Clamp, {}, SrcRectConstraint::Fast};
@@ -246,7 +244,7 @@ std::shared_ptr<Image> Context3DCompositor::snapshotTarget() {
   // Make an immutable copy so subsequent draws to _targetColorProxy do not mutate this snapshot.
   auto copyProxy = _targetColorProxy->makeTextureProxy();
   context->drawingManager()->addRenderTargetCopyTask(_targetColorProxy, copyProxy);
-  return TextureImage::Wrap(std::move(copyProxy), TargetColorSpace());
+  return TextureImage::Wrap(std::move(copyProxy), _colorSpace);
 }
 
 void Context3DCompositor::primeWithImage(const std::shared_ptr<Image>& image) {
@@ -276,7 +274,7 @@ std::shared_ptr<Image> Context3DCompositor::flushToImage() {
   auto clearColor =
       _targetCleared ? std::optional<PMColor>{} : std::optional<PMColor>(PMColor::Transparent());
   context->drawingManager()->addOpsRenderTask(_targetColorProxy, std::move(opArray), clearColor);
-  auto image = TextureImage::Wrap(_targetColorProxy->asTextureProxy(), TargetColorSpace());
+  auto image = TextureImage::Wrap(_targetColorProxy->asTextureProxy(), _colorSpace);
   _targetColorProxy = nullptr;
   _orderedFragments.clear();
   _bspTree.reset();

--- a/src/layers/compositing3d/Context3DCompositor.h
+++ b/src/layers/compositing3d/Context3DCompositor.h
@@ -27,6 +27,7 @@
 #include "core/utils/PlacementPtr.h"
 #include "gpu/ops/DrawOp.h"
 #include "gpu/proxies/RenderTargetProxy.h"
+#include "tgfx/core/ColorSpace.h"
 #include "tgfx/core/Image.h"
 
 namespace tgfx {
@@ -43,7 +44,8 @@ class Layer;
  */
 class Context3DCompositor {
  public:
-  Context3DCompositor(const Context& context, int width, int height);
+  Context3DCompositor(const Context& context, int width, int height,
+                      std::shared_ptr<ColorSpace> colorSpace = ColorSpace::SRGB());
 
   int width() const {
     return _width;
@@ -107,6 +109,7 @@ class Context3DCompositor {
 
   int _width = 0;
   int _height = 0;
+  std::shared_ptr<ColorSpace> _colorSpace = nullptr;
   std::shared_ptr<RenderTargetProxy> _targetColorProxy = nullptr;
   std::deque<std::unique_ptr<DrawPolygon3D>> _polygons = {};
   std::unique_ptr<BspTree> _bspTree = nullptr;

--- a/src/layers/compositing3d/Layer3DContext.cpp
+++ b/src/layers/compositing3d/Layer3DContext.cpp
@@ -30,8 +30,9 @@ std::shared_ptr<Layer3DContext> Layer3DContext::Make(bool opaqueMode, Context* c
   if (opaqueMode) {
     return std::make_shared<Opaque3DContext>(renderRect, contentScale, std::move(colorSpace));
   }
-  auto compositor = std::make_shared<Context3DCompositor>(
-      *context, static_cast<int>(renderRect.width()), static_cast<int>(renderRect.height()));
+  auto compositor =
+      std::make_shared<Context3DCompositor>(*context, static_cast<int>(renderRect.width()),
+                                            static_cast<int>(renderRect.height()), colorSpace);
   return std::make_shared<Render3DContext>(std::move(compositor), renderRect, contentScale,
                                            std::move(colorSpace));
 }


### PR DESCRIPTION
When rendering 3D layers (e.g., preserve-3D layer trees) onto a DisplayP3 surface, the Context3DCompositor hardcoded ColorSpace::SRGB as the target color space. This caused composited images to be incorrectly tagged as sRGB, leading to a second color space conversion when the final image was drawn to the DisplayP3 surface — effectively double-converting colors and producing wrong visual output.

### Root Cause

`Context3DCompositor.cpp:47` hardcoded:
```cpp
static const auto TargetColorSpace = ColorSpace::SRGB;
```

This was used in `flushToImage()`, `snapshotTarget()`, and `drawQuads()` instead of the actual color space from the 3D context.

### Fix

- `Context3DCompositor` now accepts a `ColorSpace` parameter in its constructor
- Replaces all `TargetColorSpace()` references with the member `_colorSpace`
- `Layer3DContext::Make()` passes `colorSpace` to the compositor constructor

### Change Summary

```
Context3DCompositor.h    | +4  constructor: add colorSpace param, add _colorSpace member
Context3DCompositor.cpp  | -3 +6  remove static TargetColorSpace, use _colorSpace
Layer3DContext.cpp       | +3 -1  pass colorSpace to compositor
```