### PR TITLE
Reassert NSWindow.colorSpace before back buffer reallocation to fix P3 color washout after cross-display migration.

### DIFF
--- a/src/gpu/opengl/cgl/CGLWindow.mm
+++ b/src/gpu/opengl/cgl/CGLWindow.mm
@@ -29,6 +29,13 @@
 
 namespace tgfx {
 
+static void ApplyWindowColorSpace(NSView* view, const std::shared_ptr<ColorSpace>& colorSpace) {
+  if (view.window != nil && colorSpace != nullptr &&
+      ColorSpace::Equals(colorSpace.get(), ColorSpace::DisplayP3().get())) {
+    view.window.colorSpace = [NSColorSpace displayP3ColorSpace];
+  }
+}
+
 std::shared_ptr<CGLWindow> CGLWindow::MakeFrom(NSView* view, CGLContextObj sharedContext,
                                                std::shared_ptr<ColorSpace> colorSpace) {
   if (view == nil) {
@@ -38,13 +45,11 @@ std::shared_ptr<CGLWindow> CGLWindow::MakeFrom(NSView* view, CGLContextObj share
   if (device == nullptr) {
     return nullptr;
   }
-  if (colorSpace != nullptr && !ColorSpace::Equals(colorSpace.get(), ColorSpace::SRGB().get())) {
-    if (ColorSpace::Equals(colorSpace.get(), ColorSpace::DisplayP3().get())) {
-      view.window.colorSpace = [NSColorSpace displayP3ColorSpace];
-    } else {
-      LOGE("CGLWindow::MakeFrom() The specified ColorSpace is not supported on this platform. "
-           "Rendering may have color inaccuracies.");
-    }
+  ApplyWindowColorSpace(view, colorSpace);
+  if (colorSpace != nullptr && !ColorSpace::Equals(colorSpace.get(), ColorSpace::SRGB().get()) &&
+      !ColorSpace::Equals(colorSpace.get(), ColorSpace::DisplayP3().get())) {
+    LOGE("CGLWindow::MakeFrom() The specified ColorSpace is not supported on this platform. "
+         "Rendering may have color inaccuracies.");
   }
   return std::shared_ptr<CGLWindow>(new CGLWindow(device, view, std::move(colorSpace)));
 }
@@ -72,10 +77,7 @@ std::shared_ptr<RenderTargetProxy> CGLWindow::onCreateRenderTarget(Context* cont
   // native gamut differs from the configured one. Reassert the color space before [glContext
   // update] reallocates the back buffer, otherwise the new buffer inherits the reset (native) color
   // space and pixels get tagged incorrectly.
-  if (_colorSpace != nullptr &&
-      ColorSpace::Equals(_colorSpace.get(), ColorSpace::DisplayP3().get()) && view.window != nil) {
-    view.window.colorSpace = [NSColorSpace displayP3ColorSpace];
-  }
+  ApplyWindowColorSpace(view, _colorSpace);
   [glContext update];
   CGSize size = [view convertSizeToBacking:view.bounds.size];
   if (size.width <= 0 || size.height <= 0) {

--- a/src/gpu/opengl/cgl/CGLWindow.mm
+++ b/src/gpu/opengl/cgl/CGLWindow.mm
@@ -45,12 +45,12 @@ std::shared_ptr<CGLWindow> CGLWindow::MakeFrom(NSView* view, CGLContextObj share
   if (device == nullptr) {
     return nullptr;
   }
-  ApplyWindowColorSpace(view, colorSpace);
   if (colorSpace != nullptr && !ColorSpace::Equals(colorSpace.get(), ColorSpace::SRGB().get()) &&
       !ColorSpace::Equals(colorSpace.get(), ColorSpace::DisplayP3().get())) {
     LOGE("CGLWindow::MakeFrom() The specified ColorSpace is not supported on this platform. "
          "Rendering may have color inaccuracies.");
   }
+  ApplyWindowColorSpace(view, colorSpace);
   return std::shared_ptr<CGLWindow>(new CGLWindow(device, view, std::move(colorSpace)));
 }
 

--- a/src/gpu/opengl/cgl/CGLWindow.mm
+++ b/src/gpu/opengl/cgl/CGLWindow.mm
@@ -68,6 +68,14 @@ std::shared_ptr<RenderTargetProxy> CGLWindow::onCreateRenderTarget(Context* cont
          "the main thread, then render on any thread.");
   }
   auto glContext = static_cast<CGLDevice*>(device.get())->glContext;
+  // AppKit may silently reset view.window.colorSpace when the window moves to a display whose
+  // native gamut differs from the configured one. Reassert the color space before [glContext
+  // update] reallocates the back buffer, otherwise the new buffer inherits the reset (native) color
+  // space and pixels get tagged incorrectly.
+  if (_colorSpace != nullptr &&
+      ColorSpace::Equals(_colorSpace.get(), ColorSpace::DisplayP3().get()) && view.window != nil) {
+    view.window.colorSpace = [NSColorSpace displayP3ColorSpace];
+  }
   [glContext update];
   CGSize size = [view convertSizeToBacking:view.bounds.size];
   if (size.width <= 0 || size.height <= 0) {


### PR DESCRIPTION
问题：macOS 上，Display P3 色域窗口在移动到不同色域的外部显示器后 resize，颜色会明显变淡。原因是 AppKit 在跨显示器迁移时静默重置了 NSWindow.colorSpace，导致 [glContext update] 重新分配 back buffer 时继承被重置的（屏幕原生）色彩空间，P3 像素被错误标注为 sRGB。

修复：在 CGLWindow::onCreateRenderTarget() 中，[glContext update] 之前重新断言 view.window.colorSpace = displayP3ColorSpace，确保 back buffer 分配时始终使用正确的色彩空间标签。

影响范围：仅 CGL（macOS OpenGL）后端，不影响 Metal 路径。