### PR TITLE
fix: sync ClipStack state when transform degenerates clip elements

### DIFF
--- a/src/core/ClipStack.cpp
+++ b/src/core/ClipStack.cpp
@@ -687,15 +687,24 @@ void ClipStack::transform(const Matrix& matrix) {
   }
 
   willModify();
+  bool emptyDetected = false;
   for (auto& element : _data->elements) {
     element.transform(matrix);
+    // A valid element degenerating to empty (e.g. a sub-pixel non-AA rect covering no pixel
+    // center) makes the intersection empty, so the whole clip collapses to Empty. Every element
+    // must still be transformed so restore() can invert the accumulated transform consistently.
+    if (element.isValid() && element.shape().isEmpty()) {
+      emptyDetected = true;
+    }
   }
 
   // Update the current record after transforming all elements.
   auto& cur = current();
   cur.transform = newTransform;
   cur.bounds = matrix.mapRect(cur.bounds);
-  if (cur.state == ClipState::Rect && !matrix.rectStaysRect()) {
+  if (emptyDetected) {
+    cur.state = ClipState::Empty;
+  } else if (cur.state == ClipState::Rect && !matrix.rectStaysRect()) {
     cur.state = ClipState::Complex;
   }
   cur.uniqueID = UniqueID::Next();

--- a/test/src/ClipTest.cpp
+++ b/test/src/ClipTest.cpp
@@ -51,6 +51,14 @@ static Path MakePath(std::initializer_list<Point> points, bool close = true) {
   return path;
 }
 
+// Builds a clip whose single non-AA rect element degenerates to empty under transform().
+static ClipStack MakeDegenerateClip() {
+  ClipStack clip;
+  clip.clipRect(Rect::MakeXYWH(10, 20, 40, 30), Matrix::I(), false);
+  clip.transform(Matrix::MakeScale(1.0f, 0.001f));
+  return clip;
+}
+
 TGFX_TEST_PRIVATE(ClipTest, RectEffect) {
   TGFX_PRIVATE_ACCESS(
       BlockAllocator allocator;
@@ -750,9 +758,7 @@ TGFX_TEST(ClipTest, EmptyElementClippedOut) {
   // (ClipElement::simplify marks it Empty because it covers no pixel center). ClipStack keeps the
   // record state in sync, so applyClip short-circuits on ClipState::Empty and reports ClippedOut
   // instead of feeding the empty element to the mask rasterizer.
-  ClipStack clip;
-  clip.clipRect(Rect::MakeXYWH(10, 20, 40, 30), Matrix::I(), false);
-  clip.transform(Matrix::MakeScale(1.0f, 0.001f));
+  auto clip = MakeDegenerateClip();
   TGFX_PRIVATE_ACCESS({
     ASSERT_EQ(clip.elements().size(), 1u);
     EXPECT_EQ(clip.state(), ClipState::Empty);
@@ -770,13 +776,9 @@ TGFX_TEST(ClipTest, SubPixelClipMaskRasterizeNoNullOp) {
   ASSERT_NE(renderTarget, nullptr);
   OpsCompositor compositor(renderTarget, 0);
 
-  // End-to-end rendering path: without the fix, the empty clip element was skipped by the
-  // scissor-only path (innerBounds == outerBounds) and the draw proceeded unclipped (Clipped,
-  // overdrawing content outside the clip). The fix reports ClippedOut instead, matching the
-  // semantics of an empty clip region. Flushing must not crash.
-  ClipStack clip;
-  clip.clipRect(Rect::MakeXYWH(10, 20, 40, 30), Matrix::I(), false);
-  clip.transform(Matrix::MakeScale(1.0f, 0.001f));
+  // End-to-end rendering path: an empty clip region reports ClippedOut, so a degenerate clip
+  // never reaches the mask rasterizer and no null draw op is queued. Flushing must not crash.
+  auto clip = MakeDegenerateClip();
   TGFX_PRIVATE_ACCESS({
     auto applied = compositor.applyClip(clip);
     EXPECT_EQ(applied.status, AppliedClipStatus::ClippedOut);

--- a/test/src/ClipTest.cpp
+++ b/test/src/ClipTest.cpp
@@ -747,15 +747,15 @@ TGFX_TEST(ClipTest, EmptyElementClippedOut) {
   OpsCompositor compositor(renderTarget, 0);
 
   // A non-AA rect compressed below one pixel by transform() degenerates into an empty element
-  // (ClipElement::simplify marks it Empty because it covers no pixel center), while
-  // ClipRecord.state stays Rect. applyClip must still recognize the empty element and report
-  // ClippedOut instead of feeding it to the mask rasterizer.
+  // (ClipElement::simplify marks it Empty because it covers no pixel center). ClipStack keeps the
+  // record state in sync, so applyClip short-circuits on ClipState::Empty and reports ClippedOut
+  // instead of feeding the empty element to the mask rasterizer.
   ClipStack clip;
   clip.clipRect(Rect::MakeXYWH(10, 20, 40, 30), Matrix::I(), false);
   clip.transform(Matrix::MakeScale(1.0f, 0.001f));
   TGFX_PRIVATE_ACCESS({
     ASSERT_EQ(clip.elements().size(), 1u);
-    EXPECT_EQ(clip.state(), ClipState::Rect);
+    EXPECT_EQ(clip.state(), ClipState::Empty);
     EXPECT_TRUE(clip.elements()[0].shape().isEmpty());
     auto applied = compositor.applyClip(clip);
     EXPECT_EQ(applied.status, AppliedClipStatus::ClippedOut);

--- a/test/src/ClipTest.cpp
+++ b/test/src/ClipTest.cpp
@@ -31,6 +31,7 @@
 #include "tgfx/core/Point.h"
 #include "tgfx/core/RRect.h"
 #include "tgfx/core/Rect.h"
+#include "tgfx/core/Shape.h"
 #include "tgfx/core/Surface.h"
 #include "utils/TestUtils.h"
 
@@ -784,6 +785,96 @@ TGFX_TEST(ClipTest, SubPixelClipMaskRasterizeNoNullOp) {
     EXPECT_EQ(applied.status, AppliedClipStatus::ClippedOut);
   });
   context->flushAndSubmit();
+}
+
+// An inverse-empty path is an identity clip element: it keeps the whole plane. It must never
+// collapse the clip. As the added element it is dropped as redundant in addElement, and as the
+// sole element it rasterizes to a full-coverage mask, so applyClip must report Clipped in both
+// cases and never ClippedOut.
+TGFX_TEST(ClipTest, InverseEmptyClipIdentity) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_NE(context, nullptr);
+
+  // Case 1: clipRect followed by clipPath(inverse-empty path). The identity element is dropped
+  // in addElement (ResolveClipGeometry returns AOnly because its removed region is empty), so the
+  // rect stays the only element and the clip keeps working.
+  {
+    ClipStack clip;
+    clip.clipRect(Rect::MakeXYWH(10, 20, 40, 30), Matrix::I(), false);
+    Path inverseEmpty = {};
+    inverseEmpty.toggleInverseFillType();
+    clip.clipPath(inverseEmpty, Matrix::I(), false);
+    TGFX_PRIVATE_ACCESS({
+      ASSERT_EQ(clip.elements().size(), 1u);
+      EXPECT_TRUE(clip.elements()[0].isValid());
+      EXPECT_EQ(clip.elements()[0].shape().type(), GeometryShape::Type::Rect);
+      EXPECT_NE(clip.state(), ClipState::Empty);
+      auto renderTarget = RenderTargetProxy::Make(context, 100, 100, false);
+      ASSERT_NE(renderTarget, nullptr);
+      OpsCompositor compositor(renderTarget, 0);
+      auto applied = compositor.applyClip(clip);
+      EXPECT_EQ(applied.status, AppliedClipStatus::Clipped);
+    });
+  }
+
+  // Case 2: Inverse-empty path as the sole element. It becomes a full-coverage mask (i == 0 in
+  // makeClipTexture preserves the inverse fill type), so the clip must remain Clipped.
+  {
+    ClipStack clip;
+    Path inverseEmpty = {};
+    inverseEmpty.toggleInverseFillType();
+    clip.clipPath(inverseEmpty, Matrix::I(), false);
+    TGFX_PRIVATE_ACCESS({
+      ASSERT_EQ(clip.elements().size(), 1u);
+      EXPECT_TRUE(clip.elements()[0].isValid());
+      EXPECT_EQ(clip.elements()[0].shape().type(), GeometryShape::Type::Path);
+      EXPECT_TRUE(clip.elements()[0].shape().path().isInverseFillType());
+      auto renderTarget = RenderTargetProxy::Make(context, 100, 100, false);
+      ASSERT_NE(renderTarget, nullptr);
+      OpsCompositor compositor(renderTarget, 0);
+      auto applied = compositor.applyClip(clip);
+      EXPECT_EQ(applied.status, AppliedClipStatus::Clipped);
+    });
+  }
+
+  // Case 3: The inverse-empty sole element survives a transform: its isEmpty stays false, so the
+  // emptyDetected check in transform() must not collapse the clip, and applyClip keeps working.
+  {
+    ClipStack clip;
+    Path inverseEmpty = {};
+    inverseEmpty.toggleInverseFillType();
+    clip.clipPath(inverseEmpty, Matrix::I(), false);
+    clip.transform(Matrix::MakeScale(2.0f, 2.0f));
+    TGFX_PRIVATE_ACCESS({
+      EXPECT_EQ(clip.elements().size(), 1u);
+      EXPECT_NE(clip.state(), ClipState::Empty);
+      auto renderTarget = RenderTargetProxy::Make(context, 100, 100, false);
+      ASSERT_NE(renderTarget, nullptr);
+      OpsCompositor compositor(renderTarget, 0);
+      auto applied = compositor.applyClip(clip);
+      EXPECT_EQ(applied.status, AppliedClipStatus::Clipped);
+    });
+  }
+}
+
+// Verifies the technical facts behind the inverse-empty review comment: Shape::MakeFrom keeps an
+// inverse-empty path (full-coverage identity shape) but rejects the same path after the inverse
+// toggle turns it into a plain empty path. This is exactly the operation makeClipTexture performs
+// on non-first mask elements.
+TGFX_TEST(ClipTest, ShapeMakeFromInverseEmpty) {
+  Path inverseEmpty = {};
+  inverseEmpty.toggleInverseFillType();
+  EXPECT_TRUE(inverseEmpty.isEmpty());
+  EXPECT_TRUE(inverseEmpty.isInverseFillType());
+  auto identityShape = Shape::MakeFrom(inverseEmpty);
+  EXPECT_NE(identityShape, nullptr);
+  EXPECT_TRUE(identityShape->isInverseFillType());
+
+  inverseEmpty.toggleInverseFillType();
+  EXPECT_TRUE(inverseEmpty.isEmpty());
+  EXPECT_FALSE(inverseEmpty.isInverseFillType());
+  EXPECT_EQ(Shape::MakeFrom(inverseEmpty), nullptr);
 }
 
 TGFX_TEST(ClipTest, Overview) {


### PR DESCRIPTION
## 描述

### 背景

`#1532` 通过三层消费端防护（`applyClip` 空元素检测 / `makeClipTexture` null 检查 / `getClipMaskFP` 失败降级）修复了 Web 端空 clip 元素导致的 null draw op 崩溃，但其根因分析中明确指出了一个遗留问题：

> ClipStack 状态摘要与元素明细脱节（元素 transform 后退化 `setEmpty` 后 `cur.state` 未同步）属更深层的一致性问题，本 PR 未改动 ClipStack 状态机（避免核心路径回归风险），建议作为独立优化任务跟进。

本 PR 正是跟进该独立任务：在 ClipStack 状态机层面修复脱节，让 `state` 摘要与元素明细自洽。

### 根因

clip 元素会变空的三条路径中，两条已同步 `ClipRecord.state`：

- **添加时即空**：`addElement` 中 `if (toAdd.shape().isEmpty()) { cur.state = ClipState::Empty; ... }`
- **合并后变空**：`appendElement` / `UpdateElements` / `tryCombine` 处理后置 `Empty`

但第三条路径——**元素经 `transform` 后退化变空**——未同步：

```cpp
void ClipStack::transform(const Matrix& matrix) {
  ...
  for (auto& element : _data->elements) {
    element.transform(matrix);   // simplify() 内部可能 setEmpty()（亚像素退化）
  }
  auto& cur = current();
  cur.transform = newTransform;
  cur.bounds = matrix.mapRect(cur.bounds);
  if (cur.state == ClipState::Rect && !matrix.rectStaysRect()) {
    cur.state = ClipState::Complex;
  }
  // ★ 未检查元素是否变空，cur.state 不会同步为 Empty
}
```

`ClipElement::simplify` 在 `transform` 后重新计算包围盒，若退化到覆盖不到任何像素中心（如高度 < 1px 的扁平矩形）则把 shape 置为 Empty。元素在加入 ClipStack 时非空，因此 `cur.state` 保持非 Empty——状态摘要与元素明细脱节。`applyClip` 的快速判断 `clipStack.state() == ClipState::Empty` 失效，只能依赖 `#1532` 的消费端防护兜底。

### 修改方案及为什么有效

**核心修改**：`ClipStack::transform` 在变换元素时检测"有效元素退化为空"，同步 `cur.state = ClipState::Empty`：

```cpp
void ClipStack::transform(const Matrix& matrix) {
  if (matrix.isIdentity()) {
    return;
  }

  auto newTransform = current().transform;
  newTransform.postConcat(matrix);
  Matrix inverse = {};
  if (!newTransform.invert(&inverse)) {
    DEBUG_ASSERT(false);
    return;
  }

  willModify();
  bool emptyDetected = false;
  for (auto& element : _data->elements) {
    element.transform(matrix);
    // A valid element degenerating to empty (e.g. a sub-pixel non-AA rect covering no pixel
    // center) makes the intersection empty, so the whole clip collapses to Empty. Every element
    // must still be transformed so restore() can invert the accumulated transform consistently.
    if (element.isValid() && element.shape().isEmpty()) {
      emptyDetected = true;
    }
  }

  auto& cur = current();
  cur.transform = newTransform;
  cur.bounds = matrix.mapRect(cur.bounds);
  if (emptyDetected) {
    cur.state = ClipState::Empty;
  } else if (cur.state == ClipState::Rect && !matrix.rectStaysRect()) {
    cur.state = ClipState::Complex;
  }
  cur.uniqueID = UniqueID::Next();
}
```

**为什么有效**：

1. **状态机自洽**：任何让元素变空的路径（添加、合并、变换）都会同步 `state = Empty`，摘要与明细不再脱节。
2. **更早返回**：
   - 追加新元素：`addElement` 首行 `cur.state == Empty → return false`，不做几何处理（O(n) 遍历 → O(1)）；
   - 应用：`applyClip` Stage 1 直接返回 `ClippedOut`，不再依赖 Stage 3 遍历元素检测空元素。
3. **零额外复杂度**：`transform` 本就是 O(n) 遍历，`isEmpty()` 布尔检查是 O(1)/元素，总复杂度不变；正常路径（不退化）只多一次分支判断。
4. **逆填充 path 不受影响**：`GeometryShape::simplify` 显式跳过 inverse-fill path（保持 Path 类型），`shape().isEmpty()` 是类型判断（`Type::Empty`），亚像素退化分支（`_outerBounds.isEmpty()`）对 inverse path 恒不触发（其 outerBounds 为全平面）——空几何 inverse path 语义为"什么都不移除"，不会被误判。
5. **不 break 的原因**：所有元素必须完成 transform，因为 `restore()` 依赖对保留元素做逆变换还原；提前 break 会使父记录元素被逆变换破坏。

**与 `#1532` 三层防护的关系（保留）**：本 PR 消除的是"主流 transform 退化路径"对消费端防护的依赖，但三层防护仍保留，各自防不同的洞：

| 防护 | 仍需保留的原因 |
|---|---|
| `applyClip` Stage 3 空元素检查 | `restore()` 后 `state` 弹回父记录非 Empty 值，而 Empty 元素逆变换不可逆（`simplify` 对 Empty 直接返回）仍为空——restore 边界脱节仍存在 |
| `makeClipTexture` null 检查 | 防 mask 光栅化内部退化（如反填充 path 经 `toggleInverseFillType` 后 `Shape::MakeFrom` 返回 null），与状态机无关 |
| `getClipMaskFP` 失败降级 | mask 路径统一失败出口（OOM 等），与状态机无关 |

### 回归测试

`test/src/ClipTest.cpp`：

- `EmptyElementClippedOut`：断言从 `ClipState::Rect`（旧行为，暴露摘要脱节）更新为 `ClipState::Empty`——该断言是唯一能区分修复前后行为的检查，锁定状态同步；
- 抽取 `MakeDegenerateClip()` helper，消除 `EmptyElementClippedOut` 与 `SubPixelClipMaskRasterizeNoNullOp` 的重复构造；
- 更新 `SubPixelClipMaskRasterizeNoNullOp` 注释为当前行为（消除"without the fix"变更历史式描述）。

### 验证

| 版本 | 结果 |
|---|---|
| `ClipTest.*`（12 用例，含视觉基线 `ClipOverview`） | 全部通过 |
| 全量测试（31 套件 625 用例） | 全部通过（本地排除 `ReadPixelsTest.NativeCodec`，该用例为本地环境既有 SIGBUS，与本 PR 无关） |
| Web WASM 构建 + 打开设计稿 `676176906082787` | 页面正常加载，无崩溃 |

### 已知边界

- **restore 边界**：`restore()` 后 `state` 恢复父记录值，但退化元素 Empty 不可逆（`ClipElement::transform` 对 Empty 类型直接返回）——此边界仍由 `#1532` 的 `applyClip` Stage 3 防护兜底。彻底解决需让退化元素可还原（改动 `ClipElement` 退化语义），改动面更大，建议另立任务。
- 空几何 inverse path（verbs 为空 + inverse fill）不会被判空（正确语义：什么都不移除，等价于无 clip）。
