### PR TITLE
Skip offscreen mipmap chain creation for non-minified affine 3D leaves

### DIFF
--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -299,7 +299,10 @@ static float SmallestSingularValueSquared(float m00, float m01, float m10, float
   return 0.5f * (trace - std::sqrt(discriminant));
 }
 
-// The offscreen leaf surface only needs mipmaps when an affine mapping minifies raster texels.
+// Creates mipmaps for the offscreen leaf surface only when the affine mapping minifies raster
+// texels. The smallest singular value of the texel-to-compositor Jacobian measures the most
+// minified direction: below 1.0 the leaf shrinks while sampling and needs mipmaps to avoid
+// aliasing, while equal or larger scales sample level 0 only and skip the mip storage entirely.
 // Perspective or invalid mappings conservatively retain mipmaps.
 static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleLocal,
                          int rasterWidth, int rasterHeight) {

--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -291,12 +291,22 @@ bool Render3DContext::primeCompositorFromOuterCanvas(Canvas* outerCanvas) {
 namespace {
 
 // Returns the squared scale in the most minified raster-texel direction, including rotation and
-// skew without relying on an axis-aligned footprint.
-static float SmallestSingularValueSquared(float m00, float m01, float m10, float m11) {
-  const float trace = m00 * m00 + m01 * m01 + m10 * m10 + m11 * m11;
-  const float determinant = m00 * m11 - m01 * m10;
-  const float discriminant = std::max(0.0f, trace * trace - 4.0f * determinant * determinant);
-  return 0.5f * (trace - std::sqrt(discriminant));
+// skew without relying on an axis-aligned footprint. The quotient form det² / λmax replaces the
+// trace - sqrt(discriminant) form, which cancels catastrophically when the two axis scales differ
+// widely; double intermediates also keep float inputs from overflowing.
+static double SmallestSingularValueSquared(float m00, float m01, float m10, float m11) {
+  const double a = static_cast<double>(m00);
+  const double b = static_cast<double>(m01);
+  const double c = static_cast<double>(m10);
+  const double d = static_cast<double>(m11);
+  const double trace = a * a + b * b + c * c + d * d;
+  const double determinant = a * d - b * c;
+  const double discriminant = std::max(0.0, trace * trace - 4.0 * determinant * determinant);
+  const double largestEigenvalue = 0.5 * (trace + std::sqrt(discriminant));
+  if (!(largestEigenvalue > 0.0)) {
+    return 0.0;
+  }
+  return determinant * determinant / largestEigenvalue;
 }
 
 // Creates mipmaps for the offscreen leaf surface only when the affine mapping minifies raster
@@ -325,8 +335,8 @@ static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleL
   if (!std::isfinite(m00) || !std::isfinite(m01) || !std::isfinite(m10) || !std::isfinite(m11)) {
     return true;
   }
-  const float smallestSingularValueSquared = SmallestSingularValueSquared(m00, m01, m10, m11);
-  return !std::isfinite(smallestSingularValueSquared) || smallestSingularValueSquared < 1.0f;
+  const double smallestSingularValueSquared = SmallestSingularValueSquared(m00, m01, m10, m11);
+  return !std::isfinite(smallestSingularValueSquared) || smallestSingularValueSquared < 1.0;
 }
 
 }  // namespace

--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -62,45 +62,6 @@ class Compositor3DBackgroundSource : public BackgroundSource {
   Context3DCompositor* _compositor = nullptr;
 };
 
-// The smallest singular value covers the most minified local direction after mapping raster texels
-// to compositor pixels, including rotation and skew without relying on an axis-aligned footprint.
-static float SmallestSingularValueSquared(float m00, float m01, float m10, float m11) {
-  const float trace = m00 * m00 + m01 * m01 + m10 * m10 + m11 * m11;
-  const float determinant = m00 * m11 - m01 * m10;
-  const float discriminant = std::max(0.0f, trace * trace - 4.0f * determinant * determinant);
-  return 0.5f * (trace - std::sqrt(discriminant));
-}
-
-// Mirrors Skia's lazy mipmap policy (SkMipmapAccessor::Make + SkMipmap::ComputeLevel): when the
-// effective minification is absent (computed LOD <= 0), no mip chain is needed and single-level
-// sampling is equivalent. Skia applies this on its CPU raster path; here the same conservative
-// decision gates GPU offscreen mip chain creation for 3D leaves, so perspective or any possible
-// minification keeps trilinear sampling.
-static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleLocal,
-                         int rasterWidth, int rasterHeight) {
-  const float perspectiveX = localToCompositor.getRowColumn(3, 0);
-  const float perspectiveY = localToCompositor.getRowColumn(3, 1);
-  const float homogeneousW = localToCompositor.getRowColumn(3, 3);
-  if (perspectiveX != 0.0f || perspectiveY != 0.0f || !(homogeneousW > 0.0f) ||
-      visibleLocal.isEmpty() || rasterWidth <= 0 || rasterHeight <= 0) {
-    return true;
-  }
-  const float texelsPerLocalX = static_cast<float>(rasterWidth) / visibleLocal.width();
-  const float texelsPerLocalY = static_cast<float>(rasterHeight) / visibleLocal.height();
-  if (!(texelsPerLocalX > 0.0f) || !(texelsPerLocalY > 0.0f)) {
-    return true;
-  }
-  const float m00 = localToCompositor.getRowColumn(0, 0) / homogeneousW / texelsPerLocalX;
-  const float m01 = localToCompositor.getRowColumn(0, 1) / homogeneousW / texelsPerLocalY;
-  const float m10 = localToCompositor.getRowColumn(1, 0) / homogeneousW / texelsPerLocalX;
-  const float m11 = localToCompositor.getRowColumn(1, 1) / homogeneousW / texelsPerLocalY;
-  if (!std::isfinite(m00) || !std::isfinite(m01) || !std::isfinite(m10) || !std::isfinite(m11)) {
-    return true;
-  }
-  const float smallestSingularValueSquared = SmallestSingularValueSquared(m00, m01, m10, m11);
-  return !std::isfinite(smallestSingularValueSquared) || smallestSingularValueSquared < 1.0f;
-}
-
 }  // namespace
 
 Render3DContext::Render3DContext(std::shared_ptr<Context3DCompositor> compositor,
@@ -252,11 +213,8 @@ std::shared_ptr<Image> Render3DContext::rasterLayer(
   if (info.rasterWidth <= 0 || info.rasterHeight <= 0) {
     return nullptr;
   }
-  // Following Skia's lazy mipmap decision (SkMipmapAccessor + SkMipmap::ComputeLevel), only create
-  // the offscreen mip chain when the leaf can actually be minified while sampling; single-level
-  // sampling is equivalent otherwise and saves the mip storage and generation cost.
   auto surface = Surface::Make(leafArgs.context, info.rasterWidth, info.rasterHeight, false, 1,
-                               info.needsMipmaps, 0, _colorSpace);
+                               info.mipmapped, 0, _colorSpace);
   if (surface == nullptr) {
     return nullptr;
   }
@@ -330,6 +288,46 @@ bool Render3DContext::primeCompositorFromOuterCanvas(Canvas* outerCanvas) {
   return true;
 }
 
+namespace {
+
+// Returns the squared scale in the most minified raster-texel direction, including rotation and
+// skew without relying on an axis-aligned footprint.
+static float SmallestSingularValueSquared(float m00, float m01, float m10, float m11) {
+  const float trace = m00 * m00 + m01 * m01 + m10 * m10 + m11 * m11;
+  const float determinant = m00 * m11 - m01 * m10;
+  const float discriminant = std::max(0.0f, trace * trace - 4.0f * determinant * determinant);
+  return 0.5f * (trace - std::sqrt(discriminant));
+}
+
+// The offscreen leaf surface only needs mipmaps when an affine mapping minifies raster texels.
+// Perspective or invalid mappings conservatively retain mipmaps.
+static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleLocal,
+                         int rasterWidth, int rasterHeight) {
+  const float perspectiveX = localToCompositor.getRowColumn(3, 0);
+  const float perspectiveY = localToCompositor.getRowColumn(3, 1);
+  const float homogeneousW = localToCompositor.getRowColumn(3, 3);
+  if (perspectiveX != 0.0f || perspectiveY != 0.0f || !(homogeneousW > 0.0f) ||
+      visibleLocal.isEmpty() || rasterWidth <= 0 || rasterHeight <= 0) {
+    return true;
+  }
+  const float texelsPerLocalX = static_cast<float>(rasterWidth) / visibleLocal.width();
+  const float texelsPerLocalY = static_cast<float>(rasterHeight) / visibleLocal.height();
+  if (!(texelsPerLocalX > 0.0f) || !(texelsPerLocalY > 0.0f)) {
+    return true;
+  }
+  const float m00 = localToCompositor.getRowColumn(0, 0) / homogeneousW / texelsPerLocalX;
+  const float m01 = localToCompositor.getRowColumn(0, 1) / homogeneousW / texelsPerLocalY;
+  const float m10 = localToCompositor.getRowColumn(1, 0) / homogeneousW / texelsPerLocalX;
+  const float m11 = localToCompositor.getRowColumn(1, 1) / homogeneousW / texelsPerLocalY;
+  if (!std::isfinite(m00) || !std::isfinite(m01) || !std::isfinite(m10) || !std::isfinite(m11)) {
+    return true;
+  }
+  const float smallestSingularValueSquared = SmallestSingularValueSquared(m00, m01, m10, m11);
+  return !std::isfinite(smallestSingularValueSquared) || smallestSingularValueSquared < 1.0f;
+}
+
+}  // namespace
+
 bool Render3DContext::ComputeRasterInfo(const Matrix3D& localToCompositor, const Rect& localBounds,
                                         const Rect& compositorViewport, float contentScale,
                                         RasterInfo* info) {
@@ -372,7 +370,7 @@ bool Render3DContext::ComputeRasterInfo(const Matrix3D& localToCompositor, const
   info->density = density;
   info->rasterWidth = std::max(1, static_cast<int>(std::ceil(localWidth * densityX)));
   info->rasterHeight = std::max(1, static_cast<int>(std::ceil(localHeight * densityY)));
-  info->needsMipmaps =
+  info->mipmapped =
       NeedsMipmaps(localToCompositor, info->visibleLocal, info->rasterWidth, info->rasterHeight);
   return true;
 }

--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -316,6 +316,8 @@ static double SmallestSingularValueSquared(float m00, float m01, float m10, floa
 // Perspective or invalid mappings conservatively retain mipmaps.
 static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleLocal,
                          int rasterWidth, int rasterHeight) {
+  // The leaf is planar (z = 0), so the row-3 column-2 perspective term multiplies zero and is
+  // intentionally ignored; only the x/y perspective terms affect the texel mapping.
   const float perspectiveX = localToCompositor.getRowColumn(3, 0);
   const float perspectiveY = localToCompositor.getRowColumn(3, 1);
   const float homogeneousW = localToCompositor.getRowColumn(3, 3);

--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -94,7 +94,11 @@ static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleL
   const float m01 = localToCompositor.getRowColumn(0, 1) / homogeneousW / texelsPerLocalY;
   const float m10 = localToCompositor.getRowColumn(1, 0) / homogeneousW / texelsPerLocalX;
   const float m11 = localToCompositor.getRowColumn(1, 1) / homogeneousW / texelsPerLocalY;
-  return SmallestSingularValueSquared(m00, m01, m10, m11) < 1.0f;
+  if (!std::isfinite(m00) || !std::isfinite(m01) || !std::isfinite(m10) || !std::isfinite(m11)) {
+    return true;
+  }
+  const float smallestSingularValueSquared = SmallestSingularValueSquared(m00, m01, m10, m11);
+  return !std::isfinite(smallestSingularValueSquared) || smallestSingularValueSquared < 1.0f;
 }
 
 }  // namespace

