### PR TITLE
Document the GLSL ES syntax contract for RuntimeEffect and GPU::createShaderModule.

### DIFF
--- a/include/tgfx/core/ImageFilter.h
+++ b/include/tgfx/core/ImageFilter.h
@@ -117,8 +117,9 @@ class ImageFilter {
   static std::shared_ptr<ImageFilter> ColorFilter(std::shared_ptr<ColorFilter> colorFilter);
 
   /**
-   * Creates a filter that applies the given RuntimeEffect object to the input image.
-   * You can use the shading language of the current GPU backend to create RuntimeEffect objects.
+   * Creates a filter that applies the given RuntimeEffect object to the input image. The shader
+   * code of the RuntimeEffect must be written in GLSL with OpenGL ES 3.0 syntax. See RuntimeEffect
+   * for details.
    */
   static std::shared_ptr<ImageFilter> Runtime(std::shared_ptr<RuntimeEffect> effect);
 

--- a/include/tgfx/gpu/GPU.h
+++ b/include/tgfx/gpu/GPU.h
@@ -141,8 +141,9 @@ class GPU {
   virtual std::shared_ptr<Sampler> createSampler(const SamplerDescriptor& descriptor) = 0;
 
   /**
-   * Creates a ShaderModule from the provided shader code. The shader code must be valid and
-   * compatible with the GPU backend. Returns nullptr if the shader module creation fails.
+   * Creates a ShaderModule from the provided shader code. The shader code must be written in GLSL
+   * with OpenGL ES 3.0 syntax. Use the "#version 300 es" directive, or "#version 150" on desktop
+   * OpenGL. Returns nullptr if the shader module creation fails.
    */
   virtual std::shared_ptr<ShaderModule> createShaderModule(
       const ShaderModuleDescriptor& descriptor) = 0;

--- a/include/tgfx/gpu/RuntimeEffect.h
+++ b/include/tgfx/gpu/RuntimeEffect.h
@@ -25,8 +25,9 @@
 namespace tgfx {
 
 /**
- * RuntimeEffect supports creating custom ImageFilter objects using the shading language of the
- * current GPU backend.
+ * RuntimeEffect supports creating custom ImageFilter objects with user-provided shader code.
+ * Shader code must be written in GLSL with OpenGL ES 3.0 syntax. Use the "#version 300 es"
+ * directive, or "#version 150" on desktop OpenGL.
  */
 class RuntimeEffect {
  public:

--- a/include/tgfx/gpu/ShaderModule.h
+++ b/include/tgfx/gpu/ShaderModule.h
@@ -28,13 +28,13 @@ namespace tgfx {
 class ShaderModuleDescriptor {
  public:
   /**
-   * The shader code to be compiled into a ShaderModule.
+   * The shader code to be compiled into a ShaderModule. Must be written in GLSL with OpenGL
+   * ES 3.0 syntax. See GPU::createShaderModule() for details.
    */
   std::string code;
 
   /**
-   * Specifies the shader stage (e.g., vertex, fragment, compute). Only relevant for the OpenGL
-   * backend; ignored by other backends.
+   * Specifies the shader stage (e.g., vertex, fragment, compute).
    */
   ShaderStage stage = ShaderStage::Vertex;
 };


### PR DESCRIPTION
The previous comments said shader code should use "the shading language of the current GPU backend", which is outdated and misleading: all backends actually accept GLSL in OpenGL ES 3.0 syntax (non-GL backends translate it internally). Writing backend-native languages (MSL/WGSL) or Vulkan-only built-ins (e.g. gl_VertexIndex) fails on the OpenGL backend, as seen in #1529.

Changes:
- RuntimeEffect: state that shader code must be GLSL with OpenGL ES 3.0 syntax, using "#version 300 es" (or "#version 150" on desktop OpenGL).
- GPU::createShaderModule / ShaderModuleDescriptor::code: same contract, pointing to RuntimeEffect for details.
- ShaderModuleDescriptor::stage: remove the incorrect claim that it is only used by the OpenGL backend (all backends rely on it).