### PR TITLE
Let D3D12Window callers choose between VSync and Immediate present modes on both opaque and transparent paths.

### DIFF
--- a/include/tgfx/gpu/d3d12/D3D12Window.h
+++ b/include/tgfx/gpu/d3d12/D3D12Window.h
@@ -37,6 +37,11 @@ namespace tgfx {
  */
 class D3D12Window : public Window {
  public:
+  enum class PresentMode {
+    VSync,
+    Immediate,
+  };
+
 #ifdef _WIN32
   /**
    * Creates an opaque D3D12Window bound to a Win32 window handle. Contents fully cover the
@@ -46,10 +51,12 @@ class D3D12Window : public Window {
    * @param device The D3D12 device used to create the swap chain resources. Must be non-null.
    * @param colorSpace Optional color space for the output. Only sRGB is currently supported;
    *        any non-sRGB value is ignored with a logged warning.
+   * @param presentMode Controls whether Present waits for vertical synchronization.
    * @return A new D3D12Window, or nullptr if creation failed.
    */
   static std::shared_ptr<D3D12Window> MakeForHwnd(HWND hwnd, std::shared_ptr<D3D12Device> device,
-                                                  std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                                  std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                                  PresentMode presentMode = PresentMode::VSync);
 
   /**
    * Creates a D3D12Window that blends with the desktop and any UI beneath the target hwnd.
@@ -62,11 +69,13 @@ class D3D12Window : public Window {
    * @param device The D3D12 device used to create the swap chain resources. Must be non-null.
    * @param colorSpace Optional color space for the output. Only sRGB is currently supported;
    *        any non-sRGB value is ignored with a logged warning.
+   * @param presentMode Controls whether Present waits for vertical synchronization.
    * @return A new D3D12Window, or nullptr if creation failed.
    */
   static std::shared_ptr<D3D12Window> MakeForComposition(
       HWND hwnd, std::shared_ptr<D3D12Device> device,
-      std::shared_ptr<ColorSpace> colorSpace = nullptr);
+      std::shared_ptr<ColorSpace> colorSpace = nullptr,
+      PresentMode presentMode = PresentMode::VSync);
 #endif
 
   ~D3D12Window() override;
@@ -81,7 +90,7 @@ class D3D12Window : public Window {
 #ifdef _WIN32
   static std::shared_ptr<D3D12Window> MakeImpl(HWND hwnd, std::shared_ptr<D3D12Device> device,
                                                std::shared_ptr<ColorSpace> colorSpace,
-                                               bool transparent);
+                                               bool transparent, PresentMode presentMode);
 #endif
 
   explicit D3D12Window(std::shared_ptr<Device> device, std::unique_ptr<PlatformState> state,

--- a/src/gpu/d3d12/D3D12Window.cpp
+++ b/src/gpu/d3d12/D3D12Window.cpp
@@ -128,6 +128,7 @@ struct D3D12Window::PlatformState {
   HWND hwnd = nullptr;
   int width = 0;
   int height = 0;
+  PresentMode presentMode = PresentMode::VSync;
 
   // currentProxyRaw mirrors the currentProxy owner so onPresent can call releaseFrame without
   // a static_cast from the base RenderTargetProxy. The two are written and cleared together.
@@ -240,18 +241,21 @@ void D3D12Window::PlatformState::detachCompositionTree() {
 
 std::shared_ptr<D3D12Window> D3D12Window::MakeForHwnd(HWND hwnd,
                                                       std::shared_ptr<D3D12Device> device,
-                                                      std::shared_ptr<ColorSpace> colorSpace) {
-  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), false);
+                                                      std::shared_ptr<ColorSpace> colorSpace,
+                                                      PresentMode presentMode) {
+  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), false, presentMode);
 }
 
-std::shared_ptr<D3D12Window> D3D12Window::MakeForComposition(
-    HWND hwnd, std::shared_ptr<D3D12Device> device, std::shared_ptr<ColorSpace> colorSpace) {
-  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), true);
+std::shared_ptr<D3D12Window> D3D12Window::MakeForComposition(HWND hwnd,
+                                                             std::shared_ptr<D3D12Device> device,
+                                                             std::shared_ptr<ColorSpace> colorSpace,
+                                                             PresentMode presentMode) {
+  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), true, presentMode);
 }
 
 std::shared_ptr<D3D12Window> D3D12Window::MakeImpl(HWND hwnd, std::shared_ptr<D3D12Device> device,
                                                    std::shared_ptr<ColorSpace> colorSpace,
-                                                   bool transparent) {
+                                                   bool transparent, PresentMode presentMode) {
   if (hwnd == nullptr || device == nullptr) {
     return nullptr;
   }
@@ -330,6 +334,7 @@ std::shared_ptr<D3D12Window> D3D12Window::MakeImpl(HWND hwnd, std::shared_ptr<D3
   state->hwnd = hwnd;
   state->width = width;
   state->height = height;
+  state->presentMode = presentMode;
   if (transparent) {
     hr = DCompositionCreateDevice(nullptr, IID_PPV_ARGS(state->compositionDevice.GetAddressOf()));
     if (SUCCEEDED(hr)) {
@@ -436,8 +441,10 @@ void D3D12Window::onPresent(Context* /*context*/) {
   if (_platformState->swapChain == nullptr) {
     return;
   }
-  // SyncInterval=1 mirrors VK_PRESENT_MODE_FIFO_KHR (wait for vblank).
-  auto hr = _platformState->swapChain->Present(1, 0);
+  // SyncInterval=1 mirrors VK_PRESENT_MODE_FIFO_KHR (wait for vblank); SyncInterval=0 mirrors
+  // VK_PRESENT_MODE_IMMEDIATE_KHR (present without waiting).
+  auto syncInterval = _platformState->presentMode == PresentMode::VSync ? 1 : 0;
+  auto hr = _platformState->swapChain->Present(syncInterval, 0);
   if (FAILED(hr)) {
     LOGE("D3D12Window: Present failed, HRESULT=0x%08X", static_cast<unsigned>(hr));
   }


### PR DESCRIPTION
为 D3D12Window 增加 PresentMode 枚举（VSync / Immediate），允许调用方在创建窗口时选择垂直同步或立即呈现，覆盖 MakeForHwnd 和 MakeForComposition 两条路径。默认值为 VSync，保持既有行为不变。onPresent 中根据 presentMode 传入相应的 SyncInterval：VSync 对应 SyncInterval=1（等同 VK_PRESENT_MODE_FIFO_KHR），Immediate 对应 SyncInterval=0（等同 VK_PRESENT_MODE_IMMEDIATE_KHR）。
