### PR TITLE
Add SetMaxThreads to limit and release task worker threads

### DIFF
--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -77,10 +77,8 @@ class Task {
   /**
    * Sets the maximum number of worker threads that can be created for running tasks. Call this
    * method before submitting any tasks to avoid thread creation races. A value of zero restores
-   * the default, which is based on the number of CPU cores and capped at 32. Worker threads are
-   * created lazily as tasks are submitted, and the actual number never exceeds this limit. If the
-   * limit is lowered, the surplus idle worker threads are released, and threads busy with tasks
-   * exit once they become idle.
+   * the default, which is based on the number of CPU cores and capped at 32. Lowering the limit
+   * releases the surplus worker threads.
    * @param maxThreads The maximum number of worker threads. Zero means use the default.
    */
   static void SetMaxThreads(int maxThreads);

--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -75,6 +75,15 @@ enum class TaskPriority {
 class Task {
  public:
   /**
+   * Sets the maximum number of worker threads that can be created for running tasks. Call this
+   * method before submitting any tasks to avoid thread creation races. A value of zero restores
+   * the default, which is based on the number of CPU cores and capped at 32. Worker threads are
+   * created lazily as tasks are submitted, and the actual number never exceeds this limit.
+   * @param maxThreads The maximum number of worker threads. Zero means use the default.
+   */
+  static void SetMaxThreads(int maxThreads);
+
+  /**
    * Release all task threads once the pending tasks have completed. This method will block the
    * current thread.
    */

--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -79,9 +79,15 @@ class Task {
    * method before submitting any tasks to avoid thread creation races. A value of zero restores
    * the default, which is based on the number of CPU cores and capped at 32. Lowering the limit
    * releases the surplus worker threads.
-   * @param maxThreads The maximum number of worker threads. Zero means use the default.
+   * @param maxThreadCount The maximum number of worker threads. Zero means use the default.
    */
-  static void SetMaxThreads(int maxThreads);
+  static void SetMaxThreadCount(size_t maxThreadCount);
+
+  /**
+   * Returns the current maximum number of worker threads that can be created for running tasks.
+   * @return The current maximum number of worker threads.
+   */
+  static size_t MaxThreadCount();
 
   /**
    * Release all task threads once the pending tasks have completed. This method will block the

--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -78,7 +78,9 @@ class Task {
    * Sets the maximum number of worker threads that can be created for running tasks. Call this
    * method before submitting any tasks to avoid thread creation races. A value of zero restores
    * the default, which is based on the number of CPU cores and capped at 32. Worker threads are
-   * created lazily as tasks are submitted, and the actual number never exceeds this limit.
+   * created lazily as tasks are submitted, and the actual number never exceeds this limit. If the
+   * limit is lowered, the surplus idle worker threads are released, and threads busy with tasks
+   * exit once they become idle.
    * @param maxThreads The maximum number of worker threads. Zero means use the default.
    */
   static void SetMaxThreads(int maxThreads);

--- a/src/core/utils/Task.cpp
+++ b/src/core/utils/Task.cpp
@@ -35,6 +35,10 @@ class BlockTask : public Task {
   std::function<void()> block;
 };
 
+void Task::SetMaxThreads(int maxThreads) {
+  TaskGroup::GetInstance()->setMaxThreads(maxThreads);
+}
+
 void Task::ReleaseThreads() {
   TaskGroup::GetInstance()->releaseThreads(false);
 }

--- a/src/core/utils/Task.cpp
+++ b/src/core/utils/Task.cpp
@@ -35,8 +35,12 @@ class BlockTask : public Task {
   std::function<void()> block;
 };
 
-void Task::SetMaxThreads(int maxThreads) {
-  TaskGroup::GetInstance()->setMaxThreads(maxThreads);
+void Task::SetMaxThreadCount(size_t maxThreadCount) {
+  TaskGroup::GetInstance()->setMaxThreadCount(maxThreadCount);
+}
+
+size_t Task::MaxThreadCount() {
+  return TaskGroup::GetInstance()->maxThreadCount();
 }
 
 void Task::ReleaseThreads() {

--- a/src/core/utils/TaskGroup.cpp
+++ b/src/core/utils/TaskGroup.cpp
@@ -63,6 +63,9 @@ void TaskGroup::RunLoop(TaskGroup* taskGroup) {
       if (taskGroup->exited) {
         break;
       }
+      if (taskGroup->shrinkThread()) {
+        break;
+      }
       continue;
     }
     task->execute();
@@ -98,6 +101,18 @@ void TaskGroup::setMaxThreads(int maxThreads) {
   if (lowPriorityThreads < 1) {
     lowPriorityThreads = 1;
   }
+  // Wake up idle threads so they can exit if the pool exceeds the new limit.
+  condition.notify_all();
+}
+
+bool TaskGroup::shrinkThread() {
+  int total = totalThreads.load();
+  while (total > maxThreads.load()) {
+    if (totalThreads.compare_exchange_weak(total, total - 1)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool TaskGroup::checkThreads() {
@@ -148,7 +163,7 @@ std::shared_ptr<Task> TaskGroup::popTask() {
         return task;
       }
     }
-    if (exited) {
+    if (exited || totalThreads > maxThreads) {
       return nullptr;
     }
     ++waitingThreads;

--- a/src/core/utils/TaskGroup.cpp
+++ b/src/core/utils/TaskGroup.cpp
@@ -89,6 +89,17 @@ TaskGroup::TaskGroup() : maxThreads(GetMaxThreads()) {
   std::atexit(OnAppExit);
 }
 
+void TaskGroup::setMaxThreads(int maxThreads) {
+  if (maxThreads <= 0) {
+    maxThreads = GetMaxThreads();
+  }
+  this->maxThreads = maxThreads;
+  lowPriorityThreads = FloatRoundToInt(static_cast<float>(maxThreads) * LOW_PRIORITY_THREAD_RATIO);
+  if (lowPriorityThreads < 1) {
+    lowPriorityThreads = 1;
+  }
+}
+
 bool TaskGroup::checkThreads() {
   if (waitingThreads == 0 && totalThreads < maxThreads) {
     auto thread = new (std::nothrow) std::thread(TaskGroup::RunLoop, this);

--- a/src/core/utils/TaskGroup.cpp
+++ b/src/core/utils/TaskGroup.cpp
@@ -28,27 +28,27 @@
 
 namespace tgfx {
 static constexpr auto THREAD_TIMEOUT = std::chrono::seconds(10);
-static constexpr int MAX_THREADS_SIZE = 32;
+static constexpr size_t MAX_THREADS_SIZE = 32;
 static constexpr size_t TASK_PRIORITY_SIZE = 3;
 // 70% of max threads can run low priority tasks
 static constexpr float LOW_PRIORITY_THREAD_RATIO = 0.7f;
 
 static size_t GetDefaultMaxThreadCount() {
-  int cpuCores = 0;
+  size_t cpuCores = 0;
 #ifdef __APPLE__
   size_t len = sizeof(cpuCores);
   // We can get the exact number of physical CPUs on apple platforms.
   sysctlbyname("hw.physicalcpu", &cpuCores, &len, nullptr, 0);
 #else
-  cpuCores = static_cast<int>(std::thread::hardware_concurrency());
+  cpuCores = std::thread::hardware_concurrency();
 #endif
-  if (cpuCores <= 0) {
+  if (cpuCores == 0) {
     cpuCores = 8;
   }
   if (cpuCores > MAX_THREADS_SIZE) {
     cpuCores = MAX_THREADS_SIZE;
   }
-  return static_cast<size_t>(cpuCores);
+  return cpuCores;
 }
 
 TaskGroup* TaskGroup::GetInstance() {

--- a/src/core/utils/TaskGroup.cpp
+++ b/src/core/utils/TaskGroup.cpp
@@ -33,7 +33,7 @@ static constexpr size_t TASK_PRIORITY_SIZE = 3;
 // 70% of max threads can run low priority tasks
 static constexpr float LOW_PRIORITY_THREAD_RATIO = 0.7f;
 
-static int GetMaxThreads() {
+static size_t GetDefaultMaxThreadCount() {
   int cpuCores = 0;
 #ifdef __APPLE__
   size_t len = sizeof(cpuCores);
@@ -48,7 +48,7 @@ static int GetMaxThreads() {
   if (cpuCores > MAX_THREADS_SIZE) {
     cpuCores = MAX_THREADS_SIZE;
   }
-  return cpuCores;
+  return static_cast<size_t>(cpuCores);
 }
 
 TaskGroup* TaskGroup::GetInstance() {
@@ -78,12 +78,13 @@ void OnAppExit() {
   TaskGroup::GetInstance()->exit();
 }
 
-TaskGroup::TaskGroup() : maxThreads(GetMaxThreads()) {
-  lowPriorityThreads = FloatRoundToInt(static_cast<float>(maxThreads) * LOW_PRIORITY_THREAD_RATIO);
+TaskGroup::TaskGroup() : _maxThreadCount(GetDefaultMaxThreadCount()) {
+  lowPriorityThreads = static_cast<size_t>(
+      FloatRoundToInt(static_cast<float>(_maxThreadCount.load()) * LOW_PRIORITY_THREAD_RATIO));
   if (lowPriorityThreads < 1) {
     lowPriorityThreads = 1;
   }
-  threads = new moodycamel::ConcurrentQueue<std::thread*>(static_cast<size_t>(maxThreads));
+  threads = new moodycamel::ConcurrentQueue<std::thread*>(_maxThreadCount.load());
   priorityQueues.reserve(TASK_PRIORITY_SIZE);
   for (size_t i = 0; i < TASK_PRIORITY_SIZE; i++) {
     auto queue = new moodycamel::ConcurrentQueue<std::shared_ptr<Task>>();
@@ -92,12 +93,14 @@ TaskGroup::TaskGroup() : maxThreads(GetMaxThreads()) {
   std::atexit(OnAppExit);
 }
 
-void TaskGroup::setMaxThreads(int maxThreads) {
-  if (maxThreads <= 0) {
-    maxThreads = GetMaxThreads();
+void TaskGroup::setMaxThreadCount(size_t maxThreadCount) {
+  if (maxThreadCount == 0) {
+    maxThreadCount = GetDefaultMaxThreadCount();
   }
-  this->maxThreads = maxThreads;
-  lowPriorityThreads = FloatRoundToInt(static_cast<float>(maxThreads) * LOW_PRIORITY_THREAD_RATIO);
+  std::lock_guard<std::mutex> autoLock(locker);
+  _maxThreadCount = maxThreadCount;
+  lowPriorityThreads = static_cast<size_t>(
+      FloatRoundToInt(static_cast<float>(maxThreadCount) * LOW_PRIORITY_THREAD_RATIO));
   if (lowPriorityThreads < 1) {
     lowPriorityThreads = 1;
   }
@@ -105,9 +108,13 @@ void TaskGroup::setMaxThreads(int maxThreads) {
   condition.notify_all();
 }
 
+size_t TaskGroup::maxThreadCount() const {
+  return _maxThreadCount.load();
+}
+
 bool TaskGroup::shrinkThread() {
-  int total = totalThreads.load();
-  while (total > maxThreads.load()) {
+  size_t total = totalThreads.load();
+  while (total > _maxThreadCount.load()) {
     if (totalThreads.compare_exchange_weak(total, total - 1)) {
       return true;
     }
@@ -116,7 +123,7 @@ bool TaskGroup::shrinkThread() {
 }
 
 bool TaskGroup::checkThreads() {
-  if (waitingThreads == 0 && totalThreads < maxThreads) {
+  if (waitingThreads.load() == 0 && totalThreads.load() < _maxThreadCount.load()) {
     auto thread = new (std::nothrow) std::thread(TaskGroup::RunLoop, this);
     if (thread) {
       if (threads->enqueue(thread)) {
@@ -143,32 +150,52 @@ bool TaskGroup::pushTask(std::shared_ptr<Task> task, TaskPriority priority) {
   if (!queue->enqueue(task)) {
     return false;
   }
+  std::lock_guard<std::mutex> autoLock(locker);
   if (waitingThreads > 0) {
     condition.notify_one();
   }
   return true;
 }
 
+std::shared_ptr<Task> TaskGroup::tryDequeueTask() {
+  std::shared_ptr<Task> task = nullptr;
+  for (size_t i = 0; i < static_cast<size_t>(TaskPriority::Low); i++) {
+    if (priorityQueues[i]->try_dequeue(task)) {
+      return task;
+    }
+  }
+  if (totalThreads.load() - waitingThreads.load() < lowPriorityThreads.load()) {
+    auto& queue = priorityQueues[static_cast<size_t>(TaskPriority::Low)];
+    if (queue->try_dequeue(task)) {
+      return task;
+    }
+  }
+  return nullptr;
+}
+
 std::shared_ptr<Task> TaskGroup::popTask() {
   while (!exited) {
-    std::shared_ptr<Task> task = nullptr;
-    for (size_t i = 0; i < static_cast<size_t>(TaskPriority::Low); i++) {
-      if (priorityQueues[i]->try_dequeue(task)) {
-        return task;
-      }
+    auto task = tryDequeueTask();
+    if (task) {
+      return task;
     }
-    if (totalThreads - waitingThreads < lowPriorityThreads) {
-      auto& queue = priorityQueues[static_cast<size_t>(TaskPriority::Low)];
-      if (queue->try_dequeue(task)) {
-        return task;
-      }
-    }
-    if (exited || totalThreads > maxThreads) {
+    if (exited || totalThreads.load() > _maxThreadCount.load()) {
       return nullptr;
     }
     ++waitingThreads;
     {
       std::unique_lock<std::mutex> autoLock(locker);
+      // Re-check the queues while holding the lock so a task pushed concurrently cannot be missed
+      // by a lost notification.
+      task = tryDequeueTask();
+      if (task) {
+        --waitingThreads;
+        return task;
+      }
+      if (totalThreads.load() > _maxThreadCount.load()) {
+        --waitingThreads;
+        return nullptr;
+      }
       auto status = condition.wait_for(autoLock, THREAD_TIMEOUT);
       if (status == std::cv_status::timeout) {
         --waitingThreads;

--- a/src/core/utils/TaskGroup.cpp
+++ b/src/core/utils/TaskGroup.cpp
@@ -78,13 +78,13 @@ void OnAppExit() {
   TaskGroup::GetInstance()->exit();
 }
 
-TaskGroup::TaskGroup() : _maxThreadCount(GetDefaultMaxThreadCount()) {
+TaskGroup::TaskGroup() : maxThreads(GetDefaultMaxThreadCount()) {
   lowPriorityThreads = static_cast<size_t>(
-      FloatRoundToInt(static_cast<float>(_maxThreadCount.load()) * LOW_PRIORITY_THREAD_RATIO));
+      FloatRoundToInt(static_cast<float>(maxThreads.load()) * LOW_PRIORITY_THREAD_RATIO));
   if (lowPriorityThreads < 1) {
     lowPriorityThreads = 1;
   }
-  threads = new moodycamel::ConcurrentQueue<std::thread*>(_maxThreadCount.load());
+  threads = new moodycamel::ConcurrentQueue<std::thread*>(maxThreads.load());
   priorityQueues.reserve(TASK_PRIORITY_SIZE);
   for (size_t i = 0; i < TASK_PRIORITY_SIZE; i++) {
     auto queue = new moodycamel::ConcurrentQueue<std::shared_ptr<Task>>();
@@ -98,7 +98,7 @@ void TaskGroup::setMaxThreadCount(size_t maxThreadCount) {
     maxThreadCount = GetDefaultMaxThreadCount();
   }
   std::lock_guard<std::mutex> autoLock(locker);
-  _maxThreadCount = maxThreadCount;
+  maxThreads = maxThreadCount;
   lowPriorityThreads = static_cast<size_t>(
       FloatRoundToInt(static_cast<float>(maxThreadCount) * LOW_PRIORITY_THREAD_RATIO));
   if (lowPriorityThreads < 1) {
@@ -109,12 +109,16 @@ void TaskGroup::setMaxThreadCount(size_t maxThreadCount) {
 }
 
 size_t TaskGroup::maxThreadCount() const {
-  return _maxThreadCount.load();
+  return maxThreads.load();
+}
+
+bool TaskGroup::shouldExit() const {
+  return exited || totalThreads.load() > maxThreads.load();
 }
 
 bool TaskGroup::shrinkThread() {
   size_t total = totalThreads.load();
-  while (total > _maxThreadCount.load()) {
+  while (total > maxThreads.load()) {
     if (totalThreads.compare_exchange_weak(total, total - 1)) {
       return true;
     }
@@ -123,7 +127,7 @@ bool TaskGroup::shrinkThread() {
 }
 
 bool TaskGroup::checkThreads() {
-  if (waitingThreads.load() == 0 && totalThreads.load() < _maxThreadCount.load()) {
+  if (waitingThreads.load() == 0 && totalThreads.load() < maxThreads.load()) {
     auto thread = new (std::nothrow) std::thread(TaskGroup::RunLoop, this);
     if (thread) {
       if (threads->enqueue(thread)) {
@@ -179,7 +183,7 @@ std::shared_ptr<Task> TaskGroup::popTask() {
     if (task) {
       return task;
     }
-    if (exited || totalThreads.load() > _maxThreadCount.load()) {
+    if (shouldExit()) {
       return nullptr;
     }
     ++waitingThreads;
@@ -192,7 +196,7 @@ std::shared_ptr<Task> TaskGroup::popTask() {
         --waitingThreads;
         return task;
       }
-      if (totalThreads.load() > _maxThreadCount.load()) {
+      if (shouldExit()) {
         --waitingThreads;
         return nullptr;
       }
@@ -219,8 +223,14 @@ static void ReleaseThread(std::thread* thread) {
 }
 
 void TaskGroup::releaseThreads(bool exit) {
-  exited = true;
-  condition.notify_all();
+  // Set exited and notify while holding the lock, so a worker that has not entered its wait yet
+  // will observe exited in the locked section of popTask() instead of missing the notification
+  // and sleeping for the full THREAD_TIMEOUT.
+  {
+    std::lock_guard<std::mutex> autoLock(locker);
+    exited = true;
+    condition.notify_all();
+  }
   std::thread* thread = nullptr;
   while (threads->try_dequeue(thread)) {
     ReleaseThread(thread);

--- a/src/core/utils/TaskGroup.h
+++ b/src/core/utils/TaskGroup.h
@@ -31,22 +31,24 @@ namespace tgfx {
 class TaskGroup {
  private:
   std::mutex locker = {};
-  std::atomic_int maxThreads = 32;
-  std::atomic_int lowPriorityThreads = 2;
+  std::atomic_size_t _maxThreadCount = 32;
+  std::atomic_size_t lowPriorityThreads = 2;
   std::condition_variable condition = {};
-  std::atomic_int totalThreads = 0;
+  std::atomic_size_t totalThreads = 0;
   std::atomic_bool exited = false;
-  std::atomic_int waitingThreads = 0;
+  std::atomic_size_t waitingThreads = 0;
   std::vector<moodycamel::ConcurrentQueue<std::shared_ptr<Task>>*> priorityQueues = {};
   moodycamel::ConcurrentQueue<std::thread*>* threads = nullptr;
   static TaskGroup* GetInstance();
   static void RunLoop(TaskGroup* taskGroup);
 
   TaskGroup();
-  void setMaxThreads(int maxThreads);
+  void setMaxThreadCount(size_t maxThreadCount);
+  size_t maxThreadCount() const;
   bool shrinkThread();
   bool checkThreads();
   bool pushTask(std::shared_ptr<Task> task, TaskPriority priority);
+  std::shared_ptr<Task> tryDequeueTask();
   std::shared_ptr<Task> popTask();
   void exit();
   void releaseThreads(bool exit);

--- a/src/core/utils/TaskGroup.h
+++ b/src/core/utils/TaskGroup.h
@@ -44,6 +44,7 @@ class TaskGroup {
 
   TaskGroup();
   void setMaxThreads(int maxThreads);
+  bool shrinkThread();
   bool checkThreads();
   bool pushTask(std::shared_ptr<Task> task, TaskPriority priority);
   std::shared_ptr<Task> popTask();

--- a/src/core/utils/TaskGroup.h
+++ b/src/core/utils/TaskGroup.h
@@ -31,8 +31,8 @@ namespace tgfx {
 class TaskGroup {
  private:
   std::mutex locker = {};
-  int maxThreads = 32;
-  int lowPriorityThreads = 2;
+  std::atomic_int maxThreads = 32;
+  std::atomic_int lowPriorityThreads = 2;
   std::condition_variable condition = {};
   std::atomic_int totalThreads = 0;
   std::atomic_bool exited = false;
@@ -43,6 +43,7 @@ class TaskGroup {
   static void RunLoop(TaskGroup* taskGroup);
 
   TaskGroup();
+  void setMaxThreads(int maxThreads);
   bool checkThreads();
   bool pushTask(std::shared_ptr<Task> task, TaskPriority priority);
   std::shared_ptr<Task> popTask();

--- a/src/core/utils/TaskGroup.h
+++ b/src/core/utils/TaskGroup.h
@@ -31,7 +31,7 @@ namespace tgfx {
 class TaskGroup {
  private:
   std::mutex locker = {};
-  std::atomic_size_t _maxThreadCount = 32;
+  std::atomic_size_t maxThreads = 32;
   std::atomic_size_t lowPriorityThreads = 2;
   std::condition_variable condition = {};
   std::atomic_size_t totalThreads = 0;
@@ -45,6 +45,7 @@ class TaskGroup {
   TaskGroup();
   void setMaxThreadCount(size_t maxThreadCount);
   size_t maxThreadCount() const;
+  bool shouldExit() const;
   bool shrinkThread();
   bool checkThreads();
   bool pushTask(std::shared_ptr<Task> task, TaskPriority priority);

--- a/src/platform/web/TGFXWasmBindings.cpp
+++ b/src/platform/web/TGFXWasmBindings.cpp
@@ -28,7 +28,8 @@ using namespace emscripten;
 
 namespace tgfx {
 bool TGFXBindInit() {
-  function("setTaskMaxThreads", &Task::SetMaxThreadCount);
+  function("setTaskMaxThreadCounts", &Task::SetMaxThreadCount);
+  function("taskMaxThreadCounts", &Task::MaxThreadCount);
 
   class_<Matrix>("TGFXMatrix").function("_get", &Matrix::get).function("_set", &Matrix::set);
 

--- a/src/platform/web/TGFXWasmBindings.cpp
+++ b/src/platform/web/TGFXWasmBindings.cpp
@@ -22,11 +22,14 @@
 #include "tgfx/core/Matrix.h"
 #include "tgfx/core/PathTypes.h"
 #include "tgfx/core/Stroke.h"
+#include "tgfx/core/Task.h"
 
 using namespace emscripten;
 
 namespace tgfx {
 bool TGFXBindInit() {
+  function("setTaskMaxThreads", &Task::SetMaxThreads);
+
   class_<Matrix>("TGFXMatrix").function("_get", &Matrix::get).function("_set", &Matrix::set);
 
   value_object<Point>("TGFXPoint").field("x", &Point::x).field("y", &Point::y);

--- a/src/platform/web/TGFXWasmBindings.cpp
+++ b/src/platform/web/TGFXWasmBindings.cpp
@@ -28,7 +28,7 @@ using namespace emscripten;
 
 namespace tgfx {
 bool TGFXBindInit() {
-  function("setTaskMaxThreads", &Task::SetMaxThreads);
+  function("setTaskMaxThreads", &Task::SetMaxThreadCount);
 
   class_<Matrix>("TGFXMatrix").function("_get", &Matrix::get).function("_set", &Matrix::set);
 

--- a/test/src/ResourceTest.cpp
+++ b/test/src/ResourceTest.cpp
@@ -39,7 +39,7 @@ TGFX_TEST(ResourceTest, TaskRelease) {
   Task::ReleaseThreads();
   TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance(); std::thread* thead = nullptr;
                       group->threads->try_dequeue(thead); EXPECT_EQ(thead, nullptr);
-                      EXPECT_EQ(group->waitingThreads, 0); EXPECT_EQ(group->totalThreads, 0);
+                      EXPECT_EQ(group->waitingThreads, 0u); EXPECT_EQ(group->totalThreads, 0u);
                       for (auto& queue
                            : group->priorityQueues) {
                         std::shared_ptr<Task> task = nullptr;
@@ -49,9 +49,10 @@ TGFX_TEST(ResourceTest, TaskRelease) {
 }
 
 #ifdef TGFX_USE_THREADS
-TGFX_TEST(ResourceTest, SetMaxThreadsShrink) {
+TGFX_TEST(ResourceTest, MaxThreadCountShrink) {
   Task::ReleaseThreads();
-  Task::SetMaxThreads(4);
+  Task::SetMaxThreadCount(4);
+  EXPECT_EQ(Task::MaxThreadCount(), 4u);
   std::atomic<int> started{0};
   std::atomic<int> finished{0};
   std::atomic_bool release{false};
@@ -76,12 +77,12 @@ TGFX_TEST(ResourceTest, SetMaxThreadsShrink) {
   }
   // Give the threads a moment to become idle before lowering the limit.
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance(); EXPECT_EQ(group->totalThreads, 4);
-                      Task::SetMaxThreads(1);
-                      for (int i = 0; i < 100 && group->totalThreads > 1; ++i) {
+  TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance(); EXPECT_EQ(group->totalThreads, 4u);
+                      Task::SetMaxThreadCount(1);
+                      for (int i = 0; i < 100 && group->totalThreads > 1u; ++i) {
                         std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                      } EXPECT_EQ(group->totalThreads, 1););
-  Task::SetMaxThreads(0);
+                      } EXPECT_EQ(group->totalThreads, 1u););
+  Task::SetMaxThreadCount(0);
 }
 #endif
 

--- a/test/src/ResourceTest.cpp
+++ b/test/src/ResourceTest.cpp
@@ -17,6 +17,8 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <array>
+#include <atomic>
+#include <thread>
 #include <utility>
 #include <vector>
 #include "base/TGFXTest.h"
@@ -45,6 +47,43 @@ TGFX_TEST(ResourceTest, TaskRelease) {
                         EXPECT_EQ(task, nullptr);
                       })
 }
+
+#ifdef TGFX_USE_THREADS
+TGFX_TEST(ResourceTest, SetMaxThreadsShrink) {
+  Task::ReleaseThreads();
+  Task::SetMaxThreads(4);
+  std::atomic<int> started{0};
+  std::atomic<int> finished{0};
+  std::atomic_bool release{false};
+  auto blockTask = [&started, &finished, &release] {
+    ++started;
+    while (!release.load()) {
+    }
+    ++finished;
+  };
+  Task::Run(blockTask);
+  // Wait for the first worker thread to start, then submit more tasks. All existing threads are
+  // busy with the blocking tasks, so each submission guarantees a new worker thread is created.
+  while (started.load() < 1) {
+  }
+  for (int i = 0; i < 3; ++i) {
+    Task::Run(blockTask);
+  }
+  while (started.load() < 4) {
+  }
+  release = true;
+  while (finished.load() < 4) {
+  }
+  // Give the threads a moment to become idle before lowering the limit.
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance(); EXPECT_EQ(group->totalThreads, 4);
+                      Task::SetMaxThreads(1);
+                      for (int i = 0; i < 100 && group->totalThreads > 1; ++i) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                      } EXPECT_EQ(group->totalThreads, 1););
+  Task::SetMaxThreads(0);
+}
+#endif
 
 // ==================== Resource Cache Tests ====================
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -170,6 +170,11 @@ export interface TGFX extends EmscriptenModule {
     TGFXLineJoin: TGFXLineJoin;
     GL: EmscriptenGL;
     TGFXPathFillType: TGFXPathFillType;
+    /**
+     * Sets the maximum number of worker threads that can be created for running tasks. Pass zero to
+     * restore the default, which is based on the number of CPU cores and capped at 32.
+     */
+    setTaskMaxThreads: (maxThreads: number) => void;
     _Matrix: {
         _MakeAll: (
             scaleX: number,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -174,7 +174,11 @@ export interface TGFX extends EmscriptenModule {
      * Sets the maximum number of worker threads that can be created for running tasks. Pass zero to
      * restore the default, which is based on the number of CPU cores and capped at 32.
      */
-    setTaskMaxThreads: (maxThreads: number) => void;
+    setTaskMaxThreadCounts: (maxThreadCounts: number) => void;
+    /**
+     * Returns the current maximum number of worker threads that can be created for running tasks.
+     */
+    taskMaxThreadCounts: () => number;
     _Matrix: {
         _MakeAll: (
             scaleX: number,


### PR DESCRIPTION
## What

Adds `Task::SetMaxThreadCount(size_t)` to cap the number of task worker threads, and releases surplus idle threads when the limit is lowered.

## Changes

- `Task::SetMaxThreadCount(size_t)`: public API to set the maximum worker thread count. Zero restores the default (CPU cores, capped at 32). Call it before submitting tasks.
- `Task::MaxThreadCount()`: returns the current maximum worker thread count.
- `TaskGroup::setMaxThreadCount` wakes idle threads after lowering the limit, and idle threads exceeding the new limit exit via an atomic CAS claim on `totalThreads`, so the pool never drops below the new maximum.
- `TaskGroup::releaseThreads` now sets `exited` and notifies while holding the lock, and `popTask` re-checks `exited` inside its locked section, closing a lost-notification window that could stall `Task::ReleaseThreads()` for up to the 10-second thread timeout.
- Worker threads are created lazily as tasks arrive; lowering the limit releases surplus idle threads, busy threads exit once they become idle.
- New test `ResourceTest.MaxThreadCountShrink` verifies the pool shrinks after lowering the limit.

## Verification

- `TGFXFullTest_OpenGL` builds clean.
- `ResourceTest.TaskRelease`, `ResourceTest.MaxThreadCountShrink`, `ResourceTest.MultiThreadRecycling` pass.
