### PR TITLE
Add maskInverted support to Layer for inverted alpha and luminance masks.

### DIFF
--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -751,7 +751,7 @@ class Layer : public std::enable_shared_from_this<Layer> {
     bool matrix3DIsAffine : 1;  // Whether the matrix3D is equivalent to a 2D affine matrix
     bool staticSubtree : 1;  // Whether the subtree (content, children, filters, styles) is static.
     uint8_t blendMode : 5;
-    uint8_t maskType : 2;
+    uint8_t maskType : 3;
   } bitFields = {};
   std::string _name;
   float _alpha = 1.0f;

--- a/include/tgfx/layers/LayerMaskType.h
+++ b/include/tgfx/layers/LayerMaskType.h
@@ -36,13 +36,15 @@ enum class LayerMaskType {
    */
   Luminance,
   /**
-   * Uses the inverted transparency of the target layer as a mask. The layer content is visible
-   * where the mask is transparent and hidden where the mask is opaque.
+   * Uses the inverted transparency of the target layer as a mask.
    */
   AlphaInverted,
   /**
-   * Uses the inverted luminance of the target layer as a mask. The layer content is visible where
-   * the mask is dark and hidden where the mask is bright.
+   * Uses the inverted contour of the target layer as a mask.
+   */
+  ContourInverted,
+  /**
+   * Uses the inverted luminance of the target layer as a mask.
    */
   LuminanceInverted
 };

