### PR TITLE
Add fixed vsync option to Window creation across backends

### DIFF
--- a/include/tgfx/gpu/Window.h
+++ b/include/tgfx/gpu/Window.h
@@ -48,33 +48,23 @@ class Window {
   std::shared_ptr<ColorSpace> colorSpace() const;
 
   /**
-   * Enables or disables vertical synchronization for presentation. When enabled (the default),
-   * presentation is throttled to the display's refresh rate. When disabled, the calling thread is
-   * no longer blocked by the display's vsync during present, which is useful when that thread must
-   * not stall (for example a UI callback thread). The exact effect depends on the backend and the
-   * underlying platform; backends that cannot control vsync ignore this setting. Takes effect on
-   * the next present.
-   *
-   * Backend note: some backends (for example Vulkan and WebGPU) apply the new setting by rebuilding
-   * their swap chain, which only happens when the render target is recreated. On those backends the
-   * caller must recreate the Surface (via Surface::MakeFrom) after changing this setting for it to
-   * take effect. Backends that switch the swap interval at present time (D3D12, WGL, EGL, CGL,
-   * Metal) apply the change on the next present without recreating the Surface.
+   * Returns whether vertical synchronization is enabled for presentation. This is fixed when the
+   * Window is created (defaults to true) and cannot be changed afterwards. When enabled,
+   * presentation is throttled to the display's refresh rate. When disabled, the presenting thread
+   * is no longer blocked by the display's vsync, which is useful when that thread must not stall
+   * (for example a UI callback thread). The exact effect depends on the backend and the underlying
+   * platform; backends that cannot control vsync ignore this setting.
    */
-  void setVSyncEnabled(bool enabled);
-
-  /**
-   * Returns whether vertical synchronization is enabled for presentation. Defaults to true.
-   */
-  bool vsyncEnabled();
+  bool vsyncEnabled() const;
 
  protected:
   std::mutex locker = {};
   std::shared_ptr<Device> device = nullptr;
   std::shared_ptr<ColorSpace> _colorSpace = nullptr;
-  bool _vsyncEnabled = true;
+  const bool _vsyncEnabled = true;
 
-  explicit Window(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace = nullptr);
+  explicit Window(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                  bool vsyncEnabled = true);
   Window() = default;
 
   /**
@@ -89,13 +79,6 @@ class Window {
    * implementation does nothing.
    */
   virtual void onPresent(Context* context);
-
-  /**
-   * Called when the vsync setting changes via setVSyncEnabled(). Subclasses that must react
-   * immediately (for example by rebuilding a swap chain) override this. Invoked while holding the
-   * window lock. The default implementation does nothing.
-   */
-  virtual void onVSyncEnabledChanged(bool enabled);
 
  private:
   friend class DrawingBuffer;

--- a/include/tgfx/gpu/Window.h
+++ b/include/tgfx/gpu/Window.h
@@ -47,10 +47,32 @@ class Window {
    */
   std::shared_ptr<ColorSpace> colorSpace() const;
 
+  /**
+   * Enables or disables vertical synchronization for presentation. When enabled (the default),
+   * presentation is throttled to the display's refresh rate. When disabled, the calling thread is
+   * no longer blocked by the display's vsync during present, which is useful when that thread must
+   * not stall (for example a UI callback thread). The exact effect depends on the backend and the
+   * underlying platform; backends that cannot control vsync ignore this setting. Takes effect on
+   * the next present.
+   *
+   * Backend note: some backends (for example Vulkan and WebGPU) apply the new setting by rebuilding
+   * their swap chain, which only happens when the render target is recreated. On those backends the
+   * caller must recreate the Surface (via Surface::MakeFrom) after changing this setting for it to
+   * take effect. Backends that switch the swap interval at present time (D3D12, WGL, EGL, CGL,
+   * Metal) apply the change on the next present without recreating the Surface.
+   */
+  void setVSyncEnabled(bool enabled);
+
+  /**
+   * Returns whether vertical synchronization is enabled for presentation. Defaults to true.
+   */
+  bool vsyncEnabled();
+
  protected:
   std::mutex locker = {};
   std::shared_ptr<Device> device = nullptr;
   std::shared_ptr<ColorSpace> _colorSpace = nullptr;
+  bool _vsyncEnabled = true;
 
   explicit Window(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace = nullptr);
   Window() = default;
@@ -67,6 +89,13 @@ class Window {
    * implementation does nothing.
    */
   virtual void onPresent(Context* context);
+
+  /**
+   * Called when the vsync setting changes via setVSyncEnabled(). Subclasses that must react
+   * immediately (for example by rebuilding a swap chain) override this. Invoked while holding the
+   * window lock. The default implementation does nothing.
+   */
+  virtual void onVSyncEnabledChanged(bool enabled);
 
  private:
   friend class DrawingBuffer;

--- a/include/tgfx/gpu/d3d12/D3D12Window.h
+++ b/include/tgfx/gpu/d3d12/D3D12Window.h
@@ -46,10 +46,13 @@ class D3D12Window : public Window {
    * @param device The D3D12 device used to create the swap chain resources. Must be non-null.
    * @param colorSpace Optional color space for the output. Only sRGB is currently supported;
    *        any non-sRGB value is ignored with a logged warning.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   *        for the lifetime of the window. Defaults to true.
    * @return A new D3D12Window, or nullptr if creation failed.
    */
   static std::shared_ptr<D3D12Window> MakeForHwnd(HWND hwnd, std::shared_ptr<D3D12Device> device,
-                                                  std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                                  std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                                  bool vsyncEnabled = true);
 
   /**
    * Creates a D3D12Window that blends with the desktop and any UI beneath the target hwnd.
@@ -62,11 +65,13 @@ class D3D12Window : public Window {
    * @param device The D3D12 device used to create the swap chain resources. Must be non-null.
    * @param colorSpace Optional color space for the output. Only sRGB is currently supported;
    *        any non-sRGB value is ignored with a logged warning.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   *        for the lifetime of the window. Defaults to true.
    * @return A new D3D12Window, or nullptr if creation failed.
    */
   static std::shared_ptr<D3D12Window> MakeForComposition(
       HWND hwnd, std::shared_ptr<D3D12Device> device,
-      std::shared_ptr<ColorSpace> colorSpace = nullptr);
+      std::shared_ptr<ColorSpace> colorSpace = nullptr, bool vsyncEnabled = true);
 #endif
 
   ~D3D12Window() override;
@@ -81,11 +86,11 @@ class D3D12Window : public Window {
 #ifdef _WIN32
   static std::shared_ptr<D3D12Window> MakeImpl(HWND hwnd, std::shared_ptr<D3D12Device> device,
                                                std::shared_ptr<ColorSpace> colorSpace,
-                                               bool transparent);
+                                               bool transparent, bool vsyncEnabled);
 #endif
 
   explicit D3D12Window(std::shared_ptr<Device> device, std::unique_ptr<PlatformState> state,
-                       std::shared_ptr<ColorSpace> colorSpace);
+                       std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled);
 
   std::unique_ptr<PlatformState> _platformState;
 };

--- a/include/tgfx/gpu/metal/MetalWindow.h
+++ b/include/tgfx/gpu/metal/MetalWindow.h
@@ -35,23 +35,28 @@ class MetalWindow : public Window {
    * @param layer The CAMetalLayer to render into. Must not be nil.
    * @param device An optional MetalDevice. If nullptr, a default device is created automatically.
    * @param colorSpace An optional color space for rendering. If nullptr, the default sRGB is used.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true.
    */
   static std::shared_ptr<MetalWindow> MakeFrom(CAMetalLayer* layer,
                                                std::shared_ptr<MetalDevice> device = nullptr,
-                                               std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                               std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                               bool vsyncEnabled = true);
 
   /**
    * Creates a new window from an MTKView.
    * @param view The MTKView to render into. Must not be nil.
    * @param colorSpace An optional color space for rendering. If nullptr, the default sRGB is used.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true.
    */
   static std::shared_ptr<MetalWindow> MakeFrom(MTKView* view,
-                                               std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                               std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                               bool vsyncEnabled = true);
 
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
   void onPresent(Context* context) override;
-  void onVSyncEnabledChanged(bool enabled) override;
 
  private:
   CAMetalLayer* metalLayer = nil;
@@ -59,9 +64,9 @@ class MetalWindow : public Window {
   std::shared_ptr<RenderTargetProxy> drawableProxy = nullptr;
 
   MetalWindow(std::shared_ptr<Device> device, CAMetalLayer* layer,
-              std::shared_ptr<ColorSpace> colorSpace);
+              std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled);
   MetalWindow(std::shared_ptr<Device> device, MTKView* view, CAMetalLayer* layer,
-              std::shared_ptr<ColorSpace> colorSpace);
+              std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled);
 };
 
 }  // namespace tgfx

