### PR TITLE
Upgrade expat to 2.8.3

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -62,7 +62,7 @@
       },
       {
         "url": "https://github.com/libexpat/libexpat.git",
-        "commit": "70a0d4b01f2b6af4ec3d851ad2b399752f531ff8",
+        "commit": "92810461043fce37e70079b37ab1f04490a8f039",
         "dir": "third_party/expat"
       },
       {

--- a/DEPS
+++ b/DEPS
@@ -62,7 +62,7 @@
       },
       {
         "url": "https://github.com/libexpat/libexpat.git",
-        "commit": "88b3ed553d8ad335559254863a33360d55b9f1d6",
+        "commit": "70a0d4b01f2b6af4ec3d851ad2b399752f531ff8",
         "dir": "third_party/expat"
       },
       {

--- a/src/svg/xml/XMLParser.cpp
+++ b/src/svg/xml/XMLParser.cpp
@@ -52,8 +52,6 @@ class AutoTCallVProc : public std::unique_ptr<T, FunctionObject<P>> {
   }
 };
 
-constexpr const void* HASH_SEED = &HASH_SEED;
-
 const XML_Memory_Handling_Suite XML_alloc = {malloc, realloc, free};
 
 struct ParsingContext {
@@ -127,12 +125,6 @@ bool XMLParser::parse(Stream& stream) {
     LOGE("could not create XML parser\n");
     return false;
   }
-
-  // Avoid calls to rand_s if this is not set. This seed helps prevent DOS
-  // with a known hash sequence so an address is sufficient. The provided
-  // seed should not be zero as that results in a call to rand_s.
-  auto seed = static_cast<unsigned long>(reinterpret_cast<size_t>(HASH_SEED) & 0xFFFFFFFF);
-  XML_SetHashSalt(parsingContext._XMLParser, seed ? seed : 1);
 
   XML_SetUserData(parsingContext._XMLParser, &parsingContext);
   XML_SetElementHandler(parsingContext._XMLParser, start_element_handler, end_element_handler);


### PR DESCRIPTION
## 说明

将 expat 依赖升级到 2.8.3 版本，修复相关安全与稳定性问题。

`XML_SetHashSalt` 接口在 2.8.3 中仍然存在（自 2.8.0 起 deprecated，声明与实现都在，照常返回 1，保留调用也能编译），因此移除该调用并非因为接口被删除，而是出于安全考量。依据 expat 2.8.0 changelog 的原文：

> Existing API function XML_SetHashSalt is now deprecated because of its limitations, **and its use should be considered a vulnerability**

旧的 32 位确定性盐防护力不足，官方明确把继续调用视为安全隐患，推荐做法是**不调用任何 `SetHashSalt*`**，由 expat 内部在未设置盐时自动生成 128 位随机熵（startParsing() 内部调用 generate_hash_secret_salt()）。相比旧的确定性地址盐，安全性是提升的。因此本次同步移除了 `src/svg/xml/XMLParser.cpp` 中对应的 `HASH_SEED` 常量与 `XML_SetHashSalt` 调用。

变更内容：
- `DEPS`：将 expat 依赖更新为 2.8.3 对应的 commit（`92810461043fce37e70079b37ab1f04490a8f039`）。
- `src/svg/xml/XMLParser.cpp`：移除对 `XML_SetHashSalt` 的调用及 `HASH_SEED` 常量。原代码以确定性地址作为 32 位盐，防护力不足且被官方视为漏洞；移除后改由 expat 内部在未设盐时自动生成 128 位随机熵。

相关 issue：https://github.com/Tencent/libpag/issues/3681