### PR TITLE
Fix WebAssembly runtime abort by disabling HarfBuzz in the FreeType build

### DIFF
--- a/vendor.json
+++ b/vendor.json
@@ -196,6 +196,7 @@
         "arguments": [
           "-DCMAKE_DISABLE_FIND_PACKAGE_BZip2=TRUE",
           "-DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE",
+          "-DFT_DISABLE_HARFBUZZ=TRUE",
           "-DFT_DISABLE_BROTLI=TRUE",
           "-DFT_REQUIRE_PNG=TRUE",
           "-DCMAKE_C_FLAGS=\"-w\""


### PR DESCRIPTION
## 问题

FreeType 升级到 2.14.3 后，**微信小程序**的 wasm 构建在首次文本光栅化（FreeType 初始化）时崩溃：

```
Aborted(To use dlopen, you need enable dynamic linking, ...)
```

之后每帧连带报 `function signature mismatch`，因为 `abort()` 穿过了未启用异常支持的 wasm 栈。
**Web 端不崩**，见下文「为什么只有小程序崩」。

## 原因

FreeType 2.14.0 新增了动态加载 HarfBuzz 的模式（`src/autofit/ft-hb.c`），其 CMake 逻辑对 Emscripten 不友好：

1. `FT_DYNAMIC_HARFBUZZ` 默认 `ON`；
2. 启用条件是 `check_symbol_exists(dlopen "dlfcn.h")` 而非「HarfBuzz 是否存在」，Emscripten 必然通过
   （`dlfcn.h` 声明了 `dlopen`，只是实现是 stub）；
3. dynamic 分支会跳过 `find_package(HarfBuzz)`，导致我们原有的 `-DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE`
   完全失效。

于是两个 HarfBuzz 宏都被打开，`af_autofitter_init()` 会调用 `dlsym(RTLD_DEFAULT, "hb_version_atleast")`。
产物核实：`autofit.c.o` 中有 `U dlopen` / `U dlsym`，反汇编可见 `af_autofitter_init` 带着
`hb_version_atleast`、`libharfbuzz.so.0` 字符串调用 `dlsym`。

## 为什么只有小程序崩

差别在 `dlsym` 被解析到哪个实现，与代码无关：

- 小程序（emsdk 3.1.20，受微信 WXWebAssembly 限制不能升级）：JS stub `__dlsym_js`，函数体是
  `abort(dlopenMissingError)` → **崩溃**。
- Web 端（emsdk 4.0.15）：musl 原生 stub `__dlsym.c`，设置 `dlerror` 后返回 `NULL` → 优雅降级。

即 Web 端的自动 hinter 同样从未真正启用 HarfBuzz，只是每次初始化白跑 30 余次空 `dlsym`；工具链一旦回退
到旧版就会出现同样崩溃。非 Web 平台不崩，但是否启用取决于最终二进制有没有恰好导出静态合并进来的
HarfBuzz 符号（下游产物中两种情况都实测到过）。

## 为什么关闭是正确的修复

- HarfBuzz 在 FreeType 中只服务自动 hinter，所有调用点都由 `ft_hb_enabled()` 保护并有回退实现。
- tgfx 用自己那份 HarfBuzz 做 shaping，且以 `-DHB_HAVE_FREETYPE=OFF` 构建，不存在需要动态加载来解的
  循环依赖。
- 2.14 之前 `FT_CONFIG_OPTION_USE_HARFBUZZ` 对 tgfx 从未定义（`find_package` 是被故意禁用的），本次修改
  是恢复这一既有意图。
- 修复与 Emscripten 版本无关，同时消除了「行为取决于符号是否导出」以及可能绑定到宿主 App 中另一版本
  HarfBuzz 的不确定性。

`-DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE` 有意保留：当前冗余，但可防止将来有人关掉新开关后误命中系统
HarfBuzz。

## 验证

- `libfreetype.a` 不再有 `dlopen`/`dlsym` 未定义引用；重建后的 wasm 不再导入 `__dlsym_js`，也不再包含
  相关字符串，原先每帧崩溃的小程序场景恢复正常。
- Web 端行为不变，仅少了那 30 余次空 `dlsym`。
- 无截图基准变化：测试二进制本就没有导出 HarfBuzz 符号，自动 hinter 一直在无 HarfBuzz 状态下运行。