--- a/include/tgfx/gpu/metal/MetalWindow.h
+++ b/include/tgfx/gpu/metal/MetalWindow.h
@@ -51,6 +51,7 @@ class MetalWindow : public Window {
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
   void onPresent(Context* context) override;
+  void onVSyncEnabledChanged(bool enabled) override;
 
  private:
   CAMetalLayer* metalLayer = nil;

--- a/include/tgfx/gpu/opengl/cgl/CGLWindow.h
+++ b/include/tgfx/gpu/opengl/cgl/CGLWindow.h
@@ -26,9 +26,15 @@ class CGLWindow : public Window {
  public:
   /**
    * Creates a new window from an NSView with specified shared context.
+   * @param view The NSView to render into. Must not be nil.
+   * @param sharedContext An optional shared CGL context.
+   * @param colorSpace An optional color space for rendering. If nullptr, the default sRGB is used.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true.
    */
   static std::shared_ptr<CGLWindow> MakeFrom(NSView* view, CGLContextObj sharedContext = nullptr,
-                                             std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                             std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                             bool vsyncEnabled = true);
 
   ~CGLWindow() override;
 
@@ -38,11 +44,8 @@ class CGLWindow : public Window {
 
  private:
   NSView* view = nil;
-  // Tracks the swap interval last applied via NSOpenGLContextParameterSwapInterval so onPresent
-  // only sets it when the vsync setting actually changes. -1 means not yet applied.
-  int appliedSwapInterval = -1;
 
-  CGLWindow(std::shared_ptr<Device> device, NSView* view,
-            std::shared_ptr<ColorSpace> colorSpace = nullptr);
+  CGLWindow(std::shared_ptr<Device> device, NSView* view, std::shared_ptr<ColorSpace> colorSpace,
+            bool vsyncEnabled);
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/cgl/CGLWindow.h
+++ b/include/tgfx/gpu/opengl/cgl/CGLWindow.h
@@ -38,6 +38,9 @@ class CGLWindow : public Window {
 
  private:
   NSView* view = nil;
+  // Tracks the swap interval last applied via NSOpenGLContextParameterSwapInterval so onPresent
+  // only sets it when the vsync setting actually changes. -1 means not yet applied.
+  int appliedSwapInterval = -1;
 
   CGLWindow(std::shared_ptr<Device> device, NSView* view,
             std::shared_ptr<ColorSpace> colorSpace = nullptr);

--- a/include/tgfx/gpu/opengl/egl/EGLWindow.h
+++ b/include/tgfx/gpu/opengl/egl/EGLWindow.h
@@ -52,6 +52,9 @@ class EGLWindow : public Window {
  private:
   EGLNativeWindowType nativeWindow;
   std::optional<int64_t> presentationTime = std::nullopt;
+  // Tracks the swap interval last applied via eglSwapInterval so onPresent only calls it when the
+  // vsync setting actually changes. -1 means no interval has been applied yet.
+  int appliedSwapInterval = -1;
 
   explicit EGLWindow(std::shared_ptr<Device> device,
                      std::shared_ptr<ColorSpace> colorSpace = nullptr);

--- a/include/tgfx/gpu/opengl/egl/EGLWindow.h
+++ b/include/tgfx/gpu/opengl/egl/EGLWindow.h
@@ -33,10 +33,16 @@ class EGLWindow : public Window {
 
   /**
    * Creates a new window from an EGL native window with specified shared context.
+   * @param nativeWindow The native window to render into.
+   * @param sharedContext An optional shared EGL context.
+   * @param colorSpace An optional color space for rendering. If nullptr, the default sRGB is used.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true.
    */
   static std::shared_ptr<EGLWindow> MakeFrom(EGLNativeWindowType nativeWindow,
                                              EGLContext sharedContext = nullptr,
-                                             std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                             std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                             bool vsyncEnabled = true);
 
   /**
    * Sets the presentation time for the next frame in microseconds. This is only applicable on
@@ -52,11 +58,11 @@ class EGLWindow : public Window {
  private:
   EGLNativeWindowType nativeWindow;
   std::optional<int64_t> presentationTime = std::nullopt;
-  // Tracks the swap interval last applied via eglSwapInterval so onPresent only calls it when the
-  // vsync setting actually changes. -1 means no interval has been applied yet.
-  int appliedSwapInterval = -1;
+  // eglSwapInterval requires the context to be current, which is only guaranteed at present time,
+  // so the fixed vsync setting is applied once on the first present.
+  bool swapIntervalApplied = false;
 
   explicit EGLWindow(std::shared_ptr<Device> device,
-                     std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                     std::shared_ptr<ColorSpace> colorSpace = nullptr, bool vsyncEnabled = true);
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/opengl/wgl/WGLWindow.h
+++ b/include/tgfx/gpu/opengl/wgl/WGLWindow.h
@@ -36,6 +36,9 @@ class WGLWindow : public Window {
 
  private:
   HWND nativeWindow = nullptr;
+  // Tracks the swap interval last applied via wglSwapInterval so onPresent only calls it when the
+  // vsync setting actually changes. -1 means no interval has been applied yet.
+  int appliedSwapInterval = -1;
 
   explicit WGLWindow(std::shared_ptr<Device> device,
                      std::shared_ptr<ColorSpace> colorSpace = nullptr);

--- a/include/tgfx/gpu/opengl/wgl/WGLWindow.h
+++ b/include/tgfx/gpu/opengl/wgl/WGLWindow.h
@@ -26,9 +26,15 @@ class WGLWindow : public Window {
  public:
   /**
    * Creates a new window from a HWND with specialed shared context.
+   * @param nativeWindow The native window handle to render into.
+   * @param sharedContext An optional shared WGL context.
+   * @param colorSpace An optional color space for rendering. If nullptr, the default sRGB is used.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true.
    */
   static std::shared_ptr<WGLWindow> MakeFrom(HWND nativeWindow, HGLRC sharedContext = nullptr,
-                                             std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                             std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                             bool vsyncEnabled = true);
 
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
@@ -36,11 +42,11 @@ class WGLWindow : public Window {
 
  private:
   HWND nativeWindow = nullptr;
-  // Tracks the swap interval last applied via wglSwapInterval so onPresent only calls it when the
-  // vsync setting actually changes. -1 means no interval has been applied yet.
-  int appliedSwapInterval = -1;
+  // wglSwapInterval requires the context to be current, which is only guaranteed at present time,
+  // so the fixed vsync setting is applied once on the first present.
+  bool swapIntervalApplied = false;
 
   explicit WGLWindow(std::shared_ptr<Device> device,
-                     std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                     std::shared_ptr<ColorSpace> colorSpace = nullptr, bool vsyncEnabled = true);
 };
 }  // namespace tgfx

--- a/include/tgfx/gpu/vulkan/VulkanWindow.h
+++ b/include/tgfx/gpu/vulkan/VulkanWindow.h
@@ -50,20 +50,24 @@ class VulkanWindow : public Window {
    * Creates a VulkanWindow from a Win32 window handle. Returns nullptr if the Vulkan surface or
    * swapchain cannot be created. Note: only sRGB output is currently supported. The colorSpace
    * parameter is accepted for forward compatibility but non-sRGB values are ignored with a warning.
-   * HDR / Display-P3 support will be added in a follow-up.
+   * HDR / Display-P3 support will be added in a follow-up. The vsyncEnabled setting is fixed for
+   * the lifetime of the window and defaults to true.
    */
   static std::shared_ptr<VulkanWindow> MakeFrom(HWND hwnd, std::shared_ptr<VulkanDevice> device,
-                                                std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                                std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                                bool vsyncEnabled = true);
 #endif
 
 #ifdef __OHOS__
   /**
    * Creates a VulkanWindow from an OHOS NativeWindow. Returns nullptr if the Vulkan surface or
-   * swapchain cannot be created. Note: only sRGB output is currently supported.
+   * swapchain cannot be created. Note: only sRGB output is currently supported. The vsyncEnabled
+   * setting is fixed for the lifetime of the window and defaults to true.
    */
   static std::shared_ptr<VulkanWindow> MakeFrom(OHNativeWindow* nativeWindow,
                                                 std::shared_ptr<VulkanDevice> device,
-                                                std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                                std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                                bool vsyncEnabled = true);
 #endif
 
 #ifdef __ANDROID__
@@ -76,10 +80,13 @@ class VulkanWindow : public Window {
    * null.
    * @param colorSpace The desired color space for the swapchain images. Defaults to sRGB when
    * nullptr is passed.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true.
    */
   static std::shared_ptr<VulkanWindow> MakeFrom(ANativeWindow* nativeWindow,
                                                 std::shared_ptr<VulkanDevice> device,
-                                                std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                                std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                                bool vsyncEnabled = true);
 #endif
 
   ~VulkanWindow() override;
@@ -87,7 +94,6 @@ class VulkanWindow : public Window {
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
   void onPresent(Context* context) override;
-  void onVSyncEnabledChanged(bool enabled) override;
 
  private:
   // PImpl: all Vulkan handles and swapchain state live in PlatformState (defined in .cpp) to avoid
@@ -96,7 +102,7 @@ class VulkanWindow : public Window {
   struct PlatformState;
 
   explicit VulkanWindow(std::shared_ptr<Device> device, std::unique_ptr<PlatformState> state,
-                        std::shared_ptr<ColorSpace> colorSpace);
+                        std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled);
 
   std::unique_ptr<PlatformState> _platformState;
 };

--- a/include/tgfx/gpu/vulkan/VulkanWindow.h
+++ b/include/tgfx/gpu/vulkan/VulkanWindow.h
@@ -87,6 +87,7 @@ class VulkanWindow : public Window {
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
   void onPresent(Context* context) override;
+  void onVSyncEnabledChanged(bool enabled) override;
 
  private:
   // PImpl: all Vulkan handles and swapchain state live in PlatformState (defined in .cpp) to avoid

--- a/include/tgfx/gpu/webgpu/WebGPUWindow.h
+++ b/include/tgfx/gpu/webgpu/WebGPUWindow.h
@@ -37,15 +37,14 @@ class WebGPUWindow : public Window {
    * supported.
    * On Web, the final executable must export the WebGPU runtime method (see the Web build section
    * in README.md); otherwise color space configuration and video texture uploads will not work.
-   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
-   * for the lifetime of the window. Defaults to true. Note: in a browser, the compositor may cap
-   * presentation to the display refresh rate regardless of this setting; Immediate is honored only
-   * where the implementation supports it (e.g. native Dawn).
+   *
+   * Note: this backend does not expose a vsync option. Browser canvas presentation only supports
+   * Fifo, so presentation is always synchronized to the display refresh rate and vsyncEnabled()
+   * always returns true.
    */
   static std::shared_ptr<WebGPUWindow> MakeFrom(const std::string& canvasSelector,
                                                 std::shared_ptr<WebGPUDevice> device = nullptr,
-                                                std::shared_ptr<ColorSpace> colorSpace = nullptr,
-                                                bool vsyncEnabled = true);
+                                                std::shared_ptr<ColorSpace> colorSpace = nullptr);
 
   ~WebGPUWindow() override;
 
@@ -55,8 +54,7 @@ class WebGPUWindow : public Window {
 
  private:
   WebGPUWindow(std::shared_ptr<Device> device, void* surface, int width, int height,
-               const std::string& canvasSelector, std::shared_ptr<ColorSpace> colorSpace,
-               bool vsyncEnabled);
+               const std::string& canvasSelector, std::shared_ptr<ColorSpace> colorSpace);
 
   // Configures the canvas's WebGPU context to use the target color space. Must be called after
   // each wgpuSurfaceConfigure() call, since the emscripten surface configuration does not carry
@@ -70,8 +68,6 @@ class WebGPUWindow : public Window {
   int _height = 0;
   int _configuredWidth = 0;
   int _configuredHeight = 0;
-  // Present mode applied to the surface, fixed at creation (Fifo for vsync on, Immediate for off).
-  WGPUPresentMode _presentMode = WGPUPresentMode_Fifo;
   std::shared_ptr<RenderTargetProxy> drawableProxy = nullptr;
 };
 

--- a/include/tgfx/gpu/webgpu/WebGPUWindow.h
+++ b/include/tgfx/gpu/webgpu/WebGPUWindow.h
@@ -47,6 +47,7 @@ class WebGPUWindow : public Window {
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
   void onPresent(Context* context) override;
+  void onVSyncEnabledChanged(bool enabled) override;
 
  private:
   WebGPUWindow(std::shared_ptr<Device> device, void* surface, int width, int height,
@@ -64,6 +65,10 @@ class WebGPUWindow : public Window {
   int _height = 0;
   int _configuredWidth = 0;
   int _configuredHeight = 0;
+  // Present mode currently applied to the surface. Defaults to Fifo (vsync on). onVSyncEnabledChanged
+  // updates it and flags a reconfigure so onCreateRenderTarget re-applies it.
+  WGPUPresentMode _presentMode = WGPUPresentMode_Fifo;
+  bool _presentModeDirty = false;
   std::shared_ptr<RenderTargetProxy> drawableProxy = nullptr;
 };
 

--- a/include/tgfx/gpu/webgpu/WebGPUWindow.h
+++ b/include/tgfx/gpu/webgpu/WebGPUWindow.h
@@ -37,21 +37,26 @@ class WebGPUWindow : public Window {
    * supported.
    * On Web, the final executable must export the WebGPU runtime method (see the Web build section
    * in README.md); otherwise color space configuration and video texture uploads will not work.
+   * @param vsyncEnabled Whether presentation is synchronized to the display's refresh rate. Fixed
+   * for the lifetime of the window. Defaults to true. Note: in a browser, the compositor may cap
+   * presentation to the display refresh rate regardless of this setting; Immediate is honored only
+   * where the implementation supports it (e.g. native Dawn).
    */
   static std::shared_ptr<WebGPUWindow> MakeFrom(const std::string& canvasSelector,
                                                 std::shared_ptr<WebGPUDevice> device = nullptr,
-                                                std::shared_ptr<ColorSpace> colorSpace = nullptr);
+                                                std::shared_ptr<ColorSpace> colorSpace = nullptr,
+                                                bool vsyncEnabled = true);
 
   ~WebGPUWindow() override;
 
  protected:
   std::shared_ptr<RenderTargetProxy> onCreateRenderTarget(Context* context) override;
   void onPresent(Context* context) override;
-  void onVSyncEnabledChanged(bool enabled) override;
 
  private:
   WebGPUWindow(std::shared_ptr<Device> device, void* surface, int width, int height,
-               const std::string& canvasSelector, std::shared_ptr<ColorSpace> colorSpace);
+               const std::string& canvasSelector, std::shared_ptr<ColorSpace> colorSpace,
+               bool vsyncEnabled);
 
   // Configures the canvas's WebGPU context to use the target color space. Must be called after
   // each wgpuSurfaceConfigure() call, since the emscripten surface configuration does not carry
@@ -65,10 +70,8 @@ class WebGPUWindow : public Window {
   int _height = 0;
   int _configuredWidth = 0;
   int _configuredHeight = 0;
-  // Present mode currently applied to the surface. Defaults to Fifo (vsync on). onVSyncEnabledChanged
-  // updates it and flags a reconfigure so onCreateRenderTarget re-applies it.
+  // Present mode applied to the surface, fixed at creation (Fifo for vsync on, Immediate for off).
   WGPUPresentMode _presentMode = WGPUPresentMode_Fifo;
-  bool _presentModeDirty = false;
   std::shared_ptr<RenderTargetProxy> drawableProxy = nullptr;
 };
 

--- a/src/gpu/Window.cpp
+++ b/src/gpu/Window.cpp
@@ -28,11 +28,28 @@ std::shared_ptr<ColorSpace> Window::colorSpace() const {
   return _colorSpace;
 }
 
+void Window::setVSyncEnabled(bool enabled) {
+  std::lock_guard<std::mutex> autoLock(locker);
+  if (_vsyncEnabled == enabled) {
+    return;
+  }
+  _vsyncEnabled = enabled;
+  onVSyncEnabledChanged(enabled);
+}
+
+bool Window::vsyncEnabled() {
+  std::lock_guard<std::mutex> autoLock(locker);
+  return _vsyncEnabled;
+}
+
 std::shared_ptr<Device> Window::getDevice() {
   std::lock_guard<std::mutex> autoLock(locker);
   return device;
 }
 
 void Window::onPresent(Context*) {
+}
+
+void Window::onVSyncEnabledChanged(bool) {
 }
 }  // namespace tgfx

--- a/src/gpu/Window.cpp
+++ b/src/gpu/Window.cpp
@@ -20,25 +20,16 @@
 #include "tgfx/gpu/Device.h"
 
 namespace tgfx {
-Window::Window(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace)
-    : device(std::move(device)), _colorSpace(std::move(colorSpace)) {
+Window::Window(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace,
+               bool vsyncEnabled)
+    : device(std::move(device)), _colorSpace(std::move(colorSpace)), _vsyncEnabled(vsyncEnabled) {
 }
 
 std::shared_ptr<ColorSpace> Window::colorSpace() const {
   return _colorSpace;
 }
 
-void Window::setVSyncEnabled(bool enabled) {
-  std::lock_guard<std::mutex> autoLock(locker);
-  if (_vsyncEnabled == enabled) {
-    return;
-  }
-  _vsyncEnabled = enabled;
-  onVSyncEnabledChanged(enabled);
-}
-
-bool Window::vsyncEnabled() {
-  std::lock_guard<std::mutex> autoLock(locker);
+bool Window::vsyncEnabled() const {
   return _vsyncEnabled;
 }
 
@@ -48,8 +39,5 @@ std::shared_ptr<Device> Window::getDevice() {
 }
 
 void Window::onPresent(Context*) {
-}
-
-void Window::onVSyncEnabledChanged(bool) {
 }
 }  // namespace tgfx

--- a/src/gpu/d3d12/D3D12Window.cpp
+++ b/src/gpu/d3d12/D3D12Window.cpp
@@ -240,18 +240,21 @@ void D3D12Window::PlatformState::detachCompositionTree() {
 
 std::shared_ptr<D3D12Window> D3D12Window::MakeForHwnd(HWND hwnd,
                                                       std::shared_ptr<D3D12Device> device,
-                                                      std::shared_ptr<ColorSpace> colorSpace) {
-  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), false);
+                                                      std::shared_ptr<ColorSpace> colorSpace,
+                                                      bool vsyncEnabled) {
+  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), false, vsyncEnabled);
 }
 
-std::shared_ptr<D3D12Window> D3D12Window::MakeForComposition(
-    HWND hwnd, std::shared_ptr<D3D12Device> device, std::shared_ptr<ColorSpace> colorSpace) {
-  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), true);
+std::shared_ptr<D3D12Window> D3D12Window::MakeForComposition(HWND hwnd,
+                                                             std::shared_ptr<D3D12Device> device,
+                                                             std::shared_ptr<ColorSpace> colorSpace,
+                                                             bool vsyncEnabled) {
+  return MakeImpl(hwnd, std::move(device), std::move(colorSpace), true, vsyncEnabled);
 }
 
 std::shared_ptr<D3D12Window> D3D12Window::MakeImpl(HWND hwnd, std::shared_ptr<D3D12Device> device,
                                                    std::shared_ptr<ColorSpace> colorSpace,
-                                                   bool transparent) {
+                                                   bool transparent, bool vsyncEnabled) {
   if (hwnd == nullptr || device == nullptr) {
     return nullptr;
   }
@@ -367,14 +370,16 @@ std::shared_ptr<D3D12Window> D3D12Window::MakeImpl(HWND hwnd, std::shared_ptr<D3
   }
 
   device->unlock();
-  return std::shared_ptr<D3D12Window>(new D3D12Window(device, std::move(state), colorSpace));
+  return std::shared_ptr<D3D12Window>(
+      new D3D12Window(device, std::move(state), colorSpace, vsyncEnabled));
 }
 
 #endif
 
 D3D12Window::D3D12Window(std::shared_ptr<Device> device, std::unique_ptr<PlatformState> state,
-                         std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)), _platformState(std::move(state)) {
+                         std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled),
+      _platformState(std::move(state)) {
 }
 
 D3D12Window::~D3D12Window() {

--- a/src/gpu/d3d12/D3D12Window.cpp
+++ b/src/gpu/d3d12/D3D12Window.cpp
@@ -436,8 +436,14 @@ void D3D12Window::onPresent(Context* /*context*/) {
   if (_platformState->swapChain == nullptr) {
     return;
   }
-  // SyncInterval=1 mirrors VK_PRESENT_MODE_FIFO_KHR (wait for vblank).
-  auto hr = _platformState->swapChain->Present(1, 0);
+  bool vsync = vsyncEnabled();
+  // With vsync on, SyncInterval=1 mirrors VK_PRESENT_MODE_FIFO_KHR (wait for vblank). With vsync
+  // off, SyncInterval=0 does NOT tear or present early here: the swap chain is created without
+  // DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING, so in windowed mode DWM still composites at vsync. It only
+  // releases the present call from blocking on vblank (intermediate frames may be dropped by DWM),
+  // which is what callers whose present thread must not stall on vsync need.
+  UINT syncInterval = vsync ? 1u : 0u;
+  auto hr = _platformState->swapChain->Present(syncInterval, 0);
   if (FAILED(hr)) {
     LOGE("D3D12Window: Present failed, HRESULT=0x%08X", static_cast<unsigned>(hr));
   }

--- a/src/gpu/metal/MetalWindow.mm
+++ b/src/gpu/metal/MetalWindow.mm
@@ -119,4 +119,14 @@ void MetalWindow::onPresent(Context*) {
   proxy->releaseDrawable();
 }
 
+void MetalWindow::onVSyncEnabledChanged(bool enabled) {
+#if TARGET_OS_OSX
+  // displaySyncEnabled only exists on macOS; on iOS/tvOS presentation is always synchronized to
+  // the display and cannot be disabled, so this is a no-op there.
+  metalLayer.displaySyncEnabled = enabled ? YES : NO;
+#else
+  (void)enabled;
+#endif
+}
+
 }  // namespace tgfx

--- a/src/gpu/metal/MetalWindow.mm
+++ b/src/gpu/metal/MetalWindow.mm
@@ -36,7 +36,8 @@ static void ApplyColorSpace(CAMetalLayer* layer, const std::shared_ptr<ColorSpac
 
 std::shared_ptr<MetalWindow> MetalWindow::MakeFrom(CAMetalLayer* layer,
                                                    std::shared_ptr<MetalDevice> device,
-                                                   std::shared_ptr<ColorSpace> colorSpace) {
+                                                   std::shared_ptr<ColorSpace> colorSpace,
+                                                   bool vsyncEnabled) {
   if (layer == nil) {
     return nullptr;
   }
@@ -54,11 +55,13 @@ std::shared_ptr<MetalWindow> MetalWindow::MakeFrom(CAMetalLayer* layer,
     layer.device = (__bridge id<MTLDevice>)device->metalDevice();
   }
   ApplyColorSpace(layer, colorSpace);
-  return std::shared_ptr<MetalWindow>(new MetalWindow(device, layer, std::move(colorSpace)));
+  return std::shared_ptr<MetalWindow>(
+      new MetalWindow(device, layer, std::move(colorSpace), vsyncEnabled));
 }
 
 std::shared_ptr<MetalWindow> MetalWindow::MakeFrom(MTKView* view,
-                                                   std::shared_ptr<ColorSpace> colorSpace) {
+                                                   std::shared_ptr<ColorSpace> colorSpace,
+                                                   bool vsyncEnabled) {
   if (view == nil) {
     return nullptr;
   }
@@ -75,18 +78,34 @@ std::shared_ptr<MetalWindow> MetalWindow::MakeFrom(MTKView* view,
     layer.device = (__bridge id<MTLDevice>)device->metalDevice();
   }
   ApplyColorSpace(layer, colorSpace);
-  return std::shared_ptr<MetalWindow>(new MetalWindow(device, view, layer, std::move(colorSpace)));
+  return std::shared_ptr<MetalWindow>(
+      new MetalWindow(device, view, layer, std::move(colorSpace), vsyncEnabled));
+}
+
+static void ApplyVSync(CAMetalLayer* layer, bool vsyncEnabled) {
+#if TARGET_OS_OSX
+  // displaySyncEnabled only exists on macOS; on iOS/tvOS presentation is always synchronized to
+  // the display and cannot be disabled, so vsync cannot be turned off there.
+  layer.displaySyncEnabled = vsyncEnabled ? YES : NO;
+#else
+  (void)layer;
+  (void)vsyncEnabled;
+#endif
 }
 
 // Do not retain layer/view here, otherwise it can cause circular reference.
 MetalWindow::MetalWindow(std::shared_ptr<Device> device, CAMetalLayer* layer,
-                         std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)), metalLayer(layer) {
+                         std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled), metalLayer(layer) {
+  ApplyVSync(metalLayer, vsyncEnabled);
 }
 
 MetalWindow::MetalWindow(std::shared_ptr<Device> device, MTKView* view, CAMetalLayer* layer,
-                         std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)), metalLayer(layer), metalView(view) {
+                         std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled),
+      metalLayer(layer),
+      metalView(view) {
+  ApplyVSync(metalLayer, vsyncEnabled);
 }
 
 std::shared_ptr<RenderTargetProxy> MetalWindow::onCreateRenderTarget(Context* context) {
@@ -117,16 +136,6 @@ void MetalWindow::onPresent(Context*) {
   }
   auto proxy = std::static_pointer_cast<MetalDrawableProxy>(drawableProxy);
   proxy->releaseDrawable();
-}
-
-void MetalWindow::onVSyncEnabledChanged(bool enabled) {
-#if TARGET_OS_OSX
-  // displaySyncEnabled only exists on macOS; on iOS/tvOS presentation is always synchronized to
-  // the display and cannot be disabled, so this is a no-op there.
-  metalLayer.displaySyncEnabled = enabled ? YES : NO;
-#else
-  (void)enabled;
-#endif
 }
 
 }  // namespace tgfx

--- a/src/gpu/opengl/cgl/CGLWindow.mm
+++ b/src/gpu/opengl/cgl/CGLWindow.mm
@@ -94,6 +94,11 @@ std::shared_ptr<RenderTargetProxy> CGLWindow::onCreateRenderTarget(Context* cont
 
 void CGLWindow::onPresent(Context*) {
   auto glContext = static_cast<CGLDevice*>(device.get())->glContext;
+  int desiredInterval = vsyncEnabled() ? 1 : 0;
+  if (desiredInterval != appliedSwapInterval) {
+    [glContext setValues:&desiredInterval forParameter:NSOpenGLContextParameterSwapInterval];
+    appliedSwapInterval = desiredInterval;
+  }
   [glContext flushBuffer];
 }
 }  // namespace tgfx

--- a/src/gpu/opengl/cgl/CGLWindow.mm
+++ b/src/gpu/opengl/cgl/CGLWindow.mm
@@ -37,7 +37,8 @@ static void ApplyWindowColorSpace(NSView* view, const std::shared_ptr<ColorSpace
 }
 
 std::shared_ptr<CGLWindow> CGLWindow::MakeFrom(NSView* view, CGLContextObj sharedContext,
-                                               std::shared_ptr<ColorSpace> colorSpace) {
+                                               std::shared_ptr<ColorSpace> colorSpace,
+                                               bool vsyncEnabled) {
   if (view == nil) {
     return nullptr;
   }
@@ -51,13 +52,17 @@ std::shared_ptr<CGLWindow> CGLWindow::MakeFrom(NSView* view, CGLContextObj share
          "Rendering may have color inaccuracies.");
   }
   ApplyWindowColorSpace(view, colorSpace);
-  return std::shared_ptr<CGLWindow>(new CGLWindow(device, view, std::move(colorSpace)));
+  return std::shared_ptr<CGLWindow>(
+      new CGLWindow(device, view, std::move(colorSpace), vsyncEnabled));
 }
 
 CGLWindow::CGLWindow(std::shared_ptr<Device> device, NSView* view,
-                     std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)), view(view) {
+                     std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled), view(view) {
   // do not retain view here, otherwise it can cause circular reference.
+  auto glContext = static_cast<CGLDevice*>(this->device.get())->glContext;
+  int interval = vsyncEnabled ? 1 : 0;
+  [glContext setValues:&interval forParameter:NSOpenGLContextParameterSwapInterval];
 }
 
 CGLWindow::~CGLWindow() {
@@ -94,11 +99,6 @@ std::shared_ptr<RenderTargetProxy> CGLWindow::onCreateRenderTarget(Context* cont
 
 void CGLWindow::onPresent(Context*) {
   auto glContext = static_cast<CGLDevice*>(device.get())->glContext;
-  int desiredInterval = vsyncEnabled() ? 1 : 0;
-  if (desiredInterval != appliedSwapInterval) {
-    [glContext setValues:&desiredInterval forParameter:NSOpenGLContextParameterSwapInterval];
-    appliedSwapInterval = desiredInterval;
-  }
   [glContext flushBuffer];
 }
 }  // namespace tgfx

--- a/src/gpu/opengl/egl/EGLWindow.cpp
+++ b/src/gpu/opengl/egl/EGLWindow.cpp
@@ -41,7 +41,8 @@ std::shared_ptr<EGLWindow> EGLWindow::Current() {
 
 std::shared_ptr<EGLWindow> EGLWindow::MakeFrom(EGLNativeWindowType nativeWindow,
                                                EGLContext sharedContext,
-                                               std::shared_ptr<ColorSpace> colorSpace) {
+                                               std::shared_ptr<ColorSpace> colorSpace,
+                                               bool vsyncEnabled) {
   if (!nativeWindow) {
     return nullptr;
   }
@@ -49,13 +50,15 @@ std::shared_ptr<EGLWindow> EGLWindow::MakeFrom(EGLNativeWindowType nativeWindow,
   if (device == nullptr) {
     return nullptr;
   }
-  auto eglWindow = std::shared_ptr<EGLWindow>(new EGLWindow(device, std::move(colorSpace)));
+  auto eglWindow =
+      std::shared_ptr<EGLWindow>(new EGLWindow(device, std::move(colorSpace), vsyncEnabled));
   eglWindow->nativeWindow = nativeWindow;
   return eglWindow;
 }
 
-EGLWindow::EGLWindow(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)) {
+EGLWindow::EGLWindow(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace,
+                     bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled) {
 }
 
 ISize GetNativeWindowSize(EGLNativeWindowType nativeWindow) {
@@ -112,12 +115,11 @@ void EGLWindow::onPresent(Context*) {
   auto eglDisplay = device->eglDisplay;
   // eglSurface cannot be nullptr in EGLWindow.
   auto eglSurface = device->eglSurface;
-  // The context is current here, so eglSwapInterval applies to this window's surface. Apply it
-  // only when the vsync setting changed to avoid a driver call every frame.
-  int desiredInterval = vsyncEnabled() ? 1 : 0;
-  if (desiredInterval != appliedSwapInterval) {
-    if (eglSwapInterval(eglDisplay, desiredInterval)) {
-      appliedSwapInterval = desiredInterval;
+  // The context is current here, so eglSwapInterval applies to this window's surface. The vsync
+  // setting is fixed at creation, so apply it once on the first present.
+  if (!swapIntervalApplied) {
+    if (eglSwapInterval(eglDisplay, vsyncEnabled() ? 1 : 0)) {
+      swapIntervalApplied = true;
     }
   }
   if (presentationTime.has_value()) {

--- a/src/gpu/opengl/egl/EGLWindow.cpp
+++ b/src/gpu/opengl/egl/EGLWindow.cpp
@@ -112,6 +112,14 @@ void EGLWindow::onPresent(Context*) {
   auto eglDisplay = device->eglDisplay;
   // eglSurface cannot be nullptr in EGLWindow.
   auto eglSurface = device->eglSurface;
+  // The context is current here, so eglSwapInterval applies to this window's surface. Apply it
+  // only when the vsync setting changed to avoid a driver call every frame.
+  int desiredInterval = vsyncEnabled() ? 1 : 0;
+  if (desiredInterval != appliedSwapInterval) {
+    if (eglSwapInterval(eglDisplay, desiredInterval)) {
+      appliedSwapInterval = desiredInterval;
+    }
+  }
   if (presentationTime.has_value()) {
     static auto eglPresentationTimeANDROID = reinterpret_cast<PFNEGLPRESENTATIONTIMEANDROIDPROC>(
         eglGetProcAddress("eglPresentationTimeANDROID"));

--- a/src/gpu/opengl/wgl/WGLWindow.cpp
+++ b/src/gpu/opengl/wgl/WGLWindow.cpp
@@ -19,6 +19,7 @@
 #include "tgfx/gpu/opengl/wgl/WGLWindow.h"
 #include <GL/GL.h>
 #include "core/utils/Log.h"
+#include "gpu/opengl/wgl/WGLInterface.h"
 #include "gpu/proxies/RenderTargetProxy.h"
 
 namespace tgfx {
@@ -65,6 +66,17 @@ std::shared_ptr<RenderTargetProxy> WGLWindow::onCreateRenderTarget(Context* cont
 
 void WGLWindow::onPresent(Context*) {
   const auto wglDevice = std::static_pointer_cast<WGLDevice>(this->device);
+  // The GL context is current here (locked by DrawingBuffer before present), so wglSwapInterval
+  // targets this window's context. Apply it only when the vsync setting changed to avoid a driver
+  // call every frame.
+  int desiredInterval = vsyncEnabled() ? 1 : 0;
+  if (desiredInterval != appliedSwapInterval) {
+    auto wglInterface = WGLInterface::Get();
+    if (wglInterface->swapIntervalSupport && wglInterface->wglSwapInterval != nullptr) {
+      wglInterface->wglSwapInterval(desiredInterval);
+      appliedSwapInterval = desiredInterval;
+    }
+  }
   SwapBuffers(wglDevice->deviceContext);
 }
 

--- a/src/gpu/opengl/wgl/WGLWindow.cpp
+++ b/src/gpu/opengl/wgl/WGLWindow.cpp
@@ -24,7 +24,8 @@
 
 namespace tgfx {
 std::shared_ptr<WGLWindow> WGLWindow::MakeFrom(HWND nativeWindow, HGLRC sharedContext,
-                                               std::shared_ptr<ColorSpace> colorSpace) {
+                                               std::shared_ptr<ColorSpace> colorSpace,
+                                               bool vsyncEnabled) {
   if (nativeWindow == nullptr) {
     return nullptr;
   }
@@ -38,13 +39,15 @@ std::shared_ptr<WGLWindow> WGLWindow::MakeFrom(HWND nativeWindow, HGLRC sharedCo
         "WGLWindow::MakeFrom() The specified ColorSpace is not supported on this platform. "
         "Rendering may have color inaccuracies.");
   }
-  auto wglWindow = std::shared_ptr<WGLWindow>(new WGLWindow(device, std::move(colorSpace)));
+  auto wglWindow =
+      std::shared_ptr<WGLWindow>(new WGLWindow(device, std::move(colorSpace), vsyncEnabled));
   wglWindow->nativeWindow = nativeWindow;
   return wglWindow;
 }
 
-WGLWindow::WGLWindow(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)) {
+WGLWindow::WGLWindow(std::shared_ptr<Device> device, std::shared_ptr<ColorSpace> colorSpace,
+                     bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled) {
 }
 
 std::shared_ptr<RenderTargetProxy> WGLWindow::onCreateRenderTarget(Context* context) {
@@ -67,14 +70,13 @@ std::shared_ptr<RenderTargetProxy> WGLWindow::onCreateRenderTarget(Context* cont
 void WGLWindow::onPresent(Context*) {
   const auto wglDevice = std::static_pointer_cast<WGLDevice>(this->device);
   // The GL context is current here (locked by DrawingBuffer before present), so wglSwapInterval
-  // targets this window's context. Apply it only when the vsync setting changed to avoid a driver
-  // call every frame.
-  int desiredInterval = vsyncEnabled() ? 1 : 0;
-  if (desiredInterval != appliedSwapInterval) {
+  // targets this window's context. The vsync setting is fixed at creation, so apply it once on the
+  // first present.
+  if (!swapIntervalApplied) {
     auto wglInterface = WGLInterface::Get();
     if (wglInterface->swapIntervalSupport && wglInterface->wglSwapInterval != nullptr) {
-      wglInterface->wglSwapInterval(desiredInterval);
-      appliedSwapInterval = desiredInterval;
+      wglInterface->wglSwapInterval(vsyncEnabled() ? 1 : 0);
+      swapIntervalApplied = true;
     }
   }
   SwapBuffers(wglDevice->deviceContext);

--- a/src/gpu/vulkan/VulkanWindow.cpp
+++ b/src/gpu/vulkan/VulkanWindow.cpp
@@ -51,6 +51,40 @@ static void DestroySwapchainResources(VkDevice device, VkInstance instance, VkSu
   }
 }
 
+// Picks the swapchain present mode for the requested vsync setting. FIFO is guaranteed by the
+// spec and used whenever vsync is enabled. When vsync is disabled, MAILBOX is preferred (tear-free,
+// low latency) and IMMEDIATE is the fallback; if neither is advertised the code stays on FIFO so
+// creation always succeeds.
+static VkPresentModeKHR ChoosePresentMode(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
+                                          bool vsyncEnabled) {
+  if (vsyncEnabled) {
+    return VK_PRESENT_MODE_FIFO_KHR;
+  }
+  uint32_t count = 0;
+  vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &count, nullptr);
+  if (count == 0) {
+    return VK_PRESENT_MODE_FIFO_KHR;
+  }
+  std::vector<VkPresentModeKHR> modes(count);
+  vkGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, &count, modes.data());
+  bool hasMailbox = false;
+  bool hasImmediate = false;
+  for (auto mode : modes) {
+    if (mode == VK_PRESENT_MODE_MAILBOX_KHR) {
+      hasMailbox = true;
+    } else if (mode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
+      hasImmediate = true;
+    }
+  }
+  if (hasMailbox) {
+    return VK_PRESENT_MODE_MAILBOX_KHR;
+  }
+  if (hasImmediate) {
+    return VK_PRESENT_MODE_IMMEDIATE_KHR;
+  }
+  return VK_PRESENT_MODE_FIFO_KHR;
+}
+
 // Holds all Vulkan-specific handles and swapchain resources. Defined here (not in the header) so
 // that vulkan.h is never required by downstream translation units that include VulkanWindow.h.
 struct VulkanWindow::PlatformState {
@@ -61,6 +95,10 @@ struct VulkanWindow::PlatformState {
   std::vector<VkImage> images;
   std::vector<VkImageView> imageViews;
   VkFormat format = VK_FORMAT_UNDEFINED;
+  VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  // Set by onVSyncEnabledChanged (which runs while holding the window lock and has no Context) so
+  // the next onCreateRenderTarget rebuilds the swapchain with the new present mode.
+  bool vsyncDirty = false;
   int width = 0;
   int height = 0;
   std::shared_ptr<RenderTargetProxy> swapchainProxy;
@@ -664,7 +702,7 @@ bool VulkanWindow::PlatformState::recreateSwapchain(VkDevice device,
   swapchainInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
   swapchainInfo.preTransform = capabilities.currentTransform;
   swapchainInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-  swapchainInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  swapchainInfo.presentMode = presentMode;
   swapchainInfo.clipped = VK_TRUE;
   swapchainInfo.oldSwapchain = swapchain;
 
@@ -729,15 +767,29 @@ std::shared_ptr<RenderTargetProxy> VulkanWindow::onCreateRenderTarget(Context* c
   }
 
   auto lastProxy = std::static_pointer_cast<VulkanSwapchainProxy>(_platformState->swapchainProxy);
+  // Recompute the desired present mode up front: a pending vsync change forces a rebuild, and the
+  // chosen mode is written into PlatformState so recreateSwapchain() picks it up.
+  bool vsyncPending = _platformState->vsyncDirty;
+  VkPresentModeKHR desiredPresentMode = _platformState->presentMode;
+  if (vsyncPending) {
+    desiredPresentMode = ChoosePresentMode(physicalDevice, _platformState->surface, vsyncEnabled());
+  }
   bool needsRebuild = (_platformState->swapchain == VK_NULL_HANDLE) ||
                       (lastProxy && lastProxy->isOutOfDate()) ||
+                      (vsyncPending && desiredPresentMode != _platformState->presentMode) ||
                       (static_cast<int>(extent.width) != _platformState->width) ||
                       (static_cast<int>(extent.height) != _platformState->height);
+
+  // Clear the dirty flag regardless: if the present mode did not actually change (e.g. IMMEDIATE
+  // not supported so it stays FIFO), there is nothing to rebuild for and re-checking every frame
+  // would be wasteful.
+  _platformState->vsyncDirty = false;
 
   if (needsRebuild) {
     if (extent.width == 0 || extent.height == 0) {
       return nullptr;
     }
+    _platformState->presentMode = desiredPresentMode;
     // Release the old proxy before rebuilding the swapchain, since recreateSwapchain() destroys
     // the old swapchain images that the proxy references.
     _platformState->swapchainProxy.reset();
@@ -759,6 +811,12 @@ void VulkanWindow::onPresent(Context*) {
   }
   auto proxy = std::static_pointer_cast<VulkanSwapchainProxy>(_platformState->swapchainProxy);
   proxy->releaseFrame();
+}
+
+void VulkanWindow::onVSyncEnabledChanged(bool /*enabled*/) {
+  // Called while holding the window lock and without a Context, so the swapchain cannot be rebuilt
+  // here. Flag it and let the next onCreateRenderTarget rebuild with the new present mode.
+  _platformState->vsyncDirty = true;
 }
 
 }  // namespace tgfx

--- a/src/gpu/vulkan/VulkanWindow.cpp
+++ b/src/gpu/vulkan/VulkanWindow.cpp
@@ -54,7 +54,9 @@ static void DestroySwapchainResources(VkDevice device, VkInstance instance, VkSu
 // Picks the swapchain present mode for the requested vsync setting. FIFO is guaranteed by the
 // spec and used whenever vsync is enabled. When vsync is disabled, MAILBOX is preferred (tear-free,
 // low latency) and IMMEDIATE is the fallback; if neither is advertised the code stays on FIFO so
-// creation always succeeds.
+// creation always succeeds. Guarded by the same platform macros as its callers (the MakeFrom
+// overloads) so it is not compiled as an unused function on platforms without a MakeFrom.
+#if defined(_WIN32) || defined(__OHOS__) || defined(__ANDROID__)
 static VkPresentModeKHR ChoosePresentMode(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                           bool vsyncEnabled) {
   if (vsyncEnabled) {
@@ -84,6 +86,7 @@ static VkPresentModeKHR ChoosePresentMode(VkPhysicalDevice physicalDevice, VkSur
   }
   return VK_PRESENT_MODE_FIFO_KHR;
 }
+#endif
 
 // Holds all Vulkan-specific handles and swapchain resources. Defined here (not in the header) so
 // that vulkan.h is never required by downstream translation units that include VulkanWindow.h.

--- a/src/gpu/vulkan/VulkanWindow.cpp
+++ b/src/gpu/vulkan/VulkanWindow.cpp
@@ -96,9 +96,6 @@ struct VulkanWindow::PlatformState {
   std::vector<VkImageView> imageViews;
   VkFormat format = VK_FORMAT_UNDEFINED;
   VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
-  // Set by onVSyncEnabledChanged (which runs while holding the window lock and has no Context) so
-  // the next onCreateRenderTarget rebuilds the swapchain with the new present mode.
-  bool vsyncDirty = false;
   int width = 0;
   int height = 0;
   std::shared_ptr<RenderTargetProxy> swapchainProxy;
@@ -111,7 +108,8 @@ struct VulkanWindow::PlatformState {
 
 std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(HWND hwnd,
                                                      std::shared_ptr<VulkanDevice> device,
-                                                     std::shared_ptr<ColorSpace> colorSpace) {
+                                                     std::shared_ptr<ColorSpace> colorSpace,
+                                                     bool vsyncEnabled) {
   if (hwnd == nullptr || device == nullptr) {
     return nullptr;
   }
@@ -232,7 +230,8 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(HWND hwnd,
   swapchainInfo.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
   swapchainInfo.preTransform = capabilities.currentTransform;
   swapchainInfo.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-  swapchainInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  auto presentMode = ChoosePresentMode(physicalDevice, surface, vsyncEnabled);
+  swapchainInfo.presentMode = presentMode;
   swapchainInfo.clipped = VK_TRUE;
 
   VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -277,10 +276,12 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(HWND hwnd,
   state->images = std::move(images);
   state->imageViews = std::move(imageViews);
   state->format = chosenFormat.format;
+  state->presentMode = presentMode;
   state->width = static_cast<int>(extent.width);
   state->height = static_cast<int>(extent.height);
 
-  return std::shared_ptr<VulkanWindow>(new VulkanWindow(device, std::move(state), colorSpace));
+  return std::shared_ptr<VulkanWindow>(
+      new VulkanWindow(device, std::move(state), colorSpace, vsyncEnabled));
 }
 
 #endif
@@ -289,7 +290,8 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(HWND hwnd,
 
 std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(OHNativeWindow* nativeWindow,
                                                      std::shared_ptr<VulkanDevice> device,
-                                                     std::shared_ptr<ColorSpace> colorSpace) {
+                                                     std::shared_ptr<ColorSpace> colorSpace,
+                                                     bool vsyncEnabled) {
   if (nativeWindow == nullptr || device == nullptr) {
     return nullptr;
   }
@@ -422,7 +424,8 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(OHNativeWindow* nativeWindo
     compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
   }
   swapchainInfo.compositeAlpha = compositeAlpha;
-  swapchainInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  auto presentMode = ChoosePresentMode(physicalDevice, surface, vsyncEnabled);
+  swapchainInfo.presentMode = presentMode;
   swapchainInfo.clipped = VK_TRUE;
 
   VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -467,10 +470,12 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(OHNativeWindow* nativeWindo
   state->images = std::move(images);
   state->imageViews = std::move(imageViews);
   state->format = chosenFormat.format;
+  state->presentMode = presentMode;
   state->width = static_cast<int>(extent.width);
   state->height = static_cast<int>(extent.height);
 
-  return std::shared_ptr<VulkanWindow>(new VulkanWindow(device, std::move(state), colorSpace));
+  return std::shared_ptr<VulkanWindow>(
+      new VulkanWindow(device, std::move(state), colorSpace, vsyncEnabled));
 }
 
 #endif
@@ -479,7 +484,8 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(OHNativeWindow* nativeWindo
 
 std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(ANativeWindow* nativeWindow,
                                                      std::shared_ptr<VulkanDevice> device,
-                                                     std::shared_ptr<ColorSpace> colorSpace) {
+                                                     std::shared_ptr<ColorSpace> colorSpace,
+                                                     bool vsyncEnabled) {
   if (nativeWindow == nullptr || device == nullptr) {
     return nullptr;
   }
@@ -595,7 +601,8 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(ANativeWindow* nativeWindow
     compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
   }
   swapchainInfo.compositeAlpha = compositeAlpha;
-  swapchainInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  auto presentMode = ChoosePresentMode(physicalDevice, surface, vsyncEnabled);
+  swapchainInfo.presentMode = presentMode;
   swapchainInfo.clipped = VK_TRUE;
 
   VkSwapchainKHR swapchain = VK_NULL_HANDLE;
@@ -640,17 +647,20 @@ std::shared_ptr<VulkanWindow> VulkanWindow::MakeFrom(ANativeWindow* nativeWindow
   state->images = std::move(images);
   state->imageViews = std::move(imageViews);
   state->format = chosenFormat.format;
+  state->presentMode = presentMode;
   state->width = static_cast<int>(extent.width);
   state->height = static_cast<int>(extent.height);
 
-  return std::shared_ptr<VulkanWindow>(new VulkanWindow(device, std::move(state), colorSpace));
+  return std::shared_ptr<VulkanWindow>(
+      new VulkanWindow(device, std::move(state), colorSpace, vsyncEnabled));
 }
 
 #endif
 
 VulkanWindow::VulkanWindow(std::shared_ptr<Device> device, std::unique_ptr<PlatformState> state,
-                           std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)), _platformState(std::move(state)) {
+                           std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled),
+      _platformState(std::move(state)) {
 }
 
 VulkanWindow::~VulkanWindow() {
@@ -767,29 +777,17 @@ std::shared_ptr<RenderTargetProxy> VulkanWindow::onCreateRenderTarget(Context* c
   }
 
   auto lastProxy = std::static_pointer_cast<VulkanSwapchainProxy>(_platformState->swapchainProxy);
-  // Recompute the desired present mode up front: a pending vsync change forces a rebuild, and the
-  // chosen mode is written into PlatformState so recreateSwapchain() picks it up.
-  bool vsyncPending = _platformState->vsyncDirty;
-  VkPresentModeKHR desiredPresentMode = _platformState->presentMode;
-  if (vsyncPending) {
-    desiredPresentMode = ChoosePresentMode(physicalDevice, _platformState->surface, vsyncEnabled());
-  }
+  // The present mode is fixed at creation (stored in PlatformState) and reused across rebuilds, so
+  // only an out-of-date swapchain or a size change triggers a rebuild.
   bool needsRebuild = (_platformState->swapchain == VK_NULL_HANDLE) ||
                       (lastProxy && lastProxy->isOutOfDate()) ||
-                      (vsyncPending && desiredPresentMode != _platformState->presentMode) ||
                       (static_cast<int>(extent.width) != _platformState->width) ||
                       (static_cast<int>(extent.height) != _platformState->height);
-
-  // Clear the dirty flag regardless: if the present mode did not actually change (e.g. IMMEDIATE
-  // not supported so it stays FIFO), there is nothing to rebuild for and re-checking every frame
-  // would be wasteful.
-  _platformState->vsyncDirty = false;
 
   if (needsRebuild) {
     if (extent.width == 0 || extent.height == 0) {
       return nullptr;
     }
-    _platformState->presentMode = desiredPresentMode;
     // Release the old proxy before rebuilding the swapchain, since recreateSwapchain() destroys
     // the old swapchain images that the proxy references.
     _platformState->swapchainProxy.reset();
@@ -811,12 +809,6 @@ void VulkanWindow::onPresent(Context*) {
   }
   auto proxy = std::static_pointer_cast<VulkanSwapchainProxy>(_platformState->swapchainProxy);
   proxy->releaseFrame();
-}
-
-void VulkanWindow::onVSyncEnabledChanged(bool /*enabled*/) {
-  // Called while holding the window lock and without a Context, so the swapchain cannot be rebuilt
-  // here. Flag it and let the next onCreateRenderTarget rebuild with the new present mode.
-  _platformState->vsyncDirty = true;
 }
 
 }  // namespace tgfx

--- a/src/gpu/webgpu/WebGPUWindow.cpp
+++ b/src/gpu/webgpu/WebGPUWindow.cpp
@@ -188,8 +188,8 @@ std::shared_ptr<RenderTargetProxy> WebGPUWindow::onCreateRenderTarget(Context* c
     return nullptr;
   }
 
-  // Only reconfigure the surface when dimensions actually change.
-  if (_width != _configuredWidth || _height != _configuredHeight) {
+  // Reconfigure the surface when dimensions change or the present mode (vsync) changed.
+  if (_width != _configuredWidth || _height != _configuredHeight || _presentModeDirty) {
     auto wgpuDevice =
         static_cast<WGPUDevice>(static_cast<WebGPUDevice*>(getDevice().get())->webgpuDevice());
     auto wgpuSurface = static_cast<WGPUSurface>(_surface);
@@ -199,12 +199,13 @@ std::shared_ptr<RenderTargetProxy> WebGPUWindow::onCreateRenderTarget(Context* c
     config.usage = WGPUTextureUsage_RenderAttachment;
     config.width = static_cast<uint32_t>(_width);
     config.height = static_cast<uint32_t>(_height);
-    config.presentMode = WGPUPresentMode_Fifo;
+    config.presentMode = _presentMode;
     config.alphaMode = WGPUCompositeAlphaMode_Premultiplied;
     wgpuSurfaceConfigure(wgpuSurface, &config);
     configureColorSpace(config.format, config.usage, config.alphaMode);
     _configuredWidth = _width;
     _configuredHeight = _height;
+    _presentModeDirty = false;
   }
 
   auto wgpuSurface = static_cast<WGPUSurface>(_surface);
@@ -220,6 +221,18 @@ void WebGPUWindow::onPresent(Context*) {
   auto proxy = std::static_pointer_cast<WebGPUDrawableProxy>(drawableProxy);
   proxy->present();
   proxy->releaseDrawable();
+}
+
+void WebGPUWindow::onVSyncEnabledChanged(bool enabled) {
+  // Called while holding the window lock; defer the actual wgpuSurfaceConfigure to the next
+  // onCreateRenderTarget. On Web the browser may still cap presentation to the display refresh
+  // rate regardless of this request; Immediate is honored only where the implementation supports
+  // it (e.g. native Dawn).
+  auto mode = enabled ? WGPUPresentMode_Fifo : WGPUPresentMode_Immediate;
+  if (mode != _presentMode) {
+    _presentMode = mode;
+    _presentModeDirty = true;
+  }
 }
 
 }  // namespace tgfx

--- a/src/gpu/webgpu/WebGPUWindow.cpp
+++ b/src/gpu/webgpu/WebGPUWindow.cpp
@@ -65,7 +65,8 @@ static const char* ToAlphaModeString(WGPUCompositeAlphaMode alphaMode) {
 
 std::shared_ptr<WebGPUWindow> WebGPUWindow::MakeFrom(const std::string& canvasSelector,
                                                      std::shared_ptr<WebGPUDevice> device,
-                                                     std::shared_ptr<ColorSpace> colorSpace) {
+                                                     std::shared_ptr<ColorSpace> colorSpace,
+                                                     bool vsyncEnabled) {
   if (canvasSelector.empty()) {
     return nullptr;
   }
@@ -115,22 +116,24 @@ std::shared_ptr<WebGPUWindow> WebGPUWindow::MakeFrom(const std::string& canvasSe
   config.usage = WGPUTextureUsage_RenderAttachment;
   config.width = static_cast<uint32_t>(canvasWidth);
   config.height = static_cast<uint32_t>(canvasHeight);
-  config.presentMode = WGPUPresentMode_Fifo;
+  config.presentMode = vsyncEnabled ? WGPUPresentMode_Fifo : WGPUPresentMode_Immediate;
   config.alphaMode = WGPUCompositeAlphaMode_Premultiplied;
   wgpuSurfaceConfigure(surface, &config);
 
   auto window = std::shared_ptr<WebGPUWindow>(
       new WebGPUWindow(std::move(device), surface, canvasWidth, canvasHeight, canvasSelector,
-                       std::move(colorSpace)));
+                       std::move(colorSpace), vsyncEnabled));
   window->configureColorSpace(config.format, config.usage, config.alphaMode);
   return window;
 }
 
 WebGPUWindow::WebGPUWindow(std::shared_ptr<Device> device, void* surface, int width, int height,
                            const std::string& canvasSelector,
-                           std::shared_ptr<ColorSpace> colorSpace)
-    : Window(std::move(device), std::move(colorSpace)), _canvasSelector(canvasSelector),
-      _surface(surface), _width(width), _height(height) {
+                           std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
+    : Window(std::move(device), std::move(colorSpace), vsyncEnabled),
+      _canvasSelector(canvasSelector), _surface(surface), _width(width), _height(height),
+      _configuredWidth(width), _configuredHeight(height),
+      _presentMode(vsyncEnabled ? WGPUPresentMode_Fifo : WGPUPresentMode_Immediate) {
 }
 
 void WebGPUWindow::configureColorSpace(WGPUTextureFormat format, WGPUTextureUsageFlags usage,
@@ -188,8 +191,9 @@ std::shared_ptr<RenderTargetProxy> WebGPUWindow::onCreateRenderTarget(Context* c
     return nullptr;
   }
 
-  // Reconfigure the surface when dimensions change or the present mode (vsync) changed.
-  if (_width != _configuredWidth || _height != _configuredHeight || _presentModeDirty) {
+  // Reconfigure the surface when dimensions change. The present mode is fixed at creation and
+  // reused here.
+  if (_width != _configuredWidth || _height != _configuredHeight) {
     auto wgpuDevice =
         static_cast<WGPUDevice>(static_cast<WebGPUDevice*>(getDevice().get())->webgpuDevice());
     auto wgpuSurface = static_cast<WGPUSurface>(_surface);
@@ -205,7 +209,6 @@ std::shared_ptr<RenderTargetProxy> WebGPUWindow::onCreateRenderTarget(Context* c
     configureColorSpace(config.format, config.usage, config.alphaMode);
     _configuredWidth = _width;
     _configuredHeight = _height;
-    _presentModeDirty = false;
   }
 
   auto wgpuSurface = static_cast<WGPUSurface>(_surface);
@@ -221,18 +224,6 @@ void WebGPUWindow::onPresent(Context*) {
   auto proxy = std::static_pointer_cast<WebGPUDrawableProxy>(drawableProxy);
   proxy->present();
   proxy->releaseDrawable();
-}
-
-void WebGPUWindow::onVSyncEnabledChanged(bool enabled) {
-  // Called while holding the window lock; defer the actual wgpuSurfaceConfigure to the next
-  // onCreateRenderTarget. On Web the browser may still cap presentation to the display refresh
-  // rate regardless of this request; Immediate is honored only where the implementation supports
-  // it (e.g. native Dawn).
-  auto mode = enabled ? WGPUPresentMode_Fifo : WGPUPresentMode_Immediate;
-  if (mode != _presentMode) {
-    _presentMode = mode;
-    _presentModeDirty = true;
-  }
 }
 
 }  // namespace tgfx

--- a/src/gpu/webgpu/WebGPUWindow.cpp
+++ b/src/gpu/webgpu/WebGPUWindow.cpp
@@ -65,8 +65,7 @@ static const char* ToAlphaModeString(WGPUCompositeAlphaMode alphaMode) {
 
 std::shared_ptr<WebGPUWindow> WebGPUWindow::MakeFrom(const std::string& canvasSelector,
                                                      std::shared_ptr<WebGPUDevice> device,
-                                                     std::shared_ptr<ColorSpace> colorSpace,
-                                                     bool vsyncEnabled) {
+                                                     std::shared_ptr<ColorSpace> colorSpace) {
   if (canvasSelector.empty()) {
     return nullptr;
   }
@@ -116,24 +115,28 @@ std::shared_ptr<WebGPUWindow> WebGPUWindow::MakeFrom(const std::string& canvasSe
   config.usage = WGPUTextureUsage_RenderAttachment;
   config.width = static_cast<uint32_t>(canvasWidth);
   config.height = static_cast<uint32_t>(canvasHeight);
-  config.presentMode = vsyncEnabled ? WGPUPresentMode_Fifo : WGPUPresentMode_Immediate;
+  // Browser canvas presentation only supports Fifo; Immediate (vsync off) is a native-only
+  // extension. Requesting an unsupported present mode makes wgpuSurfaceConfigure raise a validation
+  // error and leaves the surface invalid, so always use Fifo here and treat vsyncEnabled=false as a
+  // no-op on this backend (matching the "backends that cannot control vsync ignore this setting"
+  // contract).
+  config.presentMode = WGPUPresentMode_Fifo;
   config.alphaMode = WGPUCompositeAlphaMode_Premultiplied;
   wgpuSurfaceConfigure(surface, &config);
 
   auto window = std::shared_ptr<WebGPUWindow>(
       new WebGPUWindow(std::move(device), surface, canvasWidth, canvasHeight, canvasSelector,
-                       std::move(colorSpace), vsyncEnabled));
+                       std::move(colorSpace)));
   window->configureColorSpace(config.format, config.usage, config.alphaMode);
   return window;
 }
 
 WebGPUWindow::WebGPUWindow(std::shared_ptr<Device> device, void* surface, int width, int height,
                            const std::string& canvasSelector,
-                           std::shared_ptr<ColorSpace> colorSpace, bool vsyncEnabled)
-    : Window(std::move(device), std::move(colorSpace), vsyncEnabled),
-      _canvasSelector(canvasSelector), _surface(surface), _width(width), _height(height),
-      _configuredWidth(width), _configuredHeight(height),
-      _presentMode(vsyncEnabled ? WGPUPresentMode_Fifo : WGPUPresentMode_Immediate) {
+                           std::shared_ptr<ColorSpace> colorSpace)
+    : Window(std::move(device), std::move(colorSpace)), _canvasSelector(canvasSelector),
+      _surface(surface), _width(width), _height(height), _configuredWidth(width),
+      _configuredHeight(height) {
 }
 
 void WebGPUWindow::configureColorSpace(WGPUTextureFormat format, WGPUTextureUsageFlags usage,
@@ -191,8 +194,7 @@ std::shared_ptr<RenderTargetProxy> WebGPUWindow::onCreateRenderTarget(Context* c
     return nullptr;
   }
 
-  // Reconfigure the surface when dimensions change. The present mode is fixed at creation and
-  // reused here.
+  // Reconfigure the surface when dimensions change. Present mode stays Fifo (see MakeFrom).
   if (_width != _configuredWidth || _height != _configuredHeight) {
     auto wgpuDevice =
         static_cast<WGPUDevice>(static_cast<WebGPUDevice*>(getDevice().get())->webgpuDevice());
@@ -203,7 +205,7 @@ std::shared_ptr<RenderTargetProxy> WebGPUWindow::onCreateRenderTarget(Context* c
     config.usage = WGPUTextureUsage_RenderAttachment;
     config.width = static_cast<uint32_t>(_width);
     config.height = static_cast<uint32_t>(_height);
-    config.presentMode = _presentMode;
+    config.presentMode = WGPUPresentMode_Fifo;
     config.alphaMode = WGPUCompositeAlphaMode_Premultiplied;
     wgpuSurfaceConfigure(wgpuSurface, &config);
     configureColorSpace(config.format, config.usage, config.alphaMode);


### PR DESCRIPTION
## 概述

为 `Window` 新增创建期的垂直同步（vsync）选项：在各后端的工厂函数 `MakeFrom(...)` 末尾新增 `bool vsyncEnabled = true` 参数，并提供只读的 `vsyncEnabled()` 查询。该属性在 Window 创建时固定、之后不可更改，与 `colorSpace` 的设计保持一致。

- 开启（默认）：呈现被限制到显示器刷新率。
- 关闭：present 时不再被显示器 vsync 阻塞调用线程，适用于该线程不能被卡住的场景（例如 CEF 的 UI 回调线程）。

具体效果取决于各后端与底层平台，无法控制 vsync 的后端会忽略该设置。

## 接口设计

- 基类 `Window` 构造函数新增 `bool vsyncEnabled = true` 参数，`_vsyncEnabled` 为不可变（`const`）成员。
- `bool vsyncEnabled() const`：返回创建时固定的值，无锁（不可变属性天然线程安全）。
- 无运行时 setter：vsync 是创建期定义的不可变属性。若将来出现动态切换需求，可作为增量演进再引入。

## 各后端实现说明

**创建期一次性设置（支持 vsync 控制）**

- **Metal**：创建时设置 `CAMetalLayer.displaySyncEnabled`（仅 macOS；iOS/tvOS 始终同步到显示器，无法关闭）。
- **CGL**：创建时设置 `NSOpenGLContextParameterSwapInterval`。
- **EGL**：在首次 present 时（此时 context 为 current）调用一次 `eglSwapInterval` 应用固定值。
- **WGL**：在首次 present 时调用一次 `wglSwapInterval` 应用固定值。
- **D3D12**：工厂链（`MakeForHwnd` / `MakeForComposition` / `MakeImpl`）透传，present 时读取固定值决定 `SyncInterval`。
- **Vulkan**：创建 swapchain 时用 `ChoosePresentMode` 按 vsync 选择 present mode——关闭时优先 MAILBOX、回退 IMMEDIATE，若均不支持则保持 FIFO；结果存入 PlatformState，尺寸变化重建 swapchain 时复用，保证 present mode 始终有效。

**不支持 vsync 控制（忽略该设置，工厂不暴露参数）**

- **WebGPU**：浏览器 canvas 呈现只支持 Fifo，Immediate 属于原生扩展；请求不支持的 present mode 会导致 `wgpuSurfaceConfigure` 校验失败并使 surface 失效。因此固定使用 Fifo，`vsyncEnabled()` 恒为 true，工厂不暴露 vsync 参数。
- **WebGL / EAGL / QGL**：无可用的 vsync 控制手段，沿用基类默认（vsync 开启）。

## 说明

本 PR 仅新增接口与各后端实现，不改变既有默认行为（默认 vsync 开启，与之前一致）。
