### PR TITLE
fix(Picture): compensate makeSubset anchor shift when unwrapping DrawImageRect

### DIFF
--- a/src/core/Picture.cpp
+++ b/src/core/Picture.cpp
@@ -143,6 +143,11 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
 
   std::shared_ptr<Image> image = nullptr;
   SamplingOptions sampling = {};
+  // DrawImageRect's makeSubset(rect) moves the image anchor by rect.left/top; offsetX/offsetY
+  // below must absorb the same shift so the subset is measured from the real image anchor
+  // (recordMatrix position + rect offset) instead of the recordMatrix position only.
+  float subsetOffsetX = 0.0f;
+  float subsetOffsetY = 0.0f;
 
   // Check for direct DrawImage or DrawImageRect
   if (record->type() == PictureRecordType::DrawImage ||
@@ -156,8 +161,11 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
       }
     }
     if (record->type() == PictureRecordType::DrawImageRect) {
-      image = image->makeSubset(static_cast<const DrawImageRect*>(record)->rect);
+      auto rect = static_cast<const DrawImageRect*>(record)->rect;
+      image = image->makeSubset(rect);
       DEBUG_ASSERT(image != nullptr);
+      subsetOffsetX = rect.left;
+      subsetOffsetY = rect.top;
     }
   }
   // Check for DrawRect with ImageShader (rect + ImageShader pattern)
@@ -209,8 +217,8 @@ std::shared_ptr<Image> Picture::asImage(Point* offset, const Matrix* matrix,
   } else if (!clipRect.isEmpty()) {
     subset = clipRect;
   }
-  auto offsetX = imageMatrix.getTranslateX();
-  auto offsetY = imageMatrix.getTranslateY();
+  auto offsetX = imageMatrix.getTranslateX() + subsetOffsetX;
+  auto offsetY = imageMatrix.getTranslateY() + subsetOffsetY;
   if (!subset.isEmpty()) {
     subset.offset(-offsetX, -offsetY);
     auto roundSubset = subset;

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -329,6 +329,7 @@
         "Matrix_3D_Offscreen_Blend": "7ce872bef",
         "Matrix_Behind_Viewer": "3d686214e",
         "MeshLayer": "c3630d40",
+        "NestedOffscreenTiledZoom": "473df80b7",
         "PartialDrawLayer": "e89967392",
         "PartialDrawLayer_shapeLayer": "e89967392",
         "PassThoughAndNormal": "43cd416",

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4737,8 +4737,8 @@ TGFX_TEST(LayerTest, ComputeVisibleFootprintsRejectsSingularHomography) {
 // The text is placed off-origin so the DrawImageRect subset offset is nonzero, which makes the
 // unwrap anchor correction observable.
 static void RenderNestedOffscreenTiledZoom(DisplayList* displayList,
-                                           const std::shared_ptr<Surface>& surface,
-                                           float zoomScale, const std::string& key) {
+                                           const std::shared_ptr<Surface>& surface, float zoomScale,
+                                           const std::string& key) {
   displayList->setZoomScale(zoomScale);
   for (int i = 0; i < 40; ++i) {
     displayList->render(surface.get());

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4730,9 +4730,22 @@ TGFX_TEST(LayerTest, ComputeVisibleFootprintsRejectsSingularHomography) {
                                                        &localFootprint, &destFootprint));
 }
 
-// Tiled mode + high zoom: three nested empty layers (passThroughBackground disabled) wrapping a
-// text layer. Each empty offscreen layer records a single DrawImage, so Image::MakeFrom unwraps the
-// picture repeatedly. Compare the rendered output to catch any offset drift from the unwrap path.
+// Tiled mode with per-frame tile budget. Zooming in invalidates every tile; with
+// TileUpdateMode::Fast and setMaxTilesRefinedPerFrame(1), each render() call refines at most one
+// missing tile, so every tile runs its own offscreen pass followed by a Picture::asImage unwrap.
+// An anchor drift in the unwrap path then surfaces as block-aligned misalignment between tiles.
+// The text is placed off-origin so the DrawImageRect subset offset is nonzero, which makes the
+// unwrap anchor correction observable.
+static void RenderNestedOffscreenTiledZoom(DisplayList* displayList,
+                                           const std::shared_ptr<Surface>& surface,
+                                           float zoomScale, const std::string& key) {
+  displayList->setZoomScale(zoomScale);
+  for (int i = 0; i < 40; ++i) {
+    displayList->render(surface.get());
+  }
+  EXPECT_TRUE(Baseline::Compare(surface, key));
+}
+
 TGFX_TEST(LayerTest, NestedOffscreenTiledZoom) {
   ContextScope scope;
   auto context = scope.getContext();
@@ -4741,9 +4754,12 @@ TGFX_TEST(LayerTest, NestedOffscreenTiledZoom) {
   ASSERT_NE(surface, nullptr);
   auto displayList = std::make_unique<DisplayList>();
   displayList->setRenderMode(RenderMode::Tiled);
-  displayList->setZoomScale(8.0f);
+  displayList->setTileUpdateMode(TileUpdateMode::Fast);
+  displayList->setMaxTilesRefinedPerFrame(1);
   auto root = Layer::Make();
   displayList->root()->addChild(root);
+  // Three nested layers each with passThroughBackground disabled, forcing every level through
+  // its own offscreen render pass before compositing.
   Layer* parent = root.get();
   for (int i = 0; i < 3; ++i) {
     auto frame = Layer::Make();
@@ -4757,10 +4773,15 @@ TGFX_TEST(LayerTest, NestedOffscreenTiledZoom) {
   auto typeface = MakeTypeface("resources/font/NotoSansSC-Regular.otf");
   Font font(typeface, 40);
   textLayer->setFont(font);
-  textLayer->setMatrix(Matrix::MakeTrans(300.0f, 200.0f));
+  textLayer->setMatrix(Matrix::MakeTrans(30.0f, 20.0f));
   parent->addChild(textLayer);
+  // Warm up at zoom=1.0 to build the initial tile cache and clear the startup dirty regions.
   displayList->render(surface.get());
-  EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/NestedOffscreenTiledZoom"));
+  // Zoom in: the frame right after the zoom change has a zero tile budget, so every tile falls
+  // back to the zoom=1.0 cache. Each following frame refines at most one missing tile. Loop until
+  // all tiles in the viewport are rasterized at the target zoom.
+  RenderNestedOffscreenTiledZoom(displayList.get(), surface, 12.29f,
+                                 "LayerTest/NestedOffscreenTiledZoom");
 }
 
 }  // namespace tgfx

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4730,4 +4730,37 @@ TGFX_TEST(LayerTest, ComputeVisibleFootprintsRejectsSingularHomography) {
                                                        &localFootprint, &destFootprint));
 }
 
+// Tiled mode + high zoom: three nested empty layers (passThroughBackground disabled) wrapping a
+// text layer. Each empty offscreen layer records a single DrawImage, so Image::MakeFrom unwraps the
+// picture repeatedly. Compare the rendered output to catch any offset drift from the unwrap path.
+TGFX_TEST(LayerTest, NestedOffscreenTiledZoom) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_NE(context, nullptr);
+  auto surface = Surface::Make(context, 1024, 1024);
+  ASSERT_NE(surface, nullptr);
+  auto displayList = std::make_unique<DisplayList>();
+  displayList->setRenderMode(RenderMode::Tiled);
+  displayList->setZoomScale(8.0f);
+  auto root = Layer::Make();
+  displayList->root()->addChild(root);
+  Layer* parent = root.get();
+  for (int i = 0; i < 3; ++i) {
+    auto frame = Layer::Make();
+    frame->setPassThroughBackground(false);
+    parent->addChild(frame);
+    parent = frame.get();
+  }
+  auto textLayer = TextLayer::Make();
+  textLayer->setText("06");
+  textLayer->setTextColor(Color::Black());
+  auto typeface = MakeTypeface("resources/font/NotoSansSC-Regular.otf");
+  Font font(typeface, 40);
+  textLayer->setFont(font);
+  textLayer->setMatrix(Matrix::MakeTrans(300.0f, 200.0f));
+  parent->addChild(textLayer);
+  displayList->render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "LayerTest/NestedOffscreenTiledZoom"));
+}
+
 }  // namespace tgfx


