### PR TITLE
Update zlib to 1.3.2, freetype to 2.14.3 and libpng to 1.6.58.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -22,12 +22,12 @@
       },
       {
         "url": "https://github.com/madler/zlib.git",
-        "commit": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf",
+        "commit": "da607da739fa6047df13e66a2af6b8bec7c2a498",
         "dir": "third_party/zlib"
       },
       {
         "url": "https://github.com/glennrp/libpng.git",
-        "commit": "872555f4ba910252783af1507f9e7fe1653be252",
+        "commit": "3061454d980de7d53608f594194cfac722721d2a",
         "dir": "third_party/libpng"
       },
       {
@@ -42,7 +42,7 @@
       },
       {
         "url": "https://github.com/freetype/freetype.git",
-        "commit": "42608f77f20749dd6ddc9e0536788eaad70ea4b5",
+        "commit": "0a0221a1347e2f1e07c395263540026e9a0aa7c7",
         "dir": "third_party/freetype"
       },
       {


### PR DESCRIPTION
Upgrade third-party dependencies to fix security vulnerabilities:

- **zlib**: 1.3.1 -> 1.3.2 (fixes CVE-2026-22184, CVE-2026-27171)
- **freetype**: 2.13.3 -> 2.14.3 (fixes potential security issues)
- **libpng**: 1.6.47 -> 1.6.58 (fixes ~10 CVEs including CVE-2026-25646, CVE-2026-33416)