### PR TITLE
Respect declared dimensions when wrapping external textures across backends.

### DIFF
--- a/src/gpu/d3d12/D3D12GPU.cpp
+++ b/src/gpu/d3d12/D3D12GPU.cpp
@@ -480,7 +480,8 @@ std::shared_ptr<Texture> D3D12GPU::importBackendTexture(const BackendTexture& ba
   if (adopted) {
     d3d12Resource->Release();
   }
-  return D3D12Texture::MakeFrom(this, std::move(resource), d3d12Info.format, usage);
+  return D3D12Texture::MakeFrom(this, std::move(resource), d3d12Info.format, backendTexture.width(),
+                                backendTexture.height(), usage);
 }
 
 std::shared_ptr<Texture> D3D12GPU::importBackendRenderTarget(
@@ -504,6 +505,7 @@ std::shared_ptr<Texture> D3D12GPU::importBackendRenderTarget(
     return nullptr;
   }
   return D3D12Texture::MakeFrom(this, std::move(resource), d3d12Info.format,
+                                backendRenderTarget.width(), backendRenderTarget.height(),
                                 TextureUsage::RENDER_ATTACHMENT);
 }
 

--- a/src/gpu/d3d12/D3D12Texture.cpp
+++ b/src/gpu/d3d12/D3D12Texture.cpp
@@ -128,7 +128,8 @@ std::shared_ptr<D3D12Texture> D3D12Texture::Make(D3D12GPU* gpu,
 }
 
 std::shared_ptr<D3D12Texture> D3D12Texture::MakeFrom(D3D12GPU* gpu, ComPtr<ID3D12Resource> resource,
-                                                     unsigned dxgiFormat, uint32_t usage) {
+                                                     unsigned dxgiFormat, int width, int height,
+                                                     uint32_t usage) {
   if (gpu == nullptr || resource == nullptr) {
     return nullptr;
   }
@@ -141,10 +142,8 @@ std::shared_ptr<D3D12Texture> D3D12Texture::MakeFrom(D3D12GPU* gpu, ComPtr<ID3D1
 
   auto desc = resource->GetDesc();
   TextureDescriptor descriptor = {};
-  // D3D12 caps dimensions at D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION (16384), well below INT_MAX,
-  // so the UINT64/UINT→int narrow cast is always safe.
-  descriptor.width = static_cast<int>(desc.Width);
-  descriptor.height = static_cast<int>(desc.Height);
+  descriptor.width = width;
+  descriptor.height = height;
   descriptor.format = pixelFormat;
   descriptor.mipLevelCount = static_cast<int>(desc.MipLevels);
   descriptor.sampleCount = static_cast<int>(desc.SampleDesc.Count);

--- a/src/gpu/d3d12/D3D12Texture.h
+++ b/src/gpu/d3d12/D3D12Texture.h
@@ -35,10 +35,13 @@ class D3D12Texture : public Texture, public D3D12Resource {
   static std::shared_ptr<D3D12Texture> Make(D3D12GPU* gpu, const TextureDescriptor& descriptor);
 
   /**
-   * Creates a D3D12Texture wrapper from an external D3D12 resource.
+   * Creates a D3D12Texture wrapper from an external D3D12 resource. The width and height come from
+   * the caller's declared dimensions rather than the underlying resource size, so the logical size
+   * can be a subregion of the physical resource.
    */
   static std::shared_ptr<D3D12Texture> MakeFrom(D3D12GPU* gpu, ComPtr<ID3D12Resource> resource,
-                                                unsigned dxgiFormat, uint32_t usage);
+                                                unsigned dxgiFormat, int width, int height,
+                                                uint32_t usage);
 
   /**
    * Returns the underlying D3D12 resource.

--- a/src/gpu/metal/MetalGPU.mm
+++ b/src/gpu/metal/MetalGPU.mm
@@ -192,7 +192,8 @@ std::shared_ptr<Texture> MetalGPU::importBackendTexture(const BackendTexture& ba
   }
 
   id<MTLTexture> metalTexture = (__bridge id<MTLTexture>)metalInfo.texture;
-  return MetalTexture::MakeFrom(this, metalTexture, usage, adopted);
+  return MetalTexture::MakeFrom(this, metalTexture, backendTexture.width(), backendTexture.height(),
+                                usage, adopted);
 }
 
 std::shared_ptr<Texture> MetalGPU::importBackendRenderTarget(
@@ -209,7 +210,9 @@ std::shared_ptr<Texture> MetalGPU::importBackendRenderTarget(
   if (!metalTexture) {
     return nullptr;
   }
-  return MetalTexture::MakeFrom(this, metalTexture, TextureUsage::RENDER_ATTACHMENT, false);
+  return MetalTexture::MakeFrom(this, metalTexture, backendRenderTarget.width(),
+                                backendRenderTarget.height(), TextureUsage::RENDER_ATTACHMENT,
+                                false);
 }
 
 std::shared_ptr<Semaphore> MetalGPU::importBackendSemaphore(const BackendSemaphore& semaphore) {

--- a/src/gpu/metal/MetalTexture.h
+++ b/src/gpu/metal/MetalTexture.h
@@ -34,10 +34,13 @@ class MetalTexture : public Texture, public MetalResource {
   static std::shared_ptr<MetalTexture> Make(MetalGPU* gpu, const TextureDescriptor& descriptor);
 
   /**
-   * Creates a MetalTexture wrapper from an external Metal texture.
+   * Creates a MetalTexture wrapper from an external Metal texture. The width and height come from
+   * the caller's declared dimensions (e.g. BackendTexture/BackendRenderTarget) rather than the
+   * underlying MTLTexture size, so the logical size can be a subregion of the physical texture.
    */
   static std::shared_ptr<MetalTexture> MakeFrom(MetalGPU* gpu, id<MTLTexture> metalTexture,
-                                                uint32_t usage, bool adopted);
+                                                int width, int height, uint32_t usage,
+                                                bool adopted);
 
   /**
    * Returns the Metal texture.

--- a/src/gpu/metal/MetalTexture.mm
+++ b/src/gpu/metal/MetalTexture.mm
@@ -95,15 +95,18 @@ std::shared_ptr<MetalTexture> MetalTexture::Make(MetalGPU* gpu,
 }
 
 std::shared_ptr<MetalTexture> MetalTexture::MakeFrom(MetalGPU* gpu, id<MTLTexture> metalTexture,
-                                                     uint32_t usage, bool adopted) {
+                                                     int width, int height, uint32_t usage,
+                                                     bool adopted) {
   if (!gpu || !metalTexture) {
     return nullptr;
   }
 
-  // Build descriptor from the Metal texture properties
+  // Build descriptor from the caller-declared dimensions. The underlying MTLTexture may be larger
+  // than the logical texture (e.g. a subregion), so trust the declared width/height to stay
+  // consistent with the OpenGL backend, which also uses the BackendTexture dimensions.
   TextureDescriptor descriptor = {};
-  descriptor.width = static_cast<int>(metalTexture.width);
-  descriptor.height = static_cast<int>(metalTexture.height);
+  descriptor.width = width;
+  descriptor.height = height;
   descriptor.format = ToPixelFormat(metalTexture.pixelFormat);
   descriptor.mipLevelCount = static_cast<int>(metalTexture.mipmapLevelCount);
   descriptor.sampleCount = static_cast<int>(metalTexture.sampleCount);

--- a/src/gpu/metal/MetalTexture.mm
+++ b/src/gpu/metal/MetalTexture.mm
@@ -142,8 +142,7 @@ BackendTexture MetalTexture::getBackendTexture() const {
   MetalTextureInfo metalInfo;
   metalInfo.texture = (__bridge const void*)texture;
   metalInfo.format = static_cast<unsigned>(texture.pixelFormat);
-  return BackendTexture(metalInfo, static_cast<int>(texture.width),
-                        static_cast<int>(texture.height));
+  return BackendTexture(metalInfo, descriptor.width, descriptor.height);
 }
 
 BackendRenderTarget MetalTexture::getBackendRenderTarget() const {
@@ -153,8 +152,7 @@ BackendRenderTarget MetalTexture::getBackendRenderTarget() const {
   MetalTextureInfo metalInfo;
   metalInfo.texture = (__bridge const void*)texture;
   metalInfo.format = static_cast<unsigned>(texture.pixelFormat);
-  return BackendRenderTarget(metalInfo, static_cast<int>(texture.width),
-                             static_cast<int>(texture.height));
+  return BackendRenderTarget(metalInfo, descriptor.width, descriptor.height);
 }
 
 }  // namespace tgfx

--- a/src/gpu/webgpu/WebGPUGPU.cpp
+++ b/src/gpu/webgpu/WebGPUGPU.cpp
@@ -105,7 +105,8 @@ std::shared_ptr<Texture> WebGPUGPU::importBackendTexture(const BackendTexture& b
   if (wgpuTexture == nullptr) {
     return nullptr;
   }
-  return WebGPUTexture::MakeFrom(this, wgpuTexture, usage, adopted);
+  return WebGPUTexture::MakeFrom(this, wgpuTexture, backendTexture.width(), backendTexture.height(),
+                                 usage, adopted);
 }
 
 std::shared_ptr<Texture> WebGPUGPU::importBackendRenderTarget(
@@ -119,7 +120,8 @@ std::shared_ptr<Texture> WebGPUGPU::importBackendRenderTarget(
     return nullptr;
   }
   return WebGPUTexture::MakeFrom(
-      this, wgpuTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
+      this, wgpuTexture, backendRenderTarget.width(), backendRenderTarget.height(),
+      TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
 }
 
 std::shared_ptr<Semaphore> WebGPUGPU::importBackendSemaphore(const BackendSemaphore&) {

--- a/src/gpu/webgpu/WebGPUTexture.cpp
+++ b/src/gpu/webgpu/WebGPUTexture.cpp
@@ -71,13 +71,12 @@ std::shared_ptr<WebGPUTexture> WebGPUTexture::Make(WebGPUGPU* gpu,
 }
 
 std::shared_ptr<WebGPUTexture> WebGPUTexture::MakeFrom(WebGPUGPU* gpu, WGPUTexture texture,
-                                                       uint32_t usage, bool adopted) {
+                                                       int width, int height, uint32_t usage,
+                                                       bool adopted) {
   if (gpu == nullptr || texture == nullptr) {
     return nullptr;
   }
   auto format = wgpuTextureGetFormat(texture);
-  auto width = static_cast<int>(wgpuTextureGetWidth(texture));
-  auto height = static_cast<int>(wgpuTextureGetHeight(texture));
   auto mipLevelCount = static_cast<int>(wgpuTextureGetMipLevelCount(texture));
   auto sampleCount = static_cast<int>(wgpuTextureGetSampleCount(texture));
   TextureDescriptor descriptor = {};

--- a/src/gpu/webgpu/WebGPUTexture.h
+++ b/src/gpu/webgpu/WebGPUTexture.h
@@ -30,8 +30,13 @@ class WebGPUTexture : public Texture, public WebGPUResource {
  public:
   static std::shared_ptr<WebGPUTexture> Make(WebGPUGPU* gpu, const TextureDescriptor& descriptor);
 
-  static std::shared_ptr<WebGPUTexture> MakeFrom(WebGPUGPU* gpu, WGPUTexture texture,
-                                                 uint32_t usage, bool adopted);
+  /**
+   * Creates a WebGPUTexture wrapper from an external WGPUTexture. The width and height come from
+   * the caller's declared dimensions rather than the underlying texture size, so the logical size
+   * can be a subregion of the physical texture.
+   */
+  static std::shared_ptr<WebGPUTexture> MakeFrom(WebGPUGPU* gpu, WGPUTexture texture, int width,
+                                                 int height, uint32_t usage, bool adopted);
 
   WGPUTexture webgpuTexture() const {
     return texture;

--- a/test/src/d3d12/D3D12BackendTextureTest.cpp
+++ b/test/src/d3d12/D3D12BackendTextureTest.cpp
@@ -17,11 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gpu/d3d12/D3D12GPU.h"
-#include "tgfx/core/Canvas.h"
-#include "tgfx/core/Color.h"
-#include "tgfx/core/Paint.h"
-#include "tgfx/core/Rect.h"
-#include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
 #include "tgfx/gpu/d3d12/D3D12Types.h"
@@ -46,29 +41,36 @@ TGFX_TEST(D3D12BackendTextureTest, LogicalSize) {
   auto texture = gpu->createTexture(descriptor);
   ASSERT_TRUE(texture != nullptr);
 
-  auto backendTexture = texture->getBackendTexture();
-  D3D12TextureInfo d3d12Info = {};
-  ASSERT_TRUE(backendTexture.getD3D12TextureInfo(&d3d12Info));
+  {
+    auto backendTexture = texture->getBackendTexture();
+    D3D12TextureInfo info = {};
+    ASSERT_TRUE(backendTexture.getD3D12TextureInfo(&info));
+    BackendTexture logicalTexture(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendTexture(
+        logicalTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendTexture();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 
-  BackendTexture logicalBackendTexture(d3d12Info, logicalSize, logicalSize);
-  auto imported = gpu->importBackendTexture(
-      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
-  ASSERT_TRUE(imported != nullptr);
-  EXPECT_EQ(imported->width(), logicalSize);
-  EXPECT_EQ(imported->height(), logicalSize);
-
-  auto roundTrip = imported->getBackendTexture();
-  ASSERT_TRUE(roundTrip.isValid());
-  EXPECT_EQ(roundTrip.width(), logicalSize);
-  EXPECT_EQ(roundTrip.height(), logicalSize);
-
-  auto surface = Surface::MakeFrom(context, roundTrip, ImageOrigin::TopLeft);
-  ASSERT_TRUE(surface != nullptr);
-  auto canvas = surface->getCanvas();
-  Paint paint;
-  paint.setColor(Color::Red());
-  canvas->drawRect(Rect::MakeWH(logicalSize, logicalSize), paint);
-  EXPECT_TRUE(Baseline::Compare(surface, "BackendTextureTest/LogicalSize"));
+  {
+    auto backendRenderTarget = texture->getBackendRenderTarget();
+    D3D12TextureInfo info = {};
+    ASSERT_TRUE(backendRenderTarget.getD3D12TextureInfo(&info));
+    BackendRenderTarget logicalRenderTarget(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendRenderTarget(logicalRenderTarget);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendRenderTarget();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 }
 
 }  // namespace tgfx

--- a/test/src/d3d12/D3D12BackendTextureTest.cpp
+++ b/test/src/d3d12/D3D12BackendTextureTest.cpp
@@ -16,7 +16,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "gpu/metal/MetalGPU.h"
+#include "gpu/d3d12/D3D12GPU.h"
 #include "tgfx/core/Canvas.h"
 #include "tgfx/core/Color.h"
 #include "tgfx/core/Paint.h"
@@ -24,18 +24,18 @@
 #include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
-#include "tgfx/gpu/metal/MetalTypes.h"
+#include "tgfx/gpu/d3d12/D3D12Types.h"
 #include "utils/TestUtils.h"
 
 namespace tgfx {
 
-TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
+TGFX_TEST(D3D12BackendTextureTest, LogicalSize) {
   ContextScope scope;
   auto context = scope.getContext();
   if (context == nullptr) {
-    GTEST_SKIP() << "Metal backend not available";
+    GTEST_SKIP() << "D3D12 backend not available";
   }
-  auto gpu = static_cast<MetalGPU*>(context->gpu());
+  auto gpu = static_cast<D3D12GPU*>(context->gpu());
   ASSERT_TRUE(gpu != nullptr);
 
   const int physicalSize = 200;
@@ -47,10 +47,10 @@ TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
   ASSERT_TRUE(texture != nullptr);
 
   auto backendTexture = texture->getBackendTexture();
-  MetalTextureInfo metalInfo = {};
-  ASSERT_TRUE(backendTexture.getMetalTextureInfo(&metalInfo));
+  D3D12TextureInfo d3d12Info = {};
+  ASSERT_TRUE(backendTexture.getD3D12TextureInfo(&d3d12Info));
 
-  BackendTexture logicalBackendTexture(metalInfo, logicalSize, logicalSize);
+  BackendTexture logicalBackendTexture(d3d12Info, logicalSize, logicalSize);
   auto imported = gpu->importBackendTexture(
       logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
   ASSERT_TRUE(imported != nullptr);

--- a/test/src/metal/MetalBackendTextureTest.mm
+++ b/test/src/metal/MetalBackendTextureTest.mm
@@ -1,0 +1,94 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
+//  either express or implied. see the license for the specific language governing permissions
+//  and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <Metal/Metal.h>
+#include "gpu/metal/MetalGPU.h"
+#include "tgfx/gpu/Backend.h"
+#include "tgfx/gpu/metal/MetalTypes.h"
+#include "utils/TestUtils.h"
+
+namespace tgfx {
+
+TGFX_TEST(MetalBackendTextureTest, PreservesLogicalSize) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  if (context == nullptr) {
+    GTEST_SKIP() << "Metal backend not available";
+  }
+  auto gpu = static_cast<MetalGPU*>(context->gpu());
+  ASSERT_TRUE(gpu != nullptr);
+
+  const int physicalSize = 1024;
+  const int logicalWidth = 100;
+  const int logicalHeight = 80;
+
+  {
+    MTLTextureDescriptor* descriptor =
+        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
+                                                           width:physicalSize
+                                                          height:physicalSize
+                                                       mipmapped:NO];
+    id<MTLTexture> metalTexture = [gpu->device() newTextureWithDescriptor:descriptor];
+    ASSERT_TRUE(metalTexture != nil);
+
+    MetalTextureInfo metalInfo = {};
+    metalInfo.texture = (__bridge const void*)metalTexture;
+    metalInfo.format = static_cast<unsigned>(MTLPixelFormatRGBA8Unorm);
+
+    BackendTexture backendTexture(metalInfo, logicalWidth, logicalHeight);
+    auto texture = gpu->importBackendTexture(backendTexture, TextureUsage::TEXTURE_BINDING, true);
+    ASSERT_TRUE(texture != nullptr);
+    EXPECT_EQ(texture->width(), logicalWidth);
+    EXPECT_EQ(texture->height(), logicalHeight);
+
+    auto roundTrip = texture->getBackendTexture();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalWidth);
+    EXPECT_EQ(roundTrip.height(), logicalHeight);
+  }
+
+  {
+    MTLTextureDescriptor* descriptor =
+        [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA8Unorm
+                                                           width:physicalSize
+                                                          height:physicalSize
+                                                       mipmapped:NO];
+    id<MTLTexture> metalTexture = [gpu->device() newTextureWithDescriptor:descriptor];
+    ASSERT_TRUE(metalTexture != nil);
+
+    MetalTextureInfo metalInfo = {};
+    metalInfo.texture = (__bridge const void*)metalTexture;
+    metalInfo.format = static_cast<unsigned>(MTLPixelFormatRGBA8Unorm);
+
+    BackendRenderTarget backendRenderTarget(metalInfo, logicalWidth, logicalHeight);
+    auto renderTarget = gpu->importBackendRenderTarget(backendRenderTarget);
+    ASSERT_TRUE(renderTarget != nullptr);
+    EXPECT_EQ(renderTarget->width(), logicalWidth);
+    EXPECT_EQ(renderTarget->height(), logicalHeight);
+
+    auto roundTrip = renderTarget->getBackendRenderTarget();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalWidth);
+    EXPECT_EQ(roundTrip.height(), logicalHeight);
+
+    renderTarget.reset();
+    [metalTexture release];
+  }
+}
+
+}  // namespace tgfx

--- a/test/src/metal/MetalBackendTextureTest.mm
+++ b/test/src/metal/MetalBackendTextureTest.mm
@@ -17,11 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gpu/metal/MetalGPU.h"
-#include "tgfx/core/Canvas.h"
-#include "tgfx/core/Color.h"
-#include "tgfx/core/Paint.h"
-#include "tgfx/core/Rect.h"
-#include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
 #include "tgfx/gpu/metal/MetalTypes.h"
@@ -46,29 +41,36 @@ TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
   auto texture = gpu->createTexture(descriptor);
   ASSERT_TRUE(texture != nullptr);
 
-  auto backendTexture = texture->getBackendTexture();
-  MetalTextureInfo metalInfo = {};
-  ASSERT_TRUE(backendTexture.getMetalTextureInfo(&metalInfo));
+  {
+    auto backendTexture = texture->getBackendTexture();
+    MetalTextureInfo info = {};
+    ASSERT_TRUE(backendTexture.getMetalTextureInfo(&info));
+    BackendTexture logicalTexture(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendTexture(
+        logicalTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendTexture();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 
-  BackendTexture logicalBackendTexture(metalInfo, logicalSize, logicalSize);
-  auto imported = gpu->importBackendTexture(
-      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
-  ASSERT_TRUE(imported != nullptr);
-  EXPECT_EQ(imported->width(), logicalSize);
-  EXPECT_EQ(imported->height(), logicalSize);
-
-  auto roundTrip = imported->getBackendTexture();
-  ASSERT_TRUE(roundTrip.isValid());
-  EXPECT_EQ(roundTrip.width(), logicalSize);
-  EXPECT_EQ(roundTrip.height(), logicalSize);
-
-  auto surface = Surface::MakeFrom(context, roundTrip, ImageOrigin::TopLeft);
-  ASSERT_TRUE(surface != nullptr);
-  auto canvas = surface->getCanvas();
-  Paint paint;
-  paint.setColor(Color::Red());
-  canvas->drawRect(Rect::MakeWH(logicalSize, logicalSize), paint);
-  EXPECT_TRUE(Baseline::Compare(surface, "BackendTextureTest/LogicalSize"));
+  {
+    auto backendRenderTarget = texture->getBackendRenderTarget();
+    MetalTextureInfo info = {};
+    ASSERT_TRUE(backendRenderTarget.getMetalTextureInfo(&info));
+    BackendRenderTarget logicalRenderTarget(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendRenderTarget(logicalRenderTarget);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendRenderTarget();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 }
 
 }  // namespace tgfx

--- a/test/src/opengl/GLBackendTextureTest.cpp
+++ b/test/src/opengl/GLBackendTextureTest.cpp
@@ -17,11 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gpu/opengl/GLGPU.h"
-#include "tgfx/core/Canvas.h"
-#include "tgfx/core/Color.h"
-#include "tgfx/core/Paint.h"
-#include "tgfx/core/Rect.h"
-#include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
 #include "tgfx/gpu/opengl/GLTypes.h"
@@ -46,30 +41,36 @@ TGFX_TEST(GLBackendTextureTest, LogicalSize) {
   auto texture = gpu->createTexture(descriptor);
   ASSERT_TRUE(texture != nullptr);
 
-  auto backendTexture = texture->getBackendTexture();
-  GLTextureInfo glInfo = {};
-  ASSERT_TRUE(backendTexture.getGLTextureInfo(&glInfo));
+  {
+    auto backendTexture = texture->getBackendTexture();
+    GLTextureInfo info = {};
+    ASSERT_TRUE(backendTexture.getGLTextureInfo(&info));
+    BackendTexture logicalTexture(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendTexture(
+        logicalTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendTexture();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 
-  BackendTexture logicalBackendTexture(glInfo, logicalSize, logicalSize);
-  auto imported = gpu->importBackendTexture(
-      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING,
-      false);
-  ASSERT_TRUE(imported != nullptr);
-  EXPECT_EQ(imported->width(), logicalSize);
-  EXPECT_EQ(imported->height(), logicalSize);
-
-  auto roundTrip = imported->getBackendTexture();
-  ASSERT_TRUE(roundTrip.isValid());
-  EXPECT_EQ(roundTrip.width(), logicalSize);
-  EXPECT_EQ(roundTrip.height(), logicalSize);
-
-  auto surface = Surface::MakeFrom(context, roundTrip, ImageOrigin::TopLeft);
-  ASSERT_TRUE(surface != nullptr);
-  auto canvas = surface->getCanvas();
-  Paint paint;
-  paint.setColor(Color::Red());
-  canvas->drawRect(Rect::MakeWH(logicalSize, logicalSize), paint);
-  EXPECT_TRUE(Baseline::Compare(surface, "BackendTextureTest/LogicalSize"));
+  {
+    auto backendRenderTarget = texture->getBackendRenderTarget();
+    GLFrameBufferInfo info = {};
+    ASSERT_TRUE(backendRenderTarget.getGLFramebufferInfo(&info));
+    BackendRenderTarget logicalRenderTarget(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendRenderTarget(logicalRenderTarget);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendRenderTarget();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 }
 
 }  // namespace tgfx

--- a/test/src/opengl/GLBackendTextureTest.cpp
+++ b/test/src/opengl/GLBackendTextureTest.cpp
@@ -16,7 +16,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "gpu/metal/MetalGPU.h"
+#include "gpu/opengl/GLGPU.h"
 #include "tgfx/core/Canvas.h"
 #include "tgfx/core/Color.h"
 #include "tgfx/core/Paint.h"
@@ -24,18 +24,18 @@
 #include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
-#include "tgfx/gpu/metal/MetalTypes.h"
+#include "tgfx/gpu/opengl/GLTypes.h"
 #include "utils/TestUtils.h"
 
 namespace tgfx {
 
-TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
+TGFX_TEST(GLBackendTextureTest, LogicalSize) {
   ContextScope scope;
   auto context = scope.getContext();
   if (context == nullptr) {
-    GTEST_SKIP() << "Metal backend not available";
+    GTEST_SKIP() << "OpenGL backend not available";
   }
-  auto gpu = static_cast<MetalGPU*>(context->gpu());
+  auto gpu = static_cast<GLGPU*>(context->gpu());
   ASSERT_TRUE(gpu != nullptr);
 
   const int physicalSize = 200;
@@ -47,12 +47,13 @@ TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
   ASSERT_TRUE(texture != nullptr);
 
   auto backendTexture = texture->getBackendTexture();
-  MetalTextureInfo metalInfo = {};
-  ASSERT_TRUE(backendTexture.getMetalTextureInfo(&metalInfo));
+  GLTextureInfo glInfo = {};
+  ASSERT_TRUE(backendTexture.getGLTextureInfo(&glInfo));
 
-  BackendTexture logicalBackendTexture(metalInfo, logicalSize, logicalSize);
+  BackendTexture logicalBackendTexture(glInfo, logicalSize, logicalSize);
   auto imported = gpu->importBackendTexture(
-      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
+      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING,
+      false);
   ASSERT_TRUE(imported != nullptr);
   EXPECT_EQ(imported->width(), logicalSize);
   EXPECT_EQ(imported->height(), logicalSize);

--- a/test/src/vulkan/VulkanBackendTextureTest.cpp
+++ b/test/src/vulkan/VulkanBackendTextureTest.cpp
@@ -17,11 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gpu/vulkan/VulkanGPU.h"
-#include "tgfx/core/Canvas.h"
-#include "tgfx/core/Color.h"
-#include "tgfx/core/Paint.h"
-#include "tgfx/core/Rect.h"
-#include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
 #include "tgfx/gpu/vulkan/VulkanTypes.h"
@@ -46,29 +41,36 @@ TGFX_TEST(VulkanBackendTextureTest, LogicalSize) {
   auto texture = gpu->createTexture(descriptor);
   ASSERT_TRUE(texture != nullptr);
 
-  auto backendTexture = texture->getBackendTexture();
-  VulkanImageInfo vulkanInfo = {};
-  ASSERT_TRUE(backendTexture.getVulkanImageInfo(&vulkanInfo));
+  {
+    auto backendTexture = texture->getBackendTexture();
+    VulkanImageInfo info = {};
+    ASSERT_TRUE(backendTexture.getVulkanImageInfo(&info));
+    BackendTexture logicalTexture(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendTexture(
+        logicalTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendTexture();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 
-  BackendTexture logicalBackendTexture(vulkanInfo, logicalSize, logicalSize);
-  auto imported = gpu->importBackendTexture(
-      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
-  ASSERT_TRUE(imported != nullptr);
-  EXPECT_EQ(imported->width(), logicalSize);
-  EXPECT_EQ(imported->height(), logicalSize);
-
-  auto roundTrip = imported->getBackendTexture();
-  ASSERT_TRUE(roundTrip.isValid());
-  EXPECT_EQ(roundTrip.width(), logicalSize);
-  EXPECT_EQ(roundTrip.height(), logicalSize);
-
-  auto surface = Surface::MakeFrom(context, roundTrip, ImageOrigin::TopLeft);
-  ASSERT_TRUE(surface != nullptr);
-  auto canvas = surface->getCanvas();
-  Paint paint;
-  paint.setColor(Color::Red());
-  canvas->drawRect(Rect::MakeWH(logicalSize, logicalSize), paint);
-  EXPECT_TRUE(Baseline::Compare(surface, "BackendTextureTest/LogicalSize"));
+  {
+    auto backendRenderTarget = texture->getBackendRenderTarget();
+    VulkanImageInfo info = {};
+    ASSERT_TRUE(backendRenderTarget.getVulkanImageInfo(&info));
+    BackendRenderTarget logicalRenderTarget(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendRenderTarget(logicalRenderTarget);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendRenderTarget();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 }
 
 }  // namespace tgfx

--- a/test/src/vulkan/VulkanBackendTextureTest.cpp
+++ b/test/src/vulkan/VulkanBackendTextureTest.cpp
@@ -16,7 +16,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "gpu/metal/MetalGPU.h"
+#include "gpu/vulkan/VulkanGPU.h"
 #include "tgfx/core/Canvas.h"
 #include "tgfx/core/Color.h"
 #include "tgfx/core/Paint.h"
@@ -24,18 +24,18 @@
 #include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
-#include "tgfx/gpu/metal/MetalTypes.h"
+#include "tgfx/gpu/vulkan/VulkanTypes.h"
 #include "utils/TestUtils.h"
 
 namespace tgfx {
 
-TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
+TGFX_TEST(VulkanBackendTextureTest, LogicalSize) {
   ContextScope scope;
   auto context = scope.getContext();
   if (context == nullptr) {
-    GTEST_SKIP() << "Metal backend not available";
+    GTEST_SKIP() << "Vulkan backend not available";
   }
-  auto gpu = static_cast<MetalGPU*>(context->gpu());
+  auto gpu = static_cast<VulkanGPU*>(context->gpu());
   ASSERT_TRUE(gpu != nullptr);
 
   const int physicalSize = 200;
@@ -47,10 +47,10 @@ TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
   ASSERT_TRUE(texture != nullptr);
 
   auto backendTexture = texture->getBackendTexture();
-  MetalTextureInfo metalInfo = {};
-  ASSERT_TRUE(backendTexture.getMetalTextureInfo(&metalInfo));
+  VulkanImageInfo vulkanInfo = {};
+  ASSERT_TRUE(backendTexture.getVulkanImageInfo(&vulkanInfo));
 
-  BackendTexture logicalBackendTexture(metalInfo, logicalSize, logicalSize);
+  BackendTexture logicalBackendTexture(vulkanInfo, logicalSize, logicalSize);
   auto imported = gpu->importBackendTexture(
       logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
   ASSERT_TRUE(imported != nullptr);

--- a/test/src/webgpu/WebGPUBackendTextureTest.cpp
+++ b/test/src/webgpu/WebGPUBackendTextureTest.cpp
@@ -17,11 +17,6 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "gpu/webgpu/WebGPUGPU.h"
-#include "tgfx/core/Canvas.h"
-#include "tgfx/core/Color.h"
-#include "tgfx/core/Paint.h"
-#include "tgfx/core/Rect.h"
-#include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
 #include "tgfx/gpu/webgpu/WebGPUTypes.h"
@@ -46,29 +41,36 @@ TGFX_TEST(WebGPUBackendTextureTest, LogicalSize) {
   auto texture = gpu->createTexture(descriptor);
   ASSERT_TRUE(texture != nullptr);
 
-  auto backendTexture = texture->getBackendTexture();
-  WebGPUTextureInfo webgpuInfo = {};
-  ASSERT_TRUE(backendTexture.getWebGPUTextureInfo(&webgpuInfo));
+  {
+    auto backendTexture = texture->getBackendTexture();
+    WebGPUTextureInfo info = {};
+    ASSERT_TRUE(backendTexture.getWebGPUTextureInfo(&info));
+    BackendTexture logicalTexture(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendTexture(
+        logicalTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING, false);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendTexture();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 
-  BackendTexture logicalBackendTexture(webgpuInfo, logicalSize, logicalSize);
-  auto imported = gpu->importBackendTexture(
-      logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
-  ASSERT_TRUE(imported != nullptr);
-  EXPECT_EQ(imported->width(), logicalSize);
-  EXPECT_EQ(imported->height(), logicalSize);
-
-  auto roundTrip = imported->getBackendTexture();
-  ASSERT_TRUE(roundTrip.isValid());
-  EXPECT_EQ(roundTrip.width(), logicalSize);
-  EXPECT_EQ(roundTrip.height(), logicalSize);
-
-  auto surface = Surface::MakeFrom(context, roundTrip, ImageOrigin::TopLeft);
-  ASSERT_TRUE(surface != nullptr);
-  auto canvas = surface->getCanvas();
-  Paint paint;
-  paint.setColor(Color::Red());
-  canvas->drawRect(Rect::MakeWH(logicalSize, logicalSize), paint);
-  EXPECT_TRUE(Baseline::Compare(surface, "BackendTextureTest/LogicalSize"));
+  {
+    auto backendRenderTarget = texture->getBackendRenderTarget();
+    WebGPUTextureInfo info = {};
+    ASSERT_TRUE(backendRenderTarget.getWebGPUTextureInfo(&info));
+    BackendRenderTarget logicalRenderTarget(info, logicalSize, logicalSize);
+    auto imported = gpu->importBackendRenderTarget(logicalRenderTarget);
+    ASSERT_TRUE(imported != nullptr);
+    EXPECT_EQ(imported->width(), logicalSize);
+    EXPECT_EQ(imported->height(), logicalSize);
+    auto roundTrip = imported->getBackendRenderTarget();
+    ASSERT_TRUE(roundTrip.isValid());
+    EXPECT_EQ(roundTrip.width(), logicalSize);
+    EXPECT_EQ(roundTrip.height(), logicalSize);
+  }
 }
 
 }  // namespace tgfx

--- a/test/src/webgpu/WebGPUBackendTextureTest.cpp
+++ b/test/src/webgpu/WebGPUBackendTextureTest.cpp
@@ -16,7 +16,7 @@
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "gpu/metal/MetalGPU.h"
+#include "gpu/webgpu/WebGPUGPU.h"
 #include "tgfx/core/Canvas.h"
 #include "tgfx/core/Color.h"
 #include "tgfx/core/Paint.h"
@@ -24,18 +24,18 @@
 #include "tgfx/core/Surface.h"
 #include "tgfx/gpu/Backend.h"
 #include "tgfx/gpu/Texture.h"
-#include "tgfx/gpu/metal/MetalTypes.h"
+#include "tgfx/gpu/webgpu/WebGPUTypes.h"
 #include "utils/TestUtils.h"
 
 namespace tgfx {
 
-TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
+TGFX_TEST(WebGPUBackendTextureTest, LogicalSize) {
   ContextScope scope;
   auto context = scope.getContext();
   if (context == nullptr) {
-    GTEST_SKIP() << "Metal backend not available";
+    GTEST_SKIP() << "WebGPU backend not available";
   }
-  auto gpu = static_cast<MetalGPU*>(context->gpu());
+  auto gpu = static_cast<WebGPUGPU*>(context->gpu());
   ASSERT_TRUE(gpu != nullptr);
 
   const int physicalSize = 200;
@@ -47,10 +47,10 @@ TGFX_TEST(MetalBackendTextureTest, LogicalSize) {
   ASSERT_TRUE(texture != nullptr);
 
   auto backendTexture = texture->getBackendTexture();
-  MetalTextureInfo metalInfo = {};
-  ASSERT_TRUE(backendTexture.getMetalTextureInfo(&metalInfo));
+  WebGPUTextureInfo webgpuInfo = {};
+  ASSERT_TRUE(backendTexture.getWebGPUTextureInfo(&webgpuInfo));
 
-  BackendTexture logicalBackendTexture(metalInfo, logicalSize, logicalSize);
+  BackendTexture logicalBackendTexture(webgpuInfo, logicalSize, logicalSize);
   auto imported = gpu->importBackendTexture(
       logicalBackendTexture, TextureUsage::RENDER_ATTACHMENT | TextureUsage::TEXTURE_BINDING);
   ASSERT_TRUE(imported != nullptr);


### PR DESCRIPTION
修复各后端在包装外部纹理时，逻辑尺寸错误继承物理纹理尺寸的问题。

此前 Metal、D3D12、WebGPU 的 importBackendTexture/importBackendRenderTarget 在创建纹理包装时，直接读取底层资源（MTLTexture、D3D12 resource、WGPUTexture）的物理宽高作为纹理描述符尺寸。当外部纹理是一个更大物理纹理的子区域时，逻辑尺寸会被错误放大为物理尺寸，导致采样区域与声明不符。

OpenGL 与 Vulkan 后端一直使用调用方声明的宽高（BackendTexture/BackendRenderTarget）。本次改动让 Metal、D3D12、WebGPU 后端保持一致，统一接收声明宽高，使逻辑尺寸能正确表示物理纹理的子区域。