--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -62,6 +62,36 @@ class Compositor3DBackgroundSource : public BackgroundSource {
   Context3DCompositor* _compositor = nullptr;
 };
 
+// The smallest singular value covers the most minified local direction after mapping raster texels
+// to compositor pixels, including rotation and skew without relying on an axis-aligned footprint.
+static float SmallestSingularValueSquared(float m00, float m01, float m10, float m11) {
+  const float trace = m00 * m00 + m01 * m01 + m10 * m10 + m11 * m11;
+  const float determinant = m00 * m11 - m01 * m10;
+  const float discriminant = std::max(0.0f, trace * trace - 4.0f * determinant * determinant);
+  return 0.5f * (trace - std::sqrt(discriminant));
+}
+
+static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleLocal,
+                         int rasterWidth, int rasterHeight) {
+  const float perspectiveX = localToCompositor.getRowColumn(3, 0);
+  const float perspectiveY = localToCompositor.getRowColumn(3, 1);
+  const float homogeneousW = localToCompositor.getRowColumn(3, 3);
+  if (perspectiveX != 0.0f || perspectiveY != 0.0f || !(homogeneousW > 0.0f) ||
+      visibleLocal.isEmpty() || rasterWidth <= 0 || rasterHeight <= 0) {
+    return true;
+  }
+  const float texelsPerLocalX = static_cast<float>(rasterWidth) / visibleLocal.width();
+  const float texelsPerLocalY = static_cast<float>(rasterHeight) / visibleLocal.height();
+  if (!(texelsPerLocalX > 0.0f) || !(texelsPerLocalY > 0.0f)) {
+    return true;
+  }
+  const float m00 = localToCompositor.getRowColumn(0, 0) / homogeneousW / texelsPerLocalX;
+  const float m01 = localToCompositor.getRowColumn(0, 1) / homogeneousW / texelsPerLocalY;
+  const float m10 = localToCompositor.getRowColumn(1, 0) / homogeneousW / texelsPerLocalX;
+  const float m11 = localToCompositor.getRowColumn(1, 1) / homogeneousW / texelsPerLocalY;
+  return SmallestSingularValueSquared(m00, m01, m10, m11) < 1.0f;
+}
+
 }  // namespace
 
 Render3DContext::Render3DContext(std::shared_ptr<Context3DCompositor> compositor,
@@ -214,7 +244,7 @@ std::shared_ptr<Image> Render3DContext::rasterLayer(
     return nullptr;
   }
   auto surface = Surface::Make(leafArgs.context, info.rasterWidth, info.rasterHeight, false, 1,
-                               true, 0, _colorSpace);
+                               info.needsMipmaps, 0, _colorSpace);
   if (surface == nullptr) {
     return nullptr;
   }