--- a/include/tgfx/layers/LayerMaskType.h
+++ b/include/tgfx/layers/LayerMaskType.h
@@ -34,6 +34,16 @@ enum class LayerMaskType {
   /**
    * Uses the target layer's luminance as a mask.
    */
-  Luminance
+  Luminance,
+  /**
+   * Uses the inverted transparency of the target layer as a mask. The layer content is visible
+   * where the mask is transparent and hidden where the mask is opaque.
+   */
+  AlphaInverted,
+  /**
+   * Uses the inverted luminance of the target layer as a mask. The layer content is visible where
+   * the mask is dark and hidden where the mask is bright.
+   */
+  LuminanceInverted
 };
 }  // namespace tgfx

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -94,8 +94,6 @@ static void ClipScrollRect(Canvas* canvas, const Rect* scrollRect, const Matrix3
 struct MaskData {
   MaskData() = default;
 
-  // Creates the result for a mask that covers nothing: hides all content for normal mask types,
-  // but keeps all content for inverted mask types (an inverse-filled empty path clips nothing).
   explicit MaskData(bool inverted) {
     if (inverted) {
       clipPath.toggleInverseFillType();
@@ -1255,11 +1253,13 @@ MaskData Layer::getMaskData(const DrawArgs& args, float scale,
   DEBUG_ASSERT(_mask != nullptr);
   DEBUG_ASSERT(args.render3DContext == nullptr);
   auto maskType = static_cast<LayerMaskType>(bitFields.maskType);
-  auto isContourMode = maskType == LayerMaskType::Contour;
+  auto isContourMode =
+      maskType == LayerMaskType::Contour || maskType == LayerMaskType::ContourInverted;
   bool needLuminance =
       maskType == LayerMaskType::Luminance || maskType == LayerMaskType::LuminanceInverted;
-  bool inverted =
-      maskType == LayerMaskType::AlphaInverted || maskType == LayerMaskType::LuminanceInverted;
+  bool inverted = maskType == LayerMaskType::AlphaInverted ||
+                  maskType == LayerMaskType::LuminanceInverted ||
+                  maskType == LayerMaskType::ContourInverted;
 
   auto relativeMatrix3D = _mask->getRelativeMatrix3D(this);
   auto maskPicture = getMaskPicture(args, isContourMode, scale, relativeMatrix3D);
@@ -1267,8 +1267,6 @@ MaskData Layer::getMaskData(const DrawArgs& args, float scale,
     return MaskData(inverted);
   }
 
-  // Inverted masks take the shader path for now; a geometric fast path using
-  // toggleInverseFillType is left as a future optimization.
   if (!needLuminance && !inverted) {
     Path maskPath = {};
     if (MaskContext::GetMaskPath(maskPicture, &maskPath)) {

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -92,6 +92,20 @@ static void ClipScrollRect(Canvas* canvas, const Rect* scrollRect, const Matrix3
 }
 
 struct MaskData {
+  MaskData() = default;
+
+  // Creates the result for a mask that covers nothing: hides all content for normal mask types,
+  // but keeps all content for inverted mask types (an inverse-filled empty path clips nothing).
+  explicit MaskData(bool inverted) {
+    if (inverted) {
+      clipPath.toggleInverseFillType();
+    }
+  }
+
+  MaskData(Path path, std::shared_ptr<MaskFilter> filter)
+      : clipPath(std::move(path)), maskFilter(std::move(filter)) {
+  }
+
   Path clipPath = {};
   std::shared_ptr<MaskFilter> maskFilter = nullptr;
 };
@@ -1242,15 +1256,20 @@ MaskData Layer::getMaskData(const DrawArgs& args, float scale,
   DEBUG_ASSERT(args.render3DContext == nullptr);
   auto maskType = static_cast<LayerMaskType>(bitFields.maskType);
   auto isContourMode = maskType == LayerMaskType::Contour;
+  bool needLuminance =
+      maskType == LayerMaskType::Luminance || maskType == LayerMaskType::LuminanceInverted;
+  bool inverted =
+      maskType == LayerMaskType::AlphaInverted || maskType == LayerMaskType::LuminanceInverted;
 
   auto relativeMatrix3D = _mask->getRelativeMatrix3D(this);
   auto maskPicture = getMaskPicture(args, isContourMode, scale, relativeMatrix3D);
   if (maskPicture == nullptr) {
-    return {};
+    return MaskData(inverted);
   }
 
-  bool needLuminance = maskType == LayerMaskType::Luminance;
-  if (!needLuminance) {
+  // Inverted masks take the shader path for now; a geometric fast path using
+  // toggleInverseFillType is left as a future optimization.
+  if (!needLuminance && !inverted) {
     Path maskPath = {};
     if (MaskContext::GetMaskPath(maskPicture, &maskPath)) {
       maskPath.transform(Matrix::MakeScale(1.0f / scale, 1.0f / scale));
@@ -1263,14 +1282,14 @@ MaskData Layer::getMaskData(const DrawArgs& args, float scale,
     auto scaledClipBounds = *layerClipBounds;
     scaledClipBounds.scale(scale, scale);
     if (!maskBounds.intersect(scaledClipBounds)) {
-      return {};
+      return MaskData(inverted);
     }
   }
   Point maskImageOffset = {};
   auto maskContentImage =
       ToImageWithOffset(std::move(maskPicture), &maskImageOffset, &maskBounds, args.dstColorSpace);
   if (maskContentImage == nullptr) {
-    return {};
+    return MaskData(inverted);
   }
   if (needLuminance) {
     maskContentImage =
@@ -1283,7 +1302,7 @@ MaskData Layer::getMaskData(const DrawArgs& args, float scale,
   if (shader) {
     shader = shader->makeWithMatrix(maskMatrix);
   }
-  return {{}, MaskFilter::MakeShader(shader)};
+  return {{}, MaskFilter::MakeShader(shader, inverted)};
 }
 
 std::shared_ptr<Image> Layer::getContentContourImage(const DrawArgs& args, float contentScale,

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -255,6 +255,7 @@
         "ChildMask": "351c4df9",
         "HighZoomWithMask_Tiled": "bf48e614",
         "InvalidMask": "bf48e614",
+        "InvertedMask": "9d18f8c1",
         "MaskAlpha": "bf48e614",
         "MaskInvalidation_NoMask": "6d7f38ad",
         "MaskInvalidation_SwitchMask": "92ee56bb",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -255,7 +255,7 @@
         "ChildMask": "351c4df9",
         "HighZoomWithMask_Tiled": "bf48e614",
         "InvalidMask": "bf48e614",
-        "InvertedMask": "9d18f8c1",
+        "InvertedMask": "04225271",
         "MaskAlpha": "bf48e614",
         "MaskInvalidation_NoMask": "6d7f38ad",
         "MaskInvalidation_SwitchMask": "92ee56bb",

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -507,7 +507,22 @@ TGFX_TEST(LayerMaskTest, InvertedMask) {
   list.root()->addChild(orangeContent);
   list.root()->addChild(emptyMask);
 
-  auto surface = Surface::Make(context, 400, 100);
+  // Contour inverted: the content stays visible only outside the mask's contour.
+  auto contourContent = ShapeLayer::Make();
+  contourContent->setPath(contentPath);
+  contourContent->setMatrix(Matrix::MakeTrans(400, 0));
+  contourContent->setFillStyle(ShapeStyle::Make(Color::FromRGBA(255, 128, 0)));
+  auto contourMask = ShapeLayer::Make();
+  contourMask->setPath(halfPath);
+  contourMask->setFillStyle(ShapeStyle::Make(Color::Black()));
+  contourMask->setAlpha(0.5f);
+  contourMask->setMatrix(Matrix::MakeTrans(400, 0));
+  contourContent->setMask(contourMask);
+  contourContent->setMaskType(LayerMaskType::ContourInverted);
+  list.root()->addChild(contourContent);
+  list.root()->addChild(contourMask);
+
+  auto surface = Surface::Make(context, 500, 100);
   list.render(surface.get());
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/InvertedMask"));
 }

--- a/test/src/LayerMaskTest.cpp
+++ b/test/src/LayerMaskTest.cpp
@@ -437,6 +437,81 @@ TGFX_TEST(LayerMaskTest, MaskAlpha) {
   EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/MaskAlpha"));
 }
 
+TGFX_TEST(LayerMaskTest, InvertedMask) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+
+  Path contentPath;
+  contentPath.addRect(Rect::MakeWH(100, 100));
+  Path halfPath;
+  halfPath.addRect(Rect::MakeWH(50, 100));
+
+  // Alpha inverted: the content stays visible only where the mask is transparent.
+  auto alphaContent = ShapeLayer::Make();
+  alphaContent->setPath(contentPath);
+  alphaContent->setFillStyle(ShapeStyle::Make(Color::Green()));
+  auto alphaMask = ShapeLayer::Make();
+  alphaMask->setPath(halfPath);
+  alphaMask->setFillStyle(ShapeStyle::Make(Color::Red()));
+  alphaContent->setMask(alphaMask);
+  alphaContent->setMaskType(LayerMaskType::AlphaInverted);
+  list.root()->addChild(alphaContent);
+  list.root()->addChild(alphaMask);
+
+  // Luminance inverted: the content stays visible where the mask luminance is low.
+  auto lumaContent = ShapeLayer::Make();
+  lumaContent->setPath(contentPath);
+  lumaContent->setMatrix(Matrix::MakeTrans(100, 0));
+  lumaContent->setFillStyle(ShapeStyle::Make(Color::Blue()));
+  auto lumaMask = Layer::Make();
+  auto whiteHalf = ShapeLayer::Make();
+  whiteHalf->setPath(halfPath);
+  whiteHalf->setFillStyle(ShapeStyle::Make(Color::White()));
+  auto blackHalf = ShapeLayer::Make();
+  blackHalf->setPath(halfPath);
+  blackHalf->setMatrix(Matrix::MakeTrans(50, 0));
+  blackHalf->setFillStyle(ShapeStyle::Make(Color::Black()));
+  lumaMask->addChild(whiteHalf);
+  lumaMask->addChild(blackHalf);
+  lumaMask->setMatrix(Matrix::MakeTrans(100, 0));
+  lumaContent->setMask(lumaMask);
+  lumaContent->setMaskType(LayerMaskType::LuminanceInverted);
+  list.root()->addChild(lumaContent);
+  list.root()->addChild(lumaMask);
+
+  // Alpha inverted with an empty mask intersection: the content stays fully visible.
+  auto redContent = ShapeLayer::Make();
+  redContent->setPath(contentPath);
+  redContent->setMatrix(Matrix::MakeTrans(200, 0));
+  redContent->setFillStyle(ShapeStyle::Make(Color::Red()));
+  auto disjointMask = ShapeLayer::Make();
+  disjointMask->setPath(halfPath);
+  disjointMask->setMatrix(Matrix::MakeTrans(0, 200));
+  disjointMask->setFillStyle(ShapeStyle::Make(Color::Black()));
+  redContent->setMask(disjointMask);
+  redContent->setMaskType(LayerMaskType::AlphaInverted);
+  list.root()->addChild(redContent);
+  list.root()->addChild(disjointMask);
+
+  // Alpha inverted with a mask that draws nothing: the content stays fully visible.
+  auto orangeContent = ShapeLayer::Make();
+  orangeContent->setPath(contentPath);
+  orangeContent->setMatrix(Matrix::MakeTrans(300, 0));
+  orangeContent->setFillStyle(ShapeStyle::Make(Color::FromRGBA(255, 128, 0)));
+  auto emptyMask = ShapeLayer::Make();
+  emptyMask->setFillStyle(ShapeStyle::Make(Color::Black()));
+  orangeContent->setMask(emptyMask);
+  orangeContent->setMaskType(LayerMaskType::AlphaInverted);
+  list.root()->addChild(orangeContent);
+  list.root()->addChild(emptyMask);
+
+  auto surface = Surface::Make(context, 400, 100);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "LayerMaskTest/InvertedMask"));
+}
+
 TGFX_TEST(LayerMaskTest, ChildMask) {
   ContextScope scope;
   auto context = scope.getContext();


### PR DESCRIPTION
PAGX的轨道遮罩目前缺乏AlphaInverted 和 LumaInverted 两种反转模式，tgfx添加layer支持反转遮罩用来支持PAGX添加相关功能