### PR TITLE
Fix SVG opacity and clip being dropped when copying render contexts for nested elements.

### DIFF
--- a/src/svg/SVGRenderContext.cpp
+++ b/src/svg/SVGRenderContext.cpp
@@ -117,28 +117,43 @@ SVGRenderContext::SVGRenderContext(Canvas* canvas, const std::shared_ptr<TextSha
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other)
     : SVGRenderContext(other._canvas, other._textShaper, other.nodeIDMapper, *other._lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
+  copyFieldsNotForwardedToBaseCtor(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other, Canvas* canvas)
     : SVGRenderContext(canvas, other._textShaper, other.nodeIDMapper, *other._lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
+  copyFieldsNotForwardedToBaseCtor(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other,
                                    const SVGLengthContext& lengthContext)
     : SVGRenderContext(other._canvas, other._textShaper, other.nodeIDMapper, lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
+  copyFieldsNotForwardedToBaseCtor(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other, Canvas* canvas,
                                    const SVGLengthContext& lengthContext)
     : SVGRenderContext(canvas, other._textShaper, other.nodeIDMapper, lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
+  copyFieldsNotForwardedToBaseCtor(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other, const SVGNode* node)
     : SVGRenderContext(other._canvas, other._textShaper, other.nodeIDMapper, *other._lengthContext,
                        *other._presentationContext, OBBScope{node, this}, other._matrix) {
+  copyFieldsNotForwardedToBaseCtor(other);
+}
+
+void SVGRenderContext::copyFieldsNotForwardedToBaseCtor(const SVGRenderContext& other) {
+  // The base 7-argument constructor takes canvas/textShaper/mapper/length/presentation/scope/matrix
+  // and does not receive these two fields, so every copy-style constructor must forward them here.
+  // Without this, MSVC Debug builds (which skip NRVO for the return-by-value in CopyForPaint)
+  // silently drop these fields on the extra copy that Release optimizes away, producing wrong
+  // opacity and clip results only in Debug builds.
+  deferredPaintOpacity = other.deferredPaintOpacity;
+  _clipPath = other._clipPath;
 }
 
 SVGRenderContext::~SVGRenderContext() {

--- a/src/svg/SVGRenderContext.cpp
+++ b/src/svg/SVGRenderContext.cpp
@@ -115,43 +115,44 @@ SVGRenderContext::SVGRenderContext(Canvas* canvas, const std::shared_ptr<TextSha
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other)
-    : SVGRenderContext(other._canvas, other._textShaper, other.nodeIDMapper, *other._lengthContext,
-                       *other._presentationContext, other.scope, other._matrix) {
-  copyFieldsNotForwardedToBaseCtor(other);
+    : _textShaper(other._textShaper), nodeIDMapper(other.nodeIDMapper),
+      _lengthContext(*other._lengthContext), _presentationContext(*other._presentationContext),
+      _canvas(other._canvas), canvasSaveCount(other._canvas->getSaveCount()),
+      _clipPath(other._clipPath), deferredPaintOpacity(other.deferredPaintOpacity),
+      scope(other.scope), _matrix(other._matrix) {
+  // Track the canvas's current save level, not other.canvasSaveCount, to avoid popping
+  // other's saveOnce() layer on destruction.
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other, Canvas* canvas)
     : SVGRenderContext(canvas, other._textShaper, other.nodeIDMapper, *other._lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
-  copyFieldsNotForwardedToBaseCtor(other);
+  copyNodeRenderState(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other,
                                    const SVGLengthContext& lengthContext)
     : SVGRenderContext(other._canvas, other._textShaper, other.nodeIDMapper, lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
-  copyFieldsNotForwardedToBaseCtor(other);
+  copyNodeRenderState(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other, Canvas* canvas,
                                    const SVGLengthContext& lengthContext)
     : SVGRenderContext(canvas, other._textShaper, other.nodeIDMapper, lengthContext,
                        *other._presentationContext, other.scope, other._matrix) {
-  copyFieldsNotForwardedToBaseCtor(other);
+  copyNodeRenderState(other);
 }
 
 SVGRenderContext::SVGRenderContext(const SVGRenderContext& other, const SVGNode* node)
     : SVGRenderContext(other._canvas, other._textShaper, other.nodeIDMapper, *other._lengthContext,
                        *other._presentationContext, OBBScope{node, this}, other._matrix) {
-  copyFieldsNotForwardedToBaseCtor(other);
+  copyNodeRenderState(other);
 }
 
-void SVGRenderContext::copyFieldsNotForwardedToBaseCtor(const SVGRenderContext& other) {
-  // The base 7-argument constructor takes canvas/textShaper/mapper/length/presentation/scope/matrix
-  // and does not receive these two fields, so every copy-style constructor must forward them here.
-  // Without this, MSVC Debug builds (which skip NRVO for the return-by-value in CopyForPaint)
-  // silently drop these fields on the extra copy that Release optimizes away, producing wrong
-  // opacity and clip results only in Debug builds.
+void SVGRenderContext::copyNodeRenderState(const SVGRenderContext& other) {
+  // The delegated 7-argument constructor does not carry these fields; the replacement-style
+  // copy constructors call this to keep them.
   deferredPaintOpacity = other.deferredPaintOpacity;
   _clipPath = other._clipPath;
 }
@@ -163,7 +164,6 @@ SVGRenderContext::~SVGRenderContext() {
 SVGRenderContext SVGRenderContext::CopyForPaint(const SVGRenderContext& context, Canvas* canvas,
                                                 const SVGLengthContext& lengthContext) {
   SVGRenderContext copyContext(context, canvas, lengthContext);
-  copyContext.deferredPaintOpacity = context.deferredPaintOpacity;
   return copyContext;
 }
 

--- a/src/svg/SVGRenderContext.h
+++ b/src/svg/SVGRenderContext.h
@@ -227,7 +227,8 @@ class SVGRenderContext {
   std::shared_ptr<MaskFilter> applyMask(const SVGFuncIRI& mask);
 
   // Copies node-scoped render state (clip path, deferred paint opacity) from other. Called by
-  // the replacement-style copy constructors, whose delegated base constructor drops these fields.
+  // the replacement-style copy constructors, whose delegated constructor does not carry these
+  // fields.
   void copyNodeRenderState(const SVGRenderContext& other);
 
   std::optional<Paint> commonPaint(const SVGPaint& paint, float opacity) const;

--- a/src/svg/SVGRenderContext.h
+++ b/src/svg/SVGRenderContext.h
@@ -226,10 +226,9 @@ class SVGRenderContext {
   Path applyClip(const SVGFuncIRI& clip) const;
   std::shared_ptr<MaskFilter> applyMask(const SVGFuncIRI& mask);
 
-  // Copies fields that the base 7-argument constructor does not receive. Every copy-style
-  // constructor must call this after delegating so that the source object's opacity/clip state is
-  // preserved even when the compiler materializes an extra copy (e.g. Debug builds without NRVO).
-  void copyFieldsNotForwardedToBaseCtor(const SVGRenderContext& other);
+  // Copies node-scoped render state (clip path, deferred paint opacity) from other. Called by
+  // the replacement-style copy constructors, whose delegated base constructor drops these fields.
+  void copyNodeRenderState(const SVGRenderContext& other);
 
   std::optional<Paint> commonPaint(const SVGPaint& paint, float opacity) const;
 

--- a/src/svg/SVGRenderContext.h
+++ b/src/svg/SVGRenderContext.h
@@ -226,6 +226,11 @@ class SVGRenderContext {
   Path applyClip(const SVGFuncIRI& clip) const;
   std::shared_ptr<MaskFilter> applyMask(const SVGFuncIRI& mask);
 
+  // Copies fields that the base 7-argument constructor does not receive. Every copy-style
+  // constructor must call this after delegating so that the source object's opacity/clip state is
+  // preserved even when the compiler materializes an extra copy (e.g. Debug builds without NRVO).
+  void copyFieldsNotForwardedToBaseCtor(const SVGRenderContext& other);
+
   std::optional<Paint> commonPaint(const SVGPaint& paint, float opacity) const;
 
   std::shared_ptr<TextShaper> _textShaper;

--- a/test/src/SVGRenderTest.cpp
+++ b/test/src/SVGRenderTest.cpp
@@ -21,9 +21,12 @@
 #include "core/filters/InnerShadowImageFilter.h"
 #include "core/utils/Types.h"
 #include "gtest/gtest.h"
+#include "svg/SVGRenderContext.h"
 #include "tgfx/core/Data.h"
 #include "tgfx/core/ImageFilter.h"
 #include "tgfx/core/Paint.h"
+#include "tgfx/core/Path.h"
+#include "tgfx/core/PictureRecorder.h"
 #include "tgfx/core/Rect.h"
 #include "tgfx/core/Stream.h"
 #include "tgfx/core/Typeface.h"
@@ -31,6 +34,8 @@
 #include "tgfx/svg/SVGCustomWriter.h"
 #include "tgfx/svg/SVGDOM.h"
 #include "tgfx/svg/SVGExporter.h"
+#include "tgfx/svg/SVGLengthContext.h"
+#include "tgfx/svg/TextShaper.h"
 #include "tgfx/svg/node/SVGNode.h"
 #include "tgfx/svg/xml/XMLDOM.h"
 #include "utils/TestUtils.h"
@@ -793,6 +798,87 @@ TGFX_TEST(SVGRenderTest, MixBlendModeCustomAttribute) {
       }
     }
     EXPECT_TRUE(found);
+  }
+}
+
+// Regression test: every copy-style constructor of SVGRenderContext must preserve _clipPath and
+// deferredPaintOpacity. Originally these were dropped by the delegated constructor and only
+// surfaced on MSVC Debug builds (no NRVO in CopyForPaint's return-by-value).
+TGFX_TEST_PRIVATE(SVGRenderTest, RenderContextCopyPreservesOpacityAndClip) {
+  PictureRecorder recorder;
+  auto* canvas = recorder.beginRecording();
+  ASSERT_TRUE(canvas != nullptr);
+
+  SVGIDMapper mapper;
+  SVGLengthContext lengthContext(Size::Make(100.f, 100.f));
+  SVGPresentationContext presentationContext;
+  SVGRenderContext::OBBScope scope{nullptr, nullptr};
+
+  SVGRenderContext source(canvas, TextShaper::Make({}), mapper, lengthContext, presentationContext,
+                          scope, Matrix::I());
+
+  const float expectedOpacity = 0.375f;
+  Path expectedClip;
+  expectedClip.addRect(Rect::MakeXYWH(10.f, 20.f, 30.f, 40.f));
+  source.deferredPaintOpacity = expectedOpacity;
+  source._clipPath = expectedClip;
+
+  // 1-arg copy constructor.
+  {
+    SVGRenderContext copy(source);
+    EXPECT_FLOAT_EQ(copy.deferredPaintOpacity, expectedOpacity);
+    ASSERT_TRUE(copy._clipPath.has_value());
+    EXPECT_EQ(*copy._clipPath, expectedClip);
+  }
+
+  // 2-arg copy constructor (override canvas).
+  {
+    PictureRecorder otherRecorder;
+    auto* otherCanvas = otherRecorder.beginRecording();
+    SVGRenderContext copy(source, otherCanvas);
+    EXPECT_FLOAT_EQ(copy.deferredPaintOpacity, expectedOpacity);
+    ASSERT_TRUE(copy._clipPath.has_value());
+    EXPECT_EQ(*copy._clipPath, expectedClip);
+  }
+
+  // 2-arg copy constructor (override length context).
+  {
+    SVGLengthContext otherLengthContext(Size::Make(200.f, 200.f));
+    SVGRenderContext copy(source, otherLengthContext);
+    EXPECT_FLOAT_EQ(copy.deferredPaintOpacity, expectedOpacity);
+    ASSERT_TRUE(copy._clipPath.has_value());
+    EXPECT_EQ(*copy._clipPath, expectedClip);
+  }
+
+  // 3-arg copy constructor (override canvas and length context).
+  {
+    PictureRecorder otherRecorder;
+    auto* otherCanvas = otherRecorder.beginRecording();
+    SVGLengthContext otherLengthContext(Size::Make(200.f, 200.f));
+    SVGRenderContext copy(source, otherCanvas, otherLengthContext);
+    EXPECT_FLOAT_EQ(copy.deferredPaintOpacity, expectedOpacity);
+    ASSERT_TRUE(copy._clipPath.has_value());
+    EXPECT_EQ(*copy._clipPath, expectedClip);
+  }
+
+  // 2-arg copy constructor (establish a new OBB scope for a node).
+  {
+    SVGRenderContext copy(source, static_cast<const SVGNode*>(nullptr));
+    EXPECT_FLOAT_EQ(copy.deferredPaintOpacity, expectedOpacity);
+    ASSERT_TRUE(copy._clipPath.has_value());
+    EXPECT_EQ(*copy._clipPath, expectedClip);
+  }
+
+  // Exact original bug path: CopyForPaint returns by value; both fields must survive the
+  // extra copy that MSVC Debug builds materialize without NRVO.
+  {
+    PictureRecorder otherRecorder;
+    auto* otherCanvas = otherRecorder.beginRecording();
+    SVGLengthContext otherLengthContext(Size::Make(200.f, 200.f));
+    auto copy = SVGRenderContext::CopyForPaint(source, otherCanvas, otherLengthContext);
+    EXPECT_FLOAT_EQ(copy.deferredPaintOpacity, expectedOpacity);
+    ASSERT_TRUE(copy._clipPath.has_value());
+    EXPECT_EQ(*copy._clipPath, expectedClip);
   }
 }
 


### PR DESCRIPTION
SVGRenderContext 的 5 个 copy constructor 通过 delegating 到 7-arg 主构造函数完成初始化，但主构造函数不接收 deferredPaintOpacity 和 _clipPath 这两个字段，导致它们在 copy 时被 in-class initializer 重置。Release 下由于 NRVO 生效，CopyForPaint 的 return-by-value 不实际调用 copy-ctor 而侥幸正确；Debug 下 NRVO 不生效，触发 copy-ctor 后这两个字段被丢弃，导致 SVG 嵌套元素（<g opacity="…"> 包裹的叶子节点、clip-path 引用等）在 Debug 构建下渲染错误。修复：给每个 copy-ctor 在委托构造完成后显式拷贝这两个字段。