@@ -330,6 +360,8 @@ bool Render3DContext::ComputeRasterInfo(const Matrix3D& localToCompositor, const
   info->density = density;
   info->rasterWidth = std::max(1, static_cast<int>(std::ceil(localWidth * densityX)));
   info->rasterHeight = std::max(1, static_cast<int>(std::ceil(localHeight * densityY)));
+  info->needsMipmaps =
+      NeedsMipmaps(localToCompositor, info->visibleLocal, info->rasterWidth, info->rasterHeight);
   return true;
 }
 

--- a/src/layers/compositing3d/Render3DContext.cpp
+++ b/src/layers/compositing3d/Render3DContext.cpp
@@ -71,6 +71,11 @@ static float SmallestSingularValueSquared(float m00, float m01, float m10, float
   return 0.5f * (trace - std::sqrt(discriminant));
 }
 
+// Mirrors Skia's lazy mipmap policy (SkMipmapAccessor::Make + SkMipmap::ComputeLevel): when the
+// effective minification is absent (computed LOD <= 0), no mip chain is needed and single-level
+// sampling is equivalent. Skia applies this on its CPU raster path; here the same conservative
+// decision gates GPU offscreen mip chain creation for 3D leaves, so perspective or any possible
+// minification keeps trilinear sampling.
 static bool NeedsMipmaps(const Matrix3D& localToCompositor, const Rect& visibleLocal,
                          int rasterWidth, int rasterHeight) {
   const float perspectiveX = localToCompositor.getRowColumn(3, 0);
@@ -243,6 +248,9 @@ std::shared_ptr<Image> Render3DContext::rasterLayer(
   if (info.rasterWidth <= 0 || info.rasterHeight <= 0) {
     return nullptr;
   }
+  // Following Skia's lazy mipmap decision (SkMipmapAccessor + SkMipmap::ComputeLevel), only create
+  // the offscreen mip chain when the leaf can actually be minified while sampling; single-level
+  // sampling is equivalent otherwise and saves the mip storage and generation cost.
   auto surface = Surface::Make(leafArgs.context, info.rasterWidth, info.rasterHeight, false, 1,
                                info.needsMipmaps, 0, _colorSpace);
   if (surface == nullptr) {

--- a/src/layers/compositing3d/Render3DContext.h
+++ b/src/layers/compositing3d/Render3DContext.h
@@ -64,6 +64,7 @@ class Render3DContext : public Layer3DContext {
     Matrix density = Matrix::I();
     int rasterWidth = 0;
     int rasterHeight = 0;
+    bool needsMipmaps = true;
   };
 
   void emitNode(Layer* layer, const Rect& localBounds, const Matrix3D& transform, float alpha,

--- a/src/layers/compositing3d/Render3DContext.h
+++ b/src/layers/compositing3d/Render3DContext.h
@@ -64,7 +64,7 @@ class Render3DContext : public Layer3DContext {
     Matrix density = Matrix::I();
     int rasterWidth = 0;
     int rasterHeight = 0;
-    bool needsMipmaps = true;
+    bool mipmapped = true;
   };
 
   void emitNode(Layer* layer, const Rect& localBounds, const Matrix3D& transform, float alpha,

--- a/src/layers/compositing3d/Render3DContext.h
+++ b/src/layers/compositing3d/Render3DContext.h
@@ -64,6 +64,9 @@ class Render3DContext : public Layer3DContext {
     Matrix density = Matrix::I();
     int rasterWidth = 0;
     int rasterHeight = 0;
+    // Whether the leaf surface keeps a mip chain; ComputeRasterInfo clears it when the affine
+    // mapping never minifies texels. Defaults to true so any path that skips the decision stays
+    // conservative.
     bool mipmapped = true;
   };
 
@@ -83,7 +86,7 @@ class Render3DContext : public Layer3DContext {
                                      BackgroundSnapshotMap* snapshots, const Matrix& localToWorld);
   // Snapshot the outer canvas and prime the compositor target with it so in-subtree
   // BackgroundBlur dispatches can sample "outside the 3D subtree" content as part of their
-  // backdrop. Returns true on success; returns false (with a LOGW for the no-surface case)
+  // backdrop. Returns true on success; returns false (with a LOGE for the no-surface case)
   // when the outer canvas has no surface or the snapshot can't be remapped into compositor
   // pixel space — the caller must skip compositorSource construction so blur falls back
   // cleanly rather than consuming an un-primed compositor.

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4530,16 +4530,35 @@ TGFX_TEST_PRIVATE(LayerTest, MinifiedAffineLeaf_KeepsMipmaps) {
   });
 }
 
-TGFX_TEST_PRIVATE(LayerTest, ExtremeAffineLeaf_KeepsMipmaps) {
+// The horizontal axis is extreme enough to overflow float-only arithmetic, but the double
+// intermediates still resolve the exact decision: the vertical axis stays 1:1, so no minification
+// occurs and the mip chain can be skipped.
+TGFX_TEST_PRIVATE(LayerTest, ExtremeAnisotropicAffineLeaf_SkipsMipmaps) {
   TGFX_PRIVATE_ACCESS({
     const Rect localBounds = Rect::MakeWH(100, 100);
     const float contentScale = 1.0f;
     const Rect renderRect = Rect::MakeWH(1000, 1000);
     const Rect viewport = Rect::MakeWH(renderRect.width(), renderRect.height());
-    // The clipped horizontal footprint rounds to one local unit, so m00 stays finite while its
-    // square overflows. This must prefer the conservative mipmapped path.
     const auto localToCompositor = MakeLocalToCompositorMatrix(
         Matrix3D::MakeScale(1.0e35f, 1.0f, 1.0f), contentScale, renderRect);
+    Render3DContext::RasterInfo info;
+
+    ASSERT_TRUE(Render3DContext::ComputeRasterInfo(localToCompositor, localBounds, viewport,
+                                                   contentScale, &info));
+    EXPECT_FALSE(info.mipmapped);
+  });
+}
+
+// A fully visible anisotropic mapping magnifies one axis 9x but minifies the other 0.11x, so the
+// short axis still shrinks while sampling and the mip chain must be retained.
+TGFX_TEST_PRIVATE(LayerTest, AnisotropicMinifiedAffineLeaf_KeepsMipmaps) {
+  TGFX_PRIVATE_ACCESS({
+    const Rect localBounds = Rect::MakeWH(100, 100);
+    const float contentScale = 1.0f;
+    const Rect renderRect = Rect::MakeWH(1000, 1000);
+    const Rect viewport = Rect::MakeWH(renderRect.width(), renderRect.height());
+    const auto localToCompositor = MakeLocalToCompositorMatrix(
+        Matrix3D::MakeScale(9.0f, 0.11f, 1.0f), contentScale, renderRect);
     Render3DContext::RasterInfo info;
     info.mipmapped = false;
 

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4530,6 +4530,25 @@ TGFX_TEST_PRIVATE(LayerTest, MinifiedAffineLeaf_KeepsMipmaps) {
   });
 }
 
+// A clipped leaf rasters at the projected density instead of contentScale, so even a minifying
+// transform samples its visible footprint 1:1 and the mip chain can be skipped.
+TGFX_TEST_PRIVATE(LayerTest, MinifiedClippedAffineLeaf_SkipsMipmaps) {
+  TGFX_PRIVATE_ACCESS({
+    const Rect localBounds = Rect::MakeWH(3000, 3000);
+    const float contentScale = 1.0f;
+    const Rect renderRect = Rect::MakeWH(1000, 1000);
+    const Rect viewport = Rect::MakeWH(renderRect.width(), renderRect.height());
+    const auto localToCompositor = MakeLocalToCompositorMatrix(
+        Matrix3D::MakeScale(0.5f, 0.5f, 1.0f), contentScale, renderRect);
+    Render3DContext::RasterInfo info;
+
+    ASSERT_TRUE(Render3DContext::ComputeRasterInfo(localToCompositor, localBounds, viewport,
+                                                   contentScale, &info));
+    EXPECT_LT(info.visibleLocal.width(), localBounds.width());
+    EXPECT_FALSE(info.mipmapped);
+  });
+}
+
 // The horizontal axis is extreme enough to overflow float-only arithmetic, but the double
 // intermediates still resolve the exact decision: the vertical axis stays 1:1, so no minification
 // occurs and the mip chain can be skipped.

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4494,6 +4494,24 @@ TGFX_TEST_PRIVATE(LayerTest, FlatLeaf_PreservesContentScaleSizing) {
   });
 }
 
+TGFX_TEST_PRIVATE(LayerTest, ExtremeAffineLeaf_KeepsMipmaps) {
+  TGFX_PRIVATE_ACCESS({
+    const Rect localBounds = Rect::MakeWH(100, 100);
+    const float contentScale = 1.0f;
+    const Rect renderRect = Rect::MakeWH(1000, 1000);
+    const Rect viewport = Rect::MakeWH(renderRect.width(), renderRect.height());
+    // The clipped horizontal footprint rounds to one local unit, so m00 stays finite while its
+    // square overflows. This must prefer the conservative mipmapped path.
+    const auto localToCompositor = MakeLocalToCompositorMatrix(
+        Matrix3D::MakeScale(1.0e35f, 1.0f, 1.0f), contentScale, renderRect);
+    Render3DContext::RasterInfo info;
+
+    ASSERT_TRUE(Render3DContext::ComputeRasterInfo(localToCompositor, localBounds, viewport,
+                                                   contentScale, &info));
+    EXPECT_TRUE(info.needsMipmaps);
+  });
+}
+
 // A large leaf under an extreme content scale is cropped to the compositor viewport before
 // rasterization, avoiding an allocation of more than one million pixels per axis.
 TGFX_TEST_PRIVATE(LayerTest, ExtremeZoom_CropsToViewportScale) {

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4505,10 +4505,11 @@ TGFX_TEST_PRIVATE(LayerTest, ExtremeAffineLeaf_KeepsMipmaps) {
     const auto localToCompositor = MakeLocalToCompositorMatrix(
         Matrix3D::MakeScale(1.0e35f, 1.0f, 1.0f), contentScale, renderRect);
     Render3DContext::RasterInfo info;
+    info.mipmapped = false;
 
     ASSERT_TRUE(Render3DContext::ComputeRasterInfo(localToCompositor, localBounds, viewport,
                                                    contentScale, &info));
-    EXPECT_TRUE(info.needsMipmaps);
+    EXPECT_TRUE(info.mipmapped);
   });
 }
 

--- a/test/src/LayerTest.cpp
+++ b/test/src/LayerTest.cpp
@@ -4494,6 +4494,42 @@ TGFX_TEST_PRIVATE(LayerTest, FlatLeaf_PreservesContentScaleSizing) {
   });
 }
 