### PR DESCRIPTION
## 问题

Tiled 渲染 + 非整数 zoom + 三层嵌套 `passThroughBackground=false` 的 Layer 时，最内层内容出现规则方块错位（块边界 ≈ tile 边界）。每个 tile 错位量不同，两层嵌套正常。

## 根因

`Picture::asImage` 解包 `DrawImageRect` 时，`makeSubset(rect)` 把图片坐标原点位移了 `rect.left/top`，但后续 `offsetX/offsetY` 基准（`imageMatrix` 平移量）没有同步吸收该偏移，导致 `subset` 在原图空间算出的坐标被错误应用到子图空间，内容多裁 `rect.left`。

具体链条：

1. **Canvas 内联 SubsetImage**（`Canvas::drawImage`）：带内在偏移的 `SubsetImage` 被内联为 `drawImageRect(source, src=子集边界, dst=整幅)`。
2. **PictureContext 同尺寸折叠**：`src` 与 `dst` 同尺寸不同位置 → `MakeRectToRectMatrix` 平移折叠进矩阵 → record 变为 `DrawImageRect(source, rect=子集边界, T(recordTx−偏移))`。
3. **asImage 解包**（修复点）：`makeSubset(rect)` 恢复内在偏移使图片锚点移动，但 `offsetX` 仍取折叠后的 `recordMatrix.tx`（不含 `rect.left`），`subset` 基准与图片真实锚点脱钩。

## 为什么两层不触发、三层触发

关键差异是被"再次录制"时的图片类型不同：

- **两层嵌套**：中间层被录制时仍是惰性 `PictureImage`（无内在偏移），`Canvas::drawImage` 不内联，直接录 `DrawImage` → `recordTx` = 图片锚点，无需 `makeSubset`，坐标系不位移。
- **三层嵌套**：第二层 unwrap 产生了 `SubsetImage`（带内在偏移），被第三层录制时触发 Canvas 内联 + PictureContext 折叠 → 生成 `DrawImageRect` → `asImage` 解包时 `makeSubset(rect)` 改变坐标系，但 `offsetX` 未补偿 → 错位。

核心是一个布尔条件：被再次录制的图片是否带内在偏移。两层时内外两层图片都不带，三层时中间产物带了。

## 修复

在 `DrawImageRect` 分支，`makeSubset(rect)` 后将 `rect.left/top` 补偿进 `offsetX/offsetY`，使 `subset` 基准 = `recordMatrix.tx + rect.left` = 图片真实锚点。

**改动**：`src/core/Picture.cpp`（+11 −3），新增回归测试 `NestedOffscreenTiledZoom`（`test/src/LayerTest.cpp`，+33）。

## 验证

- Web 端三层嵌套 + 非整数 zoom（z=8.3）场景，错位消失
- 新增 `LayerTest.NestedOffscreenTiledZoom` 回归用例