### PR TITLE
Fix WebGPU readback map state handling and texture binding collisions.

### DIFF
--- a/src/core/Surface.cpp
+++ b/src/core/Surface.cpp
@@ -253,6 +253,11 @@ bool Surface::readPixels(const ImageInfo& dstInfo, void* dstPixels, int srcX, in
   auto context = renderTarget->getContext();
   auto srcPixels = readback->lockPixels(context);
   if (srcPixels == nullptr) {
+    // Unlike the asynchronous path, where an unfinished mapping is an expected intermediate state,
+    // reaching here means the synchronous read failed. Backends whose buffer mapping is only
+    // asynchronous (WebGPU without Asyncify) can never satisfy this call because the mapping
+    // completes on a later turn of the event loop; use asyncReadPixels() and poll isReady() there.
+    LOGE("Surface::readPixels() Failed to read the pixels from the surface!");
     return false;
   }
   auto flipY = renderTarget->origin() == ImageOrigin::BottomLeft;

--- a/src/core/Surface.cpp
+++ b/src/core/Surface.cpp
@@ -253,10 +253,8 @@ bool Surface::readPixels(const ImageInfo& dstInfo, void* dstPixels, int srcX, in
   auto context = renderTarget->getContext();
   auto srcPixels = readback->lockPixels(context);
   if (srcPixels == nullptr) {
-    // Unlike the asynchronous path, where an unfinished mapping is an expected intermediate state,
-    // reaching here means the synchronous read failed. Backends whose buffer mapping is only
-    // asynchronous (WebGPU without Asyncify) can never satisfy this call because the mapping
-    // completes on a later turn of the event loop; use asyncReadPixels() and poll isReady() there.
+    // Backends whose buffer mapping is only asynchronous (WebGPU without Asyncify) can never
+    // satisfy a synchronous read; use asyncReadPixels() with isReady() polling there.
     LOGE("Surface::readPixels() Failed to read the pixels from the surface!");
     return false;
   }

--- a/src/core/SurfaceReadback.cpp
+++ b/src/core/SurfaceReadback.cpp
@@ -80,14 +80,13 @@ const void* SurfaceReadback::lockPixels(Context* context, bool flipY) {
     context->gpu()->queue()->waitUntilCompleted();
   }
   auto gpuBuffer = readbackBuffer->gpuBuffer();
-  // For async-only backends like WebGPU, start the mapping if needed. The call is idempotent. With
-  // Asyncify it suspends the WASM stack until the mapping completes, so isReady() is true right
-  // after it returns.
+  // For async-only backends like WebGPU, start the mapping if needed. With Asyncify it suspends the
+  // WASM stack until the mapping completes, so isReady() is true right after it returns.
   if (!gpuBuffer->isReady()) {
     gpuBuffer->requestMapAsync();
     if (!gpuBuffer->isReady()) {
-      // Without Asyncify the mapping completes on a later turn of the event loop, so the caller is
-      // expected to poll isReady() and call lockPixels() again.
+      // Otherwise the mapping completes on a later turn of the event loop; the caller polls
+      // isReady() and calls lockPixels() again.
       return nullptr;
     }
   }

--- a/src/core/SurfaceReadback.cpp
+++ b/src/core/SurfaceReadback.cpp
@@ -80,17 +80,14 @@ const void* SurfaceReadback::lockPixels(Context* context, bool flipY) {
     context->gpu()->queue()->waitUntilCompleted();
   }
   auto gpuBuffer = readbackBuffer->gpuBuffer();
-  // For async-only backends like WebGPU, trigger async mapping if not already started. The call is
-  // idempotent, so it is safe even when a request is already in flight. With Asyncify enabled,
-  // requestMapAsync() suspends the WASM stack while buffer.mapAsync() awaits, allowing the JS event
-  // loop to process the async operation and resume once complete, so isReady() is true right after.
+  // For async-only backends like WebGPU, start the mapping if needed. The call is idempotent. With
+  // Asyncify it suspends the WASM stack until the mapping completes, so isReady() is true right
+  // after it returns.
   if (!gpuBuffer->isReady()) {
     gpuBuffer->requestMapAsync();
     if (!gpuBuffer->isReady()) {
-      // Without Asyncify the mapping completes on a later turn of the event loop, so returning
-      // nullptr here is the expected outcome of the first call: the caller polls isReady() and
-      // calls lockPixels() again once the data is available. Deliberately not logged, otherwise
-      // polling callers would flood the log every frame.
+      // Without Asyncify the mapping completes on a later turn of the event loop, so the caller is
+      // expected to poll isReady() and call lockPixels() again.
       return nullptr;
     }
   }

--- a/src/core/SurfaceReadback.cpp
+++ b/src/core/SurfaceReadback.cpp
@@ -80,13 +80,17 @@ const void* SurfaceReadback::lockPixels(Context* context, bool flipY) {
     context->gpu()->queue()->waitUntilCompleted();
   }
   auto gpuBuffer = readbackBuffer->gpuBuffer();
-  // For async-only backends like WebGPU, trigger async mapping if not already started.
-  // With Asyncify enabled, requestMapAsync() will suspend the WASM stack when buffer.mapAsync()
-  // awaits, allowing the JS event loop to process the async operation and resume when complete.
+  // For async-only backends like WebGPU, trigger async mapping if not already started. The call is
+  // idempotent, so it is safe even when a request is already in flight. With Asyncify enabled,
+  // requestMapAsync() suspends the WASM stack while buffer.mapAsync() awaits, allowing the JS event
+  // loop to process the async operation and resume once complete, so isReady() is true right after.
   if (!gpuBuffer->isReady()) {
     gpuBuffer->requestMapAsync();
     if (!gpuBuffer->isReady()) {
-      LOGE("SurfaceReadback::lockPixels() buffer mapping failed!");
+      // Without Asyncify the mapping completes on a later turn of the event loop, so returning
+      // nullptr here is the expected outcome of the first call: the caller polls isReady() and
+      // calls lockPixels() again once the data is available. Deliberately not logged, otherwise
+      // polling callers would flood the log every frame.
       return nullptr;
     }
   }

--- a/src/gpu/opengl/GLBuffer.cpp
+++ b/src/gpu/opengl/GLBuffer.cpp
@@ -80,11 +80,21 @@ void* GLBuffer::map(size_t offset, size_t size) {
   auto target = GetTarget(_usage);
   DEBUG_ASSERT(target != 0);
   gl->bindBuffer(target, _bufferID);
-  return gl->mapBufferRange(target, static_cast<GLintptr>(offset), static_cast<GLsizeiptr>(size),
-                            access);
+  auto pointer = gl->mapBufferRange(target, static_cast<GLintptr>(offset),
+                                    static_cast<GLsizeiptr>(size), access);
+  mapped = pointer != nullptr;
+  return pointer;
 }
 
 void GLBuffer::unmap() {
+  // Calling glUnmapBuffer() on a buffer that is not currently mapped raises GL_INVALID_OPERATION,
+  // which would pollute the GL error state for unrelated checks. Callers are allowed to invoke
+  // unmap() defensively (for example to reset a recycled readback buffer), so track the mapped
+  // state and make unmap() a no-op when nothing is mapped.
+  if (!mapped) {
+    return;
+  }
+  mapped = false;
   auto gl = _interface->functions();
   if (gl->mapBufferRange != nullptr) {
     auto target = GetTarget(_usage);

--- a/src/gpu/opengl/GLBuffer.cpp
+++ b/src/gpu/opengl/GLBuffer.cpp
@@ -87,10 +87,8 @@ void* GLBuffer::map(size_t offset, size_t size) {
 }
 
 void GLBuffer::unmap() {
-  // Calling glUnmapBuffer() on a buffer that is not currently mapped raises GL_INVALID_OPERATION,
-  // which would pollute the GL error state for unrelated checks. Callers are allowed to invoke
-  // unmap() defensively (for example to reset a recycled readback buffer), so track the mapped
-  // state and make unmap() a no-op when nothing is mapped.
+  // glUnmapBuffer() on an unmapped buffer raises GL_INVALID_OPERATION, and callers may invoke
+  // unmap() defensively to reset a recycled readback buffer.
   if (!mapped) {
     return;
   }

--- a/src/gpu/opengl/GLBuffer.h
+++ b/src/gpu/opengl/GLBuffer.h
@@ -58,6 +58,7 @@ class GLBuffer : public GPUBuffer, public GLResource {
   std::shared_ptr<GLInterface> _interface = nullptr;
   unsigned _bufferID = 0;
   void* readbackFence = nullptr;
+  bool mapped = false;
 
   void onRelease(GLGPU* gpu) override;
 };

--- a/src/gpu/tasks/ReadbackBufferCreateTask.cpp
+++ b/src/gpu/tasks/ReadbackBufferCreateTask.cpp
@@ -33,8 +33,7 @@ std::shared_ptr<Resource> ReadbackBufferCreateTask::onMakeResource(Context* cont
     return nullptr;
   }
   // A recycled buffer may still carry the map state of a readback that was abandoned before its
-  // pixels were consumed, which would leave it mapped while being used as a copy destination. This
-  // is the only place where a pooled readback buffer is handed out.
+  // pixels were consumed, which would leave it mapped while used as a copy destination.
   bufferResource->gpuBuffer()->unmap();
   return bufferResource;
 }

--- a/src/gpu/tasks/ReadbackBufferCreateTask.cpp
+++ b/src/gpu/tasks/ReadbackBufferCreateTask.cpp
@@ -32,6 +32,13 @@ std::shared_ptr<Resource> ReadbackBufferCreateTask::onMakeResource(Context* cont
     LOGE("ReadbackBufferCreateTask::onMakeResource() Failed to create buffer!");
     return nullptr;
   }
+  // A recycled readback buffer may still carry the map state of a previous readback that was
+  // abandoned before its pixels were consumed. Without this reset, backends with asynchronous
+  // mapping would encode a copy into a still-mapped buffer, and a late map callback could make the
+  // buffer report ready while holding the previous readback's pixels. This is the only place where
+  // a pooled readback buffer is handed out, so resetting here covers every reuse path. Backends
+  // without asynchronous mapping treat unmap() on an unmapped buffer as a no-op.
+  bufferResource->gpuBuffer()->unmap();
   return bufferResource;
 }
 

--- a/src/gpu/tasks/ReadbackBufferCreateTask.cpp
+++ b/src/gpu/tasks/ReadbackBufferCreateTask.cpp
@@ -32,12 +32,9 @@ std::shared_ptr<Resource> ReadbackBufferCreateTask::onMakeResource(Context* cont
     LOGE("ReadbackBufferCreateTask::onMakeResource() Failed to create buffer!");
     return nullptr;
   }
-  // A recycled readback buffer may still carry the map state of a previous readback that was
-  // abandoned before its pixels were consumed. Without this reset, backends with asynchronous
-  // mapping would encode a copy into a still-mapped buffer, and a late map callback could make the
-  // buffer report ready while holding the previous readback's pixels. This is the only place where
-  // a pooled readback buffer is handed out, so resetting here covers every reuse path. Backends
-  // without asynchronous mapping treat unmap() on an unmapped buffer as a no-op.
+  // A recycled buffer may still carry the map state of a readback that was abandoned before its
+  // pixels were consumed, which would leave it mapped while being used as a copy destination. This
+  // is the only place where a pooled readback buffer is handed out.
   bufferResource->gpuBuffer()->unmap();
   return bufferResource;
 }

--- a/src/gpu/webgpu/WebGPUBuffer.cpp
+++ b/src/gpu/webgpu/WebGPUBuffer.cpp
@@ -108,7 +108,6 @@ void* WebGPUBuffer::map(size_t offset, size_t mapSize) {
   }
   if (_usage & GPUBufferUsage::READBACK) {
     if (mapState != MapState::Mapped) {
-      // Expected while the asynchronous mapping is still in flight; callers poll isReady().
       return nullptr;
     }
     return const_cast<void*>(wgpuBufferGetConstMappedRange(buffer, offset, mapSize));
@@ -133,8 +132,8 @@ void WebGPUBuffer::requestMapAsync() {
   if (buffer == nullptr || (_usage & GPUBufferUsage::READBACK) == 0) {
     return;
   }
-  // Re-issuing a map on a pending buffer is a validation error, and clearing the state of a mapped
-  // buffer would drop the obligation to unmap it.
+  // Re-issuing a map while pending is a validation error, and resetting a mapped buffer would lose
+  // the unmap obligation.
   if (mapState != MapState::Unmapped) {
     return;
   }
@@ -160,7 +159,6 @@ void WebGPUBuffer::setMapReady(bool ready) {
   if ((_usage & GPUBufferUsage::READBACK) == 0) {
     return;
   }
-  // The external path maps the buffer itself, so drop any request issued from C++.
   detachMapRequest();
   mapState = ready ? MapState::Mapped : MapState::Unmapped;
 }
@@ -190,8 +188,7 @@ void WebGPUBuffer::unmap() {
 }
 
 void WebGPUBuffer::detachMapRequest() {
-  // The generation supersedes an in-flight Asyncify request; the owner pointer supersedes a
-  // callback-based one.
+  // The generation supersedes an Asyncify request in flight; the owner pointer a callback-based one.
   ++mapGeneration;
   if (mapRequest != nullptr) {
     mapRequest->owner = nullptr;

--- a/src/gpu/webgpu/WebGPUBuffer.cpp
+++ b/src/gpu/webgpu/WebGPUBuffer.cpp
@@ -87,9 +87,6 @@ void WebGPUBuffer::OnBufferMapped(WGPUBufferMapAsyncStatus status, void* userdat
   auto request = *reference;
   delete reference;
   if (request == nullptr || request->owner == nullptr) {
-    // The buffer was released, or the request was superseded by unmap() / setMapReady() before the
-    // callback arrived. Dropping the result here is what keeps this callback from writing into
-    // freed memory or into a newer request's state.
     return;
   }
   auto owner = request->owner;
@@ -97,8 +94,7 @@ void WebGPUBuffer::OnBufferMapped(WGPUBufferMapAsyncStatus status, void* userdat
     owner->mapState = MapState::Mapped;
     return;
   }
-  // Falling back to Unmapped is mandatory: leaving the state at Pending would make the guard in
-  // requestMapAsync() reject every retry, blocking the readback forever.
+  // Falling back to Unmapped is required, otherwise the guard in requestMapAsync() rejects retries.
   owner->mapState = MapState::Unmapped;
   owner->detachMapRequest();
 }
@@ -112,9 +108,7 @@ void* WebGPUBuffer::map(size_t offset, size_t mapSize) {
   }
   if (_usage & GPUBufferUsage::READBACK) {
     if (mapState != MapState::Mapped) {
-      // Not yet mapped. WebGPU has no synchronous readback, so this is the expected result while
-      // the asynchronous mapping is still in flight; callers poll isReady() until it completes.
-      // Deliberately not logged: polling callers would flood the log every frame.
+      // Expected while the asynchronous mapping is still in flight; callers poll isReady().
       return nullptr;
     }
     return const_cast<void*>(wgpuBufferGetConstMappedRange(buffer, offset, mapSize));
@@ -139,9 +133,8 @@ void WebGPUBuffer::requestMapAsync() {
   if (buffer == nullptr || (_usage & GPUBufferUsage::READBACK) == 0) {
     return;
   }
-  // Idempotent by design. Re-issuing a map on a buffer that already has one pending is a validation
-  // error, and clearing the state of an already mapped buffer would drop the obligation to unmap
-  // it, leaving the buffer permanently mapped and unusable.
+  // Re-issuing a map on a pending buffer is a validation error, and clearing the state of a mapped
+  // buffer would drop the obligation to unmap it.
   if (mapState != MapState::Unmapped) {
     return;
   }
@@ -150,9 +143,7 @@ void WebGPUBuffer::requestMapAsync() {
 #ifdef TGFX_USE_ASYNCIFY
   auto generation = mapGeneration;
   auto result = webgpu_buffer_map_sync(buffer, _size);
-  // The WASM stack was suspended during the await, so unmap(), setMapReady() or onRelease() may
-  // have superseded this request in the meantime. Writing the result now would resurrect a state
-  // that no longer matches the buffer.
+  // The WASM stack was suspended during the await, so this request may have been superseded since.
   if (generation != mapGeneration) {
     return;
   }
@@ -169,8 +160,7 @@ void WebGPUBuffer::setMapReady(bool ready) {
   if ((_usage & GPUBufferUsage::READBACK) == 0) {
     return;
   }
-  // The external path performs the mapping itself, so any request issued from C++ must be
-  // superseded to keep its late callback from overwriting the state set here.
+  // The external path maps the buffer itself, so drop any request issued from C++.
   detachMapRequest();
   mapState = ready ? MapState::Mapped : MapState::Unmapped;
 }
@@ -181,8 +171,7 @@ void WebGPUBuffer::unmap() {
   }
   if (_usage & GPUBufferUsage::READBACK) {
     if (mapState != MapState::Unmapped) {
-      // Unmapping a buffer that still has a map request pending rejects that request with an
-      // AbortError, so this doubles as the cancellation path.
+      // Unmapping rejects a pending map request, so this doubles as the cancellation path.
       wgpuBufferUnmap(buffer);
       mapState = MapState::Unmapped;
     }
@@ -201,8 +190,8 @@ void WebGPUBuffer::unmap() {
 }
 
 void WebGPUBuffer::detachMapRequest() {
-  // Bumping the generation supersedes an in-flight Asyncify request, while clearing the owner
-  // pointer supersedes an in-flight callback-based request.
+  // The generation supersedes an in-flight Asyncify request; the owner pointer supersedes a
+  // callback-based one.
   ++mapGeneration;
   if (mapRequest != nullptr) {
     mapRequest->owner = nullptr;
@@ -224,8 +213,7 @@ void WebGPUBuffer::onRelease(WebGPUGPU*) {
     buffer = nullptr;
   }
   mapState = MapState::Unmapped;
-  // Must run even when the buffer was already gone: this object is deleted right after onRelease(),
-  // so a late callback would otherwise write into freed memory.
+  // Required even without a buffer: this object is deleted right after onRelease().
   detachMapRequest();
 }
 

--- a/src/gpu/webgpu/WebGPUBuffer.cpp
+++ b/src/gpu/webgpu/WebGPUBuffer.cpp
@@ -22,7 +22,6 @@
 #include "WebGPUCommandQueue.h"
 #include "WebGPUGPU.h"
 #include "WebGPUUtil.h"
-#include "core/utils/Log.h"
 #ifdef TGFX_USE_ASYNCIFY
 #include <emscripten.h>
 #endif
@@ -52,7 +51,7 @@ WebGPUBuffer::WebGPUBuffer(WebGPUGPU* gpu, WGPUBuffer buffer, size_t size, uint3
 
 bool WebGPUBuffer::isReady() const {
   if (_usage & GPUBufferUsage::READBACK) {
-    return mapReady;
+    return mapState == MapState::Mapped;
   }
   return true;
 }
@@ -78,14 +77,31 @@ EM_ASYNC_JS(int, webgpu_buffer_map_sync, (WGPUBuffer bufHandle, size_t size), {
     return 1;
   }
 });
-#else
-static void OnBufferMapped(WGPUBufferMapAsyncStatus status, void* userdata) {
-  if (status != WGPUBufferMapAsyncStatus_Success || userdata == nullptr) {
+#endif
+
+void WebGPUBuffer::OnBufferMapped(WGPUBufferMapAsyncStatus status, void* userdata) {
+  auto reference = static_cast<std::shared_ptr<MapRequest>*>(userdata);
+  if (reference == nullptr) {
     return;
   }
-  *static_cast<bool*>(userdata) = true;
+  auto request = *reference;
+  delete reference;
+  if (request == nullptr || request->owner == nullptr) {
+    // The buffer was released, or the request was superseded by unmap() / setMapReady() before the
+    // callback arrived. Dropping the result here is what keeps this callback from writing into
+    // freed memory or into a newer request's state.
+    return;
+  }
+  auto owner = request->owner;
+  if (status == WGPUBufferMapAsyncStatus_Success) {
+    owner->mapState = MapState::Mapped;
+    return;
+  }
+  // Falling back to Unmapped is mandatory: leaving the state at Pending would make the guard in
+  // requestMapAsync() reject every retry, blocking the readback forever.
+  owner->mapState = MapState::Unmapped;
+  owner->detachMapRequest();
 }
-#endif
 
 void* WebGPUBuffer::map(size_t offset, size_t mapSize) {
   if (buffer == nullptr) {
@@ -95,10 +111,10 @@ void* WebGPUBuffer::map(size_t offset, size_t mapSize) {
     mapSize = _size - offset;
   }
   if (_usage & GPUBufferUsage::READBACK) {
-    if (!mapReady) {
-      // The buffer has not been asynchronously mapped yet. Synchronous readback is not supported
-      // in WebGPU. Call requestMapAsync() first, then poll isReady() before calling map().
-      LOGE("WebGPUBuffer::map() readback buffer not mapped. Use requestMapAsync() first.");
+    if (mapState != MapState::Mapped) {
+      // Not yet mapped. WebGPU has no synchronous readback, so this is the expected result while
+      // the asynchronous mapping is still in flight; callers poll isReady() until it completes.
+      // Deliberately not logged: polling callers would flood the log every frame.
       return nullptr;
     }
     return const_cast<void*>(wgpuBufferGetConstMappedRange(buffer, offset, mapSize));
@@ -123,13 +139,40 @@ void WebGPUBuffer::requestMapAsync() {
   if (buffer == nullptr || (_usage & GPUBufferUsage::READBACK) == 0) {
     return;
   }
-  mapReady = false;
+  // Idempotent by design. Re-issuing a map on a buffer that already has one pending is a validation
+  // error, and clearing the state of an already mapped buffer would drop the obligation to unmap
+  // it, leaving the buffer permanently mapped and unusable.
+  if (mapState != MapState::Unmapped) {
+    return;
+  }
+  detachMapRequest();
+  mapState = MapState::Pending;
 #ifdef TGFX_USE_ASYNCIFY
-  int result = webgpu_buffer_map_sync(buffer, _size);
-  mapReady = (result == 0);
+  auto generation = mapGeneration;
+  auto result = webgpu_buffer_map_sync(buffer, _size);
+  // The WASM stack was suspended during the await, so unmap(), setMapReady() or onRelease() may
+  // have superseded this request in the meantime. Writing the result now would resurrect a state
+  // that no longer matches the buffer.
+  if (generation != mapGeneration) {
+    return;
+  }
+  mapState = result == 0 ? MapState::Mapped : MapState::Unmapped;
 #else
-  wgpuBufferMapAsync(buffer, WGPUMapMode_Read, 0, _size, OnBufferMapped, &mapReady);
+  mapRequest = std::make_shared<MapRequest>();
+  mapRequest->owner = this;
+  auto reference = new std::shared_ptr<MapRequest>(mapRequest);
+  wgpuBufferMapAsync(buffer, WGPUMapMode_Read, 0, _size, OnBufferMapped, reference);
 #endif
+}
+
+void WebGPUBuffer::setMapReady(bool ready) {
+  if ((_usage & GPUBufferUsage::READBACK) == 0) {
+    return;
+  }
+  // The external path performs the mapping itself, so any request issued from C++ must be
+  // superseded to keep its late callback from overwriting the state set here.
+  detachMapRequest();
+  mapState = ready ? MapState::Mapped : MapState::Unmapped;
 }
 
 void WebGPUBuffer::unmap() {
@@ -137,8 +180,13 @@ void WebGPUBuffer::unmap() {
     return;
   }
   if (_usage & GPUBufferUsage::READBACK) {
-    wgpuBufferUnmap(buffer);
-    mapReady = false;
+    if (mapState != MapState::Unmapped) {
+      // Unmapping a buffer that still has a map request pending rejects that request with an
+      // AbortError, so this doubles as the cancellation path.
+      wgpuBufferUnmap(buffer);
+      mapState = MapState::Unmapped;
+    }
+    detachMapRequest();
     return;
   }
   if (stagingData != nullptr) {
@@ -152,20 +200,33 @@ void WebGPUBuffer::unmap() {
   }
 }
 
+void WebGPUBuffer::detachMapRequest() {
+  // Bumping the generation supersedes an in-flight Asyncify request, while clearing the owner
+  // pointer supersedes an in-flight callback-based request.
+  ++mapGeneration;
+  if (mapRequest != nullptr) {
+    mapRequest->owner = nullptr;
+    mapRequest = nullptr;
+  }
+}
+
 void WebGPUBuffer::onRelease(WebGPUGPU*) {
   if (stagingData != nullptr) {
     free(stagingData);
     stagingData = nullptr;
   }
   if (buffer != nullptr) {
-    if (mapReady) {
+    if (mapState != MapState::Unmapped) {
       wgpuBufferUnmap(buffer);
-      mapReady = false;
     }
     wgpuBufferDestroy(buffer);
     wgpuBufferRelease(buffer);
     buffer = nullptr;
   }
+  mapState = MapState::Unmapped;
+  // Must run even when the buffer was already gone: this object is deleted right after onRelease(),
+  // so a late callback would otherwise write into freed memory.
+  detachMapRequest();
 }
 
 }  // namespace tgfx

--- a/src/gpu/webgpu/WebGPUBuffer.h
+++ b/src/gpu/webgpu/WebGPUBuffer.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <webgpu/webgpu.h>
+#include <memory>
 #include "WebGPUResource.h"
 #include "tgfx/gpu/GPUBuffer.h"
 
@@ -38,33 +39,55 @@ class WebGPUBuffer : public GPUBuffer, public WebGPUResource {
 
   void* map(size_t offset = 0, size_t size = GPU_BUFFER_WHOLE_SIZE) override;
 
+  /**
+   * Unmaps the buffer, and also cancels an in-flight asynchronous map request. Calling this on a
+   * buffer that is neither mapped nor pending is a no-op.
+   */
   void unmap() override;
 
   /**
    * Initiates an asynchronous map request for READBACK buffers. After calling this, poll isReady()
-   * to check completion, then call map() to access the data.
+   * to check completion, then call map() to access the data. This method is idempotent: it does
+   * nothing while a request is in flight or the buffer is already mapped. If a previous request
+   * failed, calling it again issues a new request.
    */
   void requestMapAsync() override;
 
   /**
-   * Marks the buffer as mapped (ready for map() call). Used by external async mapping paths
-   * (e.g., JS-side mapAsync) to notify C++ that the buffer is now accessible.
+   * Marks the buffer as mapped or unmapped. Used by external async mapping paths (e.g., JS-side
+   * mapAsync) to notify C++ about the mapping result. Any in-flight request issued from C++ is
+   * superseded, so its late callback cannot overwrite the state set here.
    */
-  void setMapReady(bool ready) {
-    mapReady = ready;
-  }
+  void setMapReady(bool ready);
 
   void onRelease(WebGPUGPU* gpu) override;
 
  private:
+  enum class MapState { Unmapped, Pending, Mapped };
+
+  /**
+   * Shared state for one asynchronous map request. It is kept alive by the map callback, so the
+   * callback stays safe even when the WebGPUBuffer has already been destroyed: the owner pointer is
+   * cleared before the buffer goes away.
+   */
+  struct MapRequest {
+    WebGPUBuffer* owner = nullptr;
+  };
+
   WebGPUBuffer(WebGPUGPU* gpu, WGPUBuffer buffer, size_t size, uint32_t usage);
+
+  void detachMapRequest();
+
+  static void OnBufferMapped(WGPUBufferMapAsyncStatus status, void* userdata);
 
   WebGPUGPU* _gpu = nullptr;
   WGPUBuffer buffer = nullptr;
   void* stagingData = nullptr;
   size_t stagingOffset = 0;
   size_t stagingSize = 0;
-  bool mapReady = false;
+  MapState mapState = MapState::Unmapped;
+  uint32_t mapGeneration = 0;
+  std::shared_ptr<MapRequest> mapRequest = nullptr;
 
   friend class WebGPUGPU;
 };

--- a/src/gpu/webgpu/WebGPUBuffer.h
+++ b/src/gpu/webgpu/WebGPUBuffer.h
@@ -40,23 +40,20 @@ class WebGPUBuffer : public GPUBuffer, public WebGPUResource {
   void* map(size_t offset = 0, size_t size = GPU_BUFFER_WHOLE_SIZE) override;
 
   /**
-   * Unmaps the buffer, and also cancels an in-flight asynchronous map request. Calling this on a
-   * buffer that is neither mapped nor pending is a no-op.
+   * Unmaps the buffer and cancels any in-flight asynchronous map request.
    */
   void unmap() override;
 
   /**
    * Initiates an asynchronous map request for READBACK buffers. After calling this, poll isReady()
-   * to check completion, then call map() to access the data. This method is idempotent: it does
-   * nothing while a request is in flight or the buffer is already mapped. If a previous request
-   * failed, calling it again issues a new request.
+   * to check completion, then call map() to access the data. Idempotent: does nothing while a
+   * request is in flight or the buffer is already mapped, and re-issues the request after a failure.
    */
   void requestMapAsync() override;
 
   /**
-   * Marks the buffer as mapped or unmapped. Used by external async mapping paths (e.g., JS-side
-   * mapAsync) to notify C++ about the mapping result. Any in-flight request issued from C++ is
-   * superseded, so its late callback cannot overwrite the state set here.
+   * Marks the buffer as mapped or unmapped, for external mapping paths such as JS-side mapAsync.
+   * Supersedes any request issued from C++.
    */
   void setMapReady(bool ready);
 
@@ -65,11 +62,8 @@ class WebGPUBuffer : public GPUBuffer, public WebGPUResource {
  private:
   enum class MapState { Unmapped, Pending, Mapped };
 
-  /**
-   * Shared state for one asynchronous map request. It is kept alive by the map callback, so the
-   * callback stays safe even when the WebGPUBuffer has already been destroyed: the owner pointer is
-   * cleared before the buffer goes away.
-   */
+  // Shared with the map callback so it stays valid after the buffer is destroyed; the owner pointer
+  // is cleared before that happens.
   struct MapRequest {
     WebGPUBuffer* owner = nullptr;
   };

--- a/src/gpu/webgpu/WebGPUBuffer.h
+++ b/src/gpu/webgpu/WebGPUBuffer.h
@@ -45,9 +45,8 @@ class WebGPUBuffer : public GPUBuffer, public WebGPUResource {
   void unmap() override;
 
   /**
-   * Initiates an asynchronous map request for READBACK buffers. After calling this, poll isReady()
-   * to check completion, then call map() to access the data. Idempotent: does nothing while a
-   * request is in flight or the buffer is already mapped, and re-issues the request after a failure.
+   * Initiates an asynchronous map request for READBACK buffers. Idempotent: does nothing while a
+   * request is in flight or the buffer is already mapped, and re-issues it after a failure.
    */
   void requestMapAsync() override;
 
@@ -62,8 +61,7 @@ class WebGPUBuffer : public GPUBuffer, public WebGPUResource {
  private:
   enum class MapState { Unmapped, Pending, Mapped };
 
-  // Shared with the map callback so it stays valid after the buffer is destroyed; the owner pointer
-  // is cleared before that happens.
+  // Shared with the map callback so it stays valid after the buffer is destroyed.
   struct MapRequest {
     WebGPUBuffer* owner = nullptr;
   };

--- a/src/gpu/webgpu/WebGPURenderPipeline.cpp
+++ b/src/gpu/webgpu/WebGPURenderPipeline.cpp
@@ -89,17 +89,20 @@ bool WebGPURenderPipeline::createPipelineState(WebGPUGPU* gpu,
     uniformBlockVisibility[entry.binding] = entry.visibility;
   }
 
+  // In the GLSL→WGSL conversion, combined samplers are split into separate texture and sampler
+  // resources, renumbered by declaration order starting from TEXTURE_BINDING_POINT_START (after
+  // uniform blocks), so each combined sampler occupies two consecutive WGSL bindings:
+  //   texture = TEXTURE_BINDING_POINT_START + samplerIndex * 2
+  //   sampler = texture_binding + 1
+  // samplerIndex must be the position within textureSamplers, matching the declaration order used
+  // by separateSamplerDeclarations() in WebGPUShaderModule.cpp. Deriving it from entry.binding
+  // instead maps distinct samplers onto the same WGSL binding once a pipeline has three or more of
+  // them, which makes the whole BindGroupLayout invalid.
+  unsigned samplerIndex = 0;
   for (auto& entry : descriptor.layout.textureSamplers) {
-    // In the GLSL→WGSL conversion, combined samplers are split into separate texture and sampler
-    // resources. The GLSL binding numbers are reassigned starting from TEXTURE_BINDING_POINT_START
-    // (after uniform blocks). In WGSL, each combined sampler occupies two consecutive bindings:
-    //   texture = TEXTURE_BINDING_POINT_START + samplerIndex * 2
-    //   sampler = texture_binding + 1
-    auto samplerIndex = static_cast<unsigned>(entry.binding < TEXTURE_BINDING_POINT_START
-                                                  ? entry.binding
-                                                  : entry.binding - TEXTURE_BINDING_POINT_START);
     unsigned textureBinding = TEXTURE_BINDING_POINT_START + samplerIndex * 2;
     unsigned samplerBinding = textureBinding + 1;
+    samplerIndex++;
     WGPUBindGroupLayoutEntry textureEntry = {};
     textureEntry.binding = textureBinding;
     textureEntry.visibility = WGPUShaderStage_Fragment;

--- a/src/gpu/webgpu/WebGPURenderPipeline.cpp
+++ b/src/gpu/webgpu/WebGPURenderPipeline.cpp
@@ -89,15 +89,13 @@ bool WebGPURenderPipeline::createPipelineState(WebGPUGPU* gpu,
     uniformBlockVisibility[entry.binding] = entry.visibility;
   }
 
-  // In the GLSL→WGSL conversion, combined samplers are split into separate texture and sampler
-  // resources, renumbered by declaration order starting from TEXTURE_BINDING_POINT_START (after
-  // uniform blocks), so each combined sampler occupies two consecutive WGSL bindings:
-  //   texture = TEXTURE_BINDING_POINT_START + samplerIndex * 2
-  //   sampler = texture_binding + 1
-  // samplerIndex must be the position within textureSamplers, matching the declaration order used
-  // by separateSamplerDeclarations() in WebGPUShaderModule.cpp. Deriving it from entry.binding
-  // instead maps distinct samplers onto the same WGSL binding once a pipeline has three or more of
-  // them, which makes the whole BindGroupLayout invalid.
+  // The GLSL to WGSL conversion splits combined samplers into separate texture and sampler
+  // resources, renumbered by declaration order from TEXTURE_BINDING_POINT_START, two bindings each:
+  //   texture = TEXTURE_BINDING_POINT_START + samplerIndex * 2, sampler = texture + 1
+  // samplerIndex must be the position within textureSamplers to match the order used by
+  // separateSamplerDeclarations() in WebGPUShaderModule.cpp. Deriving it from entry.binding maps
+  // distinct samplers onto the same binding once there are three or more of them, which makes the
+  // whole BindGroupLayout invalid.
   unsigned samplerIndex = 0;
   for (auto& entry : descriptor.layout.textureSamplers) {
     unsigned textureBinding = TEXTURE_BINDING_POINT_START + samplerIndex * 2;

--- a/src/gpu/webgpu/WebGPURenderPipeline.cpp
+++ b/src/gpu/webgpu/WebGPURenderPipeline.cpp
@@ -89,13 +89,11 @@ bool WebGPURenderPipeline::createPipelineState(WebGPUGPU* gpu,
     uniformBlockVisibility[entry.binding] = entry.visibility;
   }
 
-  // The GLSL to WGSL conversion splits combined samplers into separate texture and sampler
-  // resources, renumbered by declaration order from TEXTURE_BINDING_POINT_START, two bindings each:
-  //   texture = TEXTURE_BINDING_POINT_START + samplerIndex * 2, sampler = texture + 1
-  // samplerIndex must be the position within textureSamplers to match the order used by
-  // separateSamplerDeclarations() in WebGPUShaderModule.cpp. Deriving it from entry.binding maps
-  // distinct samplers onto the same binding once there are three or more of them, which makes the
-  // whole BindGroupLayout invalid.
+  // The GLSL to WGSL conversion splits each combined sampler into a texture and a sampler, packed in
+  // pairs from TEXTURE_BINDING_POINT_START by declaration order. samplerIndex must therefore be the
+  // position within textureSamplers, matching separateSamplerDeclarations() in
+  // WebGPUShaderModule.cpp; deriving it from entry.binding makes distinct samplers collide once
+  // there are three or more of them.
   unsigned samplerIndex = 0;
   for (auto& entry : descriptor.layout.textureSamplers) {
     unsigned textureBinding = TEXTURE_BINDING_POINT_START + samplerIndex * 2;


### PR DESCRIPTION
修复 WebGPU 后端的两类问题。

一、readback 的异步 map 缺少防重入保护

WebGPUBuffer 原先用单个 bool 同时表达「已就绪」与「无在途请求」，导致：重复调用 requestMapAsync 会对 pending 中的 buffer 再次发起 mapAsync 触发 validation error；对已 mapped 的 buffer 调用会清掉就绪标记并丢失 unmap 义务；map 回调以成员地址作为 userdata，资源释放后可能写入已释放内存；被回收复用的 readback buffer 残留 map 状态，会让 isReady 误报就绪并交出上一轮的像素。

改为 Unmapped / Pending / Mapped 三态：requestMapAsync 在非 Unmapped 时为幂等空操作，失败回落 Unmapped 以保留重试能力；回调改用引用计数的共享块承载 owner 指针，unmap 与 onRelease 置空 owner 完成换代；Asyncify 分支用代号校验，避免栈挂起期间状态被改写后又被恢复值覆盖；unmap 兼作取消；并在 ReadbackBufferCreateTask 取出池化 buffer 后重置其 map 状态，该处是缓存复用的唯一入口。

配套为 GLBuffer::unmap 补 mapped 守卫，它原先对未 map 的 buffer 也会调用 glUnmapBuffer 而产生 GL_INVALID_OPERATION。其余四个后端的 unmap 已有早退守卫，行为不变。

日志上区分两种语义：异步轮询返回空指针是预期中间状态，不再逐帧打印；同步 Surface::readPixels 失败是真实错误，改在该入口打印。

二、pipeline 的 sampler binding 撞车

WebGPURenderPipeline 原先从 entry.binding 反推 samplerIndex，而 textureSamplers 的 binding 从 0 连续编号，WGSL 侧由 separateSamplerDeclarations 按声明顺序从 TEXTURE_BINDING_POINT_START（值为 2）起成对编号。当 pipeline 含三个及以上 sampler 时 binding 2 会折叠到 binding 0 的位置，layoutEntries 出现重复 binding 使 BindGroupLayout 创建失败，textureUnits 映射冲突也会让后一张纹理覆盖前一张。改为按 textureSamplers 中的位置编号。