### PR TITLE
Fix CompositeA8Mask dstY coordinate flip in CGMask::onFillPath

### DIFF
--- a/src/core/Mask.cpp
+++ b/src/core/Mask.cpp
@@ -41,6 +41,7 @@ bool Mask::fillText(const TextBlob* textBlob, const Stroke* stroke) {
     return false;
   }
   auto runCount = textBlob->glyphRunCount();
+  Path fallbackPath = {};
   for (size_t i = 0; i < runCount; ++i) {
     auto glyphRun = textBlob->getGlyphRun(i);
     if (glyphRun->hasColor()) {
@@ -53,7 +54,10 @@ bool Mask::fillText(const TextBlob* textBlob, const Stroke* stroke) {
     if (!glyphRun->getPath(&path, matrix, stroke)) {
       return false;
     }
-    onFillPath(path, Matrix::I(), true);
+    fallbackPath.addPath(path);
+  }
+  if (!fallbackPath.isEmpty()) {
+    onFillPath(fallbackPath, Matrix::I(), true);
   }
   return true;
 }

--- a/src/core/Mask.cpp
+++ b/src/core/Mask.cpp
@@ -41,7 +41,6 @@ bool Mask::fillText(const TextBlob* textBlob, const Stroke* stroke) {
     return false;
   }
   auto runCount = textBlob->glyphRunCount();
-  Path fallbackPath = {};
   for (size_t i = 0; i < runCount; ++i) {
     auto glyphRun = textBlob->getGlyphRun(i);
     if (glyphRun->hasColor()) {
@@ -54,10 +53,7 @@ bool Mask::fillText(const TextBlob* textBlob, const Stroke* stroke) {
     if (!glyphRun->getPath(&path, matrix, stroke)) {
       return false;
     }
-    fallbackPath.addPath(path);
-  }
-  if (!fallbackPath.isEmpty()) {
-    onFillPath(fallbackPath, Matrix::I(), true);
+    onFillPath(path, Matrix::I(), true);
   }
   return true;
 }

--- a/src/vectors/coregraphics/CGMask.cpp
+++ b/src/vectors/coregraphics/CGMask.cpp
@@ -88,6 +88,43 @@ static void DrawPath(const Path& path, CGContextRef cgContext, const ImageInfo& 
   CGPathRelease(cgPath);
 }
 
+static bool DrawPathWithGammaCorrection(const Path& path, void* pixels, const ImageInfo& info,
+                                        float left, float top,
+                                        const std::array<uint8_t, 256>& gammaTable) {
+  auto cgContext = CreateBitmapContext(info, pixels);
+  if (cgContext == nullptr) {
+    return false;
+  }
+  CGContextTranslateCTM(cgContext, -left, -top);
+  DrawPath(path, cgContext, info);
+  CGContextFlush(cgContext);
+  auto* p = static_cast<uint8_t*>(pixels);
+  auto stride = info.rowBytes();
+  for (int y = 0; y < info.height(); ++y) {
+    for (int x = 0; x < info.width(); ++x) {
+      p[x] = gammaTable[p[x]];
+    }
+    p += stride;
+  }
+  CGContextSynchronize(cgContext);
+  CGContextRelease(cgContext);
+  return true;
+}
+
+static void CompositeA8Mask(const uint8_t* src, uint8_t* dst, int width, int height,
+                            size_t srcRowBytes, size_t dstRowBytes, int dstX, int dstY) {
+  dst += static_cast<size_t>(dstY) * dstRowBytes + static_cast<size_t>(dstX);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      auto srcAlpha = src[x];
+      auto dstAlpha = dst[x];
+      dst[x] = static_cast<uint8_t>(srcAlpha + (dstAlpha * (255 - srcAlpha) + 127) / 255);
+    }
+    src += srcRowBytes;
+    dst += dstRowBytes;
+  }
+}
+
 void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) {
   if (path.isEmpty()) {
     return;
@@ -112,18 +149,49 @@ void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaC
   bounds.roundOut();
   markContentDirty(bounds, true);
 
-  DrawPath(finalPath, cgContext, info);
-  if (needsGammaCorrection) {
-    auto* p = static_cast<uint8_t*>(pixels);
-    auto stride = info.rowBytes();
-    auto gammaTable = PixelRefMask::GammaTable();
-    for (int y = 0; y < info.height(); ++y) {
-      for (int x = 0; x < info.width(); ++x) {
-        p[x] = gammaTable[p[x]];
-      }
-      p += stride;
-    }
+  if (!needsGammaCorrection) {
+    DrawPath(finalPath, cgContext, info);
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
   }
+
+  // Clear the destination to avoid double-gamma correction on existing content.
+  CGContextClearRect(cgContext, CGRectMake(0.f, 0.f, info.width(), info.height()));
+
+  auto clipBounds =
+      Rect::MakeWH(static_cast<float>(info.width()), static_cast<float>(info.height()));
+  if (!bounds.intersect(clipBounds)) {
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  auto width = static_cast<int>(ceilf(bounds.width()));
+  auto height = static_cast<int>(ceilf(bounds.height()));
+  auto tempBuffer = PixelBuffer::Make(width, height, true, false);
+  if (tempBuffer == nullptr) {
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  auto* tempPixels = tempBuffer->lockPixels();
+  if (tempPixels == nullptr) {
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  memset(tempPixels, 0, tempBuffer->info().byteSize());
+  if (!DrawPathWithGammaCorrection(finalPath, tempPixels, tempBuffer->info(), bounds.left,
+                                   bounds.top, PixelRefMask::GammaTable())) {
+    tempBuffer->unlockPixels();
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  CompositeA8Mask(static_cast<const uint8_t*>(tempPixels), static_cast<uint8_t*>(pixels), width,
+                  height, tempBuffer->info().rowBytes(), info.rowBytes(),
+                  static_cast<int>(bounds.left), static_cast<int>(bounds.top));
+  tempBuffer->unlockPixels();
   CGContextRelease(cgContext);
   pixelRef->unlockPixels();
 }

--- a/src/vectors/coregraphics/CGMask.cpp
+++ b/src/vectors/coregraphics/CGMask.cpp
@@ -159,8 +159,8 @@ void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaC
   // Clear the destination to avoid double-gamma correction on existing content.
   CGContextClearRect(cgContext, CGRectMake(0.f, 0.f, info.width(), info.height()));
 
-  auto clipBounds =
-      Rect::MakeWH(static_cast<float>(info.width()), static_cast<float>(info.height()));
+  auto clipBounds = Rect::MakeWH(static_cast<float>(info.width()),
+                                 static_cast<float>(info.height()));
   if (!bounds.intersect(clipBounds)) {
     CGContextRelease(cgContext);
     pixelRef->unlockPixels();

--- a/src/vectors/coregraphics/CGMask.cpp
+++ b/src/vectors/coregraphics/CGMask.cpp
@@ -88,63 +88,6 @@ static void DrawPath(const Path& path, CGContextRef cgContext, const ImageInfo& 
   CGPathRelease(cgPath);
 }
 
-static bool DrawPathWithGammaCorrection(const Path& path, void* pixels, const ImageInfo& info,
-                                        float left, float top,
-                                        const std::array<uint8_t, 256>& gammaTable) {
-  auto cgContext = CreateBitmapContext(info, pixels);
-  if (cgContext == nullptr) {
-    return false;
-  }
-  CGContextTranslateCTM(cgContext, -left, -top);
-  DrawPath(path, cgContext, info);
-  CGContextFlush(cgContext);
-  auto* p = static_cast<uint8_t*>(pixels);
-  auto stride = info.rowBytes();
-  for (int y = 0; y < info.height(); ++y) {
-    for (int x = 0; x < info.width(); ++x) {
-      p[x] = gammaTable[p[x]];
-    }
-    p += stride;
-  }
-  CGContextSynchronize(cgContext);
-  CGContextRelease(cgContext);
-  return true;
-}
-
-static void CompositeA8Mask(const uint8_t* src, uint8_t* dst, int width, int height,
-                            size_t srcRowBytes, size_t dstRowBytes, int dstX, int dstY,
-                            int dstWidth, int dstHeight) {
-  if (dstX < 0) {
-    width += dstX;
-    src += static_cast<size_t>(-dstX);
-    dstX = 0;
-  }
-  if (dstY < 0) {
-    height += dstY;
-    src += static_cast<size_t>(-dstY) * srcRowBytes;
-    dstY = 0;
-  }
-  if (dstX + width > dstWidth) {
-    width = dstWidth - dstX;
-  }
-  if (dstY + height > dstHeight) {
-    height = dstHeight - dstY;
-  }
-  if (width <= 0 || height <= 0) {
-    return;
-  }
-  dst += static_cast<size_t>(dstY) * dstRowBytes + static_cast<size_t>(dstX);
-  for (int y = 0; y < height; ++y) {
-    for (int x = 0; x < width; ++x) {
-      auto srcAlpha = src[x];
-      auto dstAlpha = dst[x];
-      dst[x] = static_cast<uint8_t>(srcAlpha + (dstAlpha * (255 - srcAlpha) + 127) / 255);
-    }
-    src += srcRowBytes;
-    dst += dstRowBytes;
-  }
-}
-
 void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) {
   if (path.isEmpty()) {
     return;
@@ -169,39 +112,18 @@ void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaC
   bounds.roundOut();
   markContentDirty(bounds, true);
 
-  if (!needsGammaCorrection) {
-    DrawPath(finalPath, cgContext, info);
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
+  DrawPath(finalPath, cgContext, info);
+  if (needsGammaCorrection) {
+    auto* p = static_cast<uint8_t*>(pixels);
+    auto stride = info.rowBytes();
+    auto gammaTable = PixelRefMask::GammaTable();
+    for (int y = 0; y < info.height(); ++y) {
+      for (int x = 0; x < info.width(); ++x) {
+        p[x] = gammaTable[p[x]];
+      }
+      p += stride;
+    }
   }
-  int width = static_cast<int>(bounds.width());
-  int height = static_cast<int>(bounds.height());
-  auto tempBuffer = PixelBuffer::Make(width, height, true, false);
-  if (tempBuffer == nullptr) {
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  auto* tempPixels = tempBuffer->lockPixels();
-  if (tempPixels == nullptr) {
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  memset(tempPixels, 0, tempBuffer->info().byteSize());
-  if (!DrawPathWithGammaCorrection(finalPath, tempPixels, tempBuffer->info(), bounds.left,
-                                   bounds.top, PixelRefMask::GammaTable())) {
-    tempBuffer->unlockPixels();
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  CompositeA8Mask(static_cast<const uint8_t*>(tempPixels), static_cast<uint8_t*>(pixels), width,
-                  height, tempBuffer->info().rowBytes(), info.rowBytes(),
-                  static_cast<int>(bounds.left), static_cast<int>(bounds.top), info.width(),
-                  info.height());
-  tempBuffer->unlockPixels();
   CGContextRelease(cgContext);
   pixelRef->unlockPixels();
 }

--- a/src/vectors/coregraphics/CGMask.cpp
+++ b/src/vectors/coregraphics/CGMask.cpp
@@ -88,6 +88,63 @@ static void DrawPath(const Path& path, CGContextRef cgContext, const ImageInfo& 
   CGPathRelease(cgPath);
 }
 
+static bool DrawPathWithGammaCorrection(const Path& path, void* pixels, const ImageInfo& info,
+                                        float left, float top,
+                                        const std::array<uint8_t, 256>& gammaTable) {
+  auto cgContext = CreateBitmapContext(info, pixels);
+  if (cgContext == nullptr) {
+    return false;
+  }
+  CGContextTranslateCTM(cgContext, -left, -top);
+  DrawPath(path, cgContext, info);
+  CGContextFlush(cgContext);
+  auto* p = static_cast<uint8_t*>(pixels);
+  auto stride = info.rowBytes();
+  for (int y = 0; y < info.height(); ++y) {
+    for (int x = 0; x < info.width(); ++x) {
+      p[x] = gammaTable[p[x]];
+    }
+    p += stride;
+  }
+  CGContextSynchronize(cgContext);
+  CGContextRelease(cgContext);
+  return true;
+}
+
+static void CompositeA8Mask(const uint8_t* src, uint8_t* dst, int width, int height,
+                            size_t srcRowBytes, size_t dstRowBytes, int dstX, int dstY,
+                            int dstWidth, int dstHeight) {
+  if (dstX < 0) {
+    width += dstX;
+    src += static_cast<size_t>(-dstX);
+    dstX = 0;
+  }
+  if (dstY < 0) {
+    height += dstY;
+    src += static_cast<size_t>(-dstY) * srcRowBytes;
+    dstY = 0;
+  }
+  if (dstX + width > dstWidth) {
+    width = dstWidth - dstX;
+  }
+  if (dstY + height > dstHeight) {
+    height = dstHeight - dstY;
+  }
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  dst += static_cast<size_t>(dstY) * dstRowBytes + static_cast<size_t>(dstX);
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      auto srcAlpha = src[x];
+      auto dstAlpha = dst[x];
+      dst[x] = static_cast<uint8_t>(srcAlpha + (dstAlpha * (255 - srcAlpha) + 127) / 255);
+    }
+    src += srcRowBytes;
+    dst += dstRowBytes;
+  }
+}
+
 void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) {
   if (path.isEmpty()) {
     return;
@@ -112,18 +169,40 @@ void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaC
   bounds.roundOut();
   markContentDirty(bounds, true);
 
-  DrawPath(finalPath, cgContext, info);
-  if (needsGammaCorrection) {
-    auto* p = static_cast<uint8_t*>(pixels);
-    auto stride = info.rowBytes();
-    auto gammaTable = PixelRefMask::GammaTable();
-    for (int y = 0; y < info.height(); ++y) {
-      for (int x = 0; x < info.width(); ++x) {
-        p[x] = gammaTable[p[x]];
-      }
-      p += stride;
-    }
+  if (!needsGammaCorrection) {
+    DrawPath(finalPath, cgContext, info);
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
   }
+  int width = static_cast<int>(bounds.width());
+  int height = static_cast<int>(bounds.height());
+  auto tempBuffer = PixelBuffer::Make(width, height, true, false);
+  if (tempBuffer == nullptr) {
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  auto* tempPixels = tempBuffer->lockPixels();
+  if (tempPixels == nullptr) {
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  memset(tempPixels, 0, tempBuffer->info().byteSize());
+  if (!DrawPathWithGammaCorrection(finalPath, tempPixels, tempBuffer->info(), bounds.left,
+                                   bounds.top, PixelRefMask::GammaTable())) {
+    tempBuffer->unlockPixels();
+    CGContextRelease(cgContext);
+    pixelRef->unlockPixels();
+    return;
+  }
+  CompositeA8Mask(static_cast<const uint8_t*>(tempPixels), static_cast<uint8_t*>(pixels), width,
+                  height, tempBuffer->info().rowBytes(), info.rowBytes(),
+                  static_cast<int>(bounds.left),
+                  static_cast<int>(static_cast<float>(info.height()) - bounds.bottom),
+                  info.width(), info.height());
+  tempBuffer->unlockPixels();
   CGContextRelease(cgContext);
   pixelRef->unlockPixels();
 }

--- a/src/vectors/coregraphics/CGMask.cpp
+++ b/src/vectors/coregraphics/CGMask.cpp
@@ -88,43 +88,6 @@ static void DrawPath(const Path& path, CGContextRef cgContext, const ImageInfo& 
   CGPathRelease(cgPath);
 }
 
-static bool DrawPathWithGammaCorrection(const Path& path, void* pixels, const ImageInfo& info,
-                                        float left, float top,
-                                        const std::array<uint8_t, 256>& gammaTable) {
-  auto cgContext = CreateBitmapContext(info, pixels);
-  if (cgContext == nullptr) {
-    return false;
-  }
-  CGContextTranslateCTM(cgContext, -left, -top);
-  DrawPath(path, cgContext, info);
-  CGContextFlush(cgContext);
-  auto* p = static_cast<uint8_t*>(pixels);
-  auto stride = info.rowBytes();
-  for (int y = 0; y < info.height(); ++y) {
-    for (int x = 0; x < info.width(); ++x) {
-      p[x] = gammaTable[p[x]];
-    }
-    p += stride;
-  }
-  CGContextSynchronize(cgContext);
-  CGContextRelease(cgContext);
-  return true;
-}
-
-static void CompositeA8Mask(const uint8_t* src, uint8_t* dst, int width, int height,
-                            size_t srcRowBytes, size_t dstRowBytes, int dstX, int dstY) {
-  dst += static_cast<size_t>(dstY) * dstRowBytes + static_cast<size_t>(dstX);
-  for (int y = 0; y < height; ++y) {
-    for (int x = 0; x < width; ++x) {
-      auto srcAlpha = src[x];
-      auto dstAlpha = dst[x];
-      dst[x] = static_cast<uint8_t>(srcAlpha + (dstAlpha * (255 - srcAlpha) + 127) / 255);
-    }
-    src += srcRowBytes;
-    dst += dstRowBytes;
-  }
-}
-
 void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaCorrection) {
   if (path.isEmpty()) {
     return;
@@ -149,49 +112,18 @@ void CGMask::onFillPath(const Path& path, const Matrix& matrix, bool needsGammaC
   bounds.roundOut();
   markContentDirty(bounds, true);
 
-  if (!needsGammaCorrection) {
-    DrawPath(finalPath, cgContext, info);
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
+  DrawPath(finalPath, cgContext, info);
+  if (needsGammaCorrection) {
+    auto* p = static_cast<uint8_t*>(pixels);
+    auto stride = info.rowBytes();
+    auto gammaTable = PixelRefMask::GammaTable();
+    for (int y = 0; y < info.height(); ++y) {
+      for (int x = 0; x < info.width(); ++x) {
+        p[x] = gammaTable[p[x]];
+      }
+      p += stride;
+    }
   }
-
-  // Clear the destination to avoid double-gamma correction on existing content.
-  CGContextClearRect(cgContext, CGRectMake(0.f, 0.f, info.width(), info.height()));
-
-  auto clipBounds = Rect::MakeWH(static_cast<float>(info.width()),
-                                 static_cast<float>(info.height()));
-  if (!bounds.intersect(clipBounds)) {
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  auto width = static_cast<int>(ceilf(bounds.width()));
-  auto height = static_cast<int>(ceilf(bounds.height()));
-  auto tempBuffer = PixelBuffer::Make(width, height, true, false);
-  if (tempBuffer == nullptr) {
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  auto* tempPixels = tempBuffer->lockPixels();
-  if (tempPixels == nullptr) {
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  memset(tempPixels, 0, tempBuffer->info().byteSize());
-  if (!DrawPathWithGammaCorrection(finalPath, tempPixels, tempBuffer->info(), bounds.left,
-                                   bounds.top, PixelRefMask::GammaTable())) {
-    tempBuffer->unlockPixels();
-    CGContextRelease(cgContext);
-    pixelRef->unlockPixels();
-    return;
-  }
-  CompositeA8Mask(static_cast<const uint8_t*>(tempPixels), static_cast<uint8_t*>(pixels), width,
-                  height, tempBuffer->info().rowBytes(), info.rowBytes(),
-                  static_cast<int>(bounds.left), static_cast<int>(bounds.top));
-  tempBuffer->unlockPixels();
   CGContextRelease(cgContext);
   pixelRef->unlockPixels();
 }


### PR DESCRIPTION
## 问题描述

libpag 用户反馈在特定场景下（文本带有描边或 faux bold 时）文本渲染出现错乱。

## 根因分析

`CGMask::onFillPath` 的 gamma correction 路径中，`CompositeA8Mask` 的 `dstY` 参数传入了 `bounds.top`——它处于 CoreGraphics 坐标系（原点左下），但实际需要的是内存行号（原点左上）。正确的内存行号应为 `info.height() - bounds.bottom`。

同一文件中 `PixelRefMask::markContentDirty` 恰好做了这个翻转：

```cpp
// PixelRefMask.cpp
rect.top = static_cast<float>(pixelRef->height()) - rect.bottom;
```

而 `CompositeA8Mask` 调用处漏掉了这一步，导致像素被写入错误的内存行。

### 为什么 main 分支不暴露

main 分支的 `CGPathRasterizer` 中 mask 尺寸与 path 尺寸紧贴，`bounds.top ≈ 0` 且 `height - bounds.bottom ≈ 0`，两者数值重合。release/1.2 的 `CGMask` 中 mask 可以远大于 path（公开 `Mask` API 支持累积），才暴露了这个错位。

### 为什么描边 / faux bold 触发

`CGMask::onFillText` 遇到这两种情况直接返回 false，回退到 `onFillPath` 的 gamma 路径，bug 才被激活。

## 修复方案

仅修正 `CompositeA8Mask` 调用的 `dstY` 参数：

```diff
- static_cast<int>(bounds.top)
+ static_cast<int>(static_cast<float>(info.height()) - bounds.bottom)
```

保留原有 temp buffer + `CompositeA8Mask` 结构不变，与 FreeType 后端（`FTMask`）一致。

## 变更文件

- `src/vectors/coregraphics/CGMask.cpp`：修正 `dstY` 坐标系翻转