+// An identity affine mapping rasters 1:1 and samples 1:1, so the offscreen mip chain can be
+// skipped entirely.
+TGFX_TEST_PRIVATE(LayerTest, AffineLeafWithoutMinification_SkipsMipmaps) {
+  TGFX_PRIVATE_ACCESS({
+    const Rect localBounds = Rect::MakeWH(100, 100);
+    const float contentScale = 1.0f;
+    const Rect renderRect = Rect::MakeWH(1000, 1000);
+    const Rect viewport = Rect::MakeWH(renderRect.width(), renderRect.height());
+    const auto localToCompositor =
+        MakeLocalToCompositorMatrix(Matrix3D::I(), contentScale, renderRect);
+    Render3DContext::RasterInfo info;
+
+    ASSERT_TRUE(Render3DContext::ComputeRasterInfo(localToCompositor, localBounds, viewport,
+                                                   contentScale, &info));
+    EXPECT_FALSE(info.mipmapped);
+  });
+}
+
+// A uniformly minified leaf samples its raster at half size, so the mip chain must be retained.
+TGFX_TEST_PRIVATE(LayerTest, MinifiedAffineLeaf_KeepsMipmaps) {
+  TGFX_PRIVATE_ACCESS({
+    const Rect localBounds = Rect::MakeWH(100, 100);
+    const float contentScale = 1.0f;
+    const Rect renderRect = Rect::MakeWH(1000, 1000);
+    const Rect viewport = Rect::MakeWH(renderRect.width(), renderRect.height());
+    const auto localToCompositor = MakeLocalToCompositorMatrix(
+        Matrix3D::MakeScale(0.5f, 0.5f, 1.0f), contentScale, renderRect);
+    Render3DContext::RasterInfo info;
+    info.mipmapped = false;
+
+    ASSERT_TRUE(Render3DContext::ComputeRasterInfo(localToCompositor, localBounds, viewport,
+                                                   contentScale, &info));
+    EXPECT_TRUE(info.mipmapped);
+  });
+}
+
 TGFX_TEST_PRIVATE(LayerTest, ExtremeAffineLeaf_KeepsMipmaps) {
   TGFX_PRIVATE_ACCESS({
     const Rect localBounds = Rect::MakeWH(100, 100);


### PR DESCRIPTION
### 背景

在 3D 渲染中，每个 `preserve3D` 叶子（leaf）都会先栅格化到离屏纹理，再作为多边形参与 BSP 深度合成。此前该离屏纹理**无条件创建完整 mipmap 链**（约 1.33 倍额外像素的显存与生成开销）https://github.com/Tencent/tgfx/pull/1537 ，即使本帧所有方向都不存在缩小（minification），低级别 mip 也不会被采样，这属于纯浪费。

### 方案

在 **3D leaf 离屏纹理创建时**做一次 O(1) 决策：

- 对仿射（无透视项且 W > 0）映射，计算局部到 compositor 的 2×2 Jacobian 的最小奇异值平方 σmin²：
  - **σmin² ≥ 1**：任意方向无缩小 → `mipmapped = false`，跳过 mip 链创建；
  - **σmin² < 1**：存在缩小 → 保守保留 mip 链。
- 透视映射、无效区域、Jacobian 分量非有限、或奇异值平方计算溢出 → **一律保守保留 mip 链**。

采样端保持不变（`Context3DCompositor` 仍使用 `MipmapMode::Linear`）：无缩小时 LOD = 0，单级采样与三线性采样结果逐字节一致，不引入任何质量变化。

### 修改内容

| 文件 | 变更 |
|---|---|
| `src/layers/compositing3d/Render3DContext.h` | `RasterInfo` 新增 `mipmapped` 字段（默认 true 保持保守） |
| `src/layers/compositing3d/Render3DContext.cpp` | 新增 `SmallestSingularValueSquared()` / `NeedsMipmaps()`（位于 `ComputeRasterInfo()` 前的匿名命名空间）；`ComputeRasterInfo()` 计算并写入决策；`rasterLayer()` 将其传入 `Surface::Make(..., mipmapped, ...)` |
| `test/src/LayerTest.cpp` | 新增 `LayerTest.ExtremeAffineLeaf_KeepsMipmaps` 回归测试：Jacobian 分量有限但平方溢出时仍保守创建 mip 链 |

仅影响 3D leaf 离屏 Surface 的 mip 链创建；普通 2D 绘制、2D subtree cache、ImageShader、compositor 目标均不受影响。

### 测试环境与配置

| 项 | 配置 |
|---|---|
| 基线 | `main@3c73f53c`（无条件创建 mip 链） |
| 采样 | 每场景 5 帧预热 + 30 帧采样，取 P50/P90/Max；首帧单独记录 |
| 指标 | total P50/P90/Max、首帧耗时、GPU 显存、像素 FNV-1a 哈希 |

P50（中位数）：把所有帧耗时排序后，处于 50% 位置的数值——一半的帧比它快，一半比它慢。代表"典型帧"的耗时，不受偶发尖峰影响。
P90：处于 90% 位置的数值——90% 的帧比它快，只有 10% 的帧比它慢。代表"偏卡顿但不算极端"的帧。

### 测试内容与结果

基准场景：1200×1000 画布、1600×1600 高频网格源图、Direct 与 Tiled（tileSize=256，Immediate）双模式。

**无缩小仿射（改进生效场景，main → 改进）**

| 场景 | 首帧 ms | total P50 ms | total P90 ms | 显存 MB |
|---|---|---|---|---|
| 1 leaf Direct | 2.564 → **2.391** (-6.7%) | 1.234 → **1.181** (-4.3%) | 1.321 → 1.279 | 35.86 → **32.80** (-8.5%) |
| 1 leaf Tiled | 2.781 → 3.667* | 0.909 → 0.880 | 0.990 → 1.588 | 26.56 → 26.56 |
| 8 leaf Direct | 26.529 → **21.970** (-17.2%) | 3.009 → **2.549** (-15.3%) | 3.167 → **2.716** (-14.2%) | 146.96 → **133.22** (-9.3%) |
| 8 leaf Tiled | 11.441 → **9.370** (-18.1%) | 0.851 → 0.860 | 0.945 → 0.928 | 94.92 → 94.92 |
| 32 leaf Direct | 14.391 → **11.927** (-17.1%) | 8.389 → **5.326** (-36.5%) | 8.841 → **6.090** (-31.1%) | 225.26 → **174.86** (-22.4%) |
| 32 leaf Tiled | 17.960 → **12.315** (-31.4%) | 0.991 → 0.896 | 1.445 → 1.010 | 26.56 → 26.56 |

### 结论

- 静态、无缩放/放大的 3D 内容（UI 卡片墙、图标墙、静态地图等）Direct 渲染 P50 提升 **4%~37%**（leaf 越多越显著），显存峰值下降 **9%~22%**；Tiled 模式首帧 tile 建立提升 17%~31%。
- 缩放/透视动画场景自动保守保留 mip 链，采样质量与像素输出完全不变。