### PR TITLE
Fix video edge flicker for SurfaceTexture external textures

### DIFF
--- a/src/gpu/processors/TextureEffect.cpp
+++ b/src/gpu/processors/TextureEffect.cpp
@@ -111,6 +111,14 @@ bool TextureEffect::needSubset() const {
     // If the texture size is different from the proxy size, we need to use subset.
     return true;
   }
+  auto type = textureView->getTexture()->type();
+  if (type == TextureType::External) {
+    // The descriptor size of external (OES) textures may not match the actual size of the
+    // underlying buffer, which can hold unstable padding outside the content bounds (for example,
+    // SurfaceTexture buffers aligned by hardware decoders). Always clamp the sampling to the
+    // content bounds to prevent bilinear filtering from reaching the padding area.
+    return true;
+  }
   return false;
 }
 

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -37,7 +37,6 @@ static jfieldID SurfaceTexture_mEventHandler;
 static jmethodID SurfaceTexture_updateTexImage;
 static jmethodID SurfaceTexture_attachToGLContext;
 static jmethodID SurfaceTexture_detachFromGLContext;
-static jmethodID SurfaceTexture_getTransformMatrix;
 static jmethodID SurfaceTexture_release;
 static jmethodID SurfaceTexture_getDataSpace;
 static Global<jclass> SurfaceClass;
@@ -84,8 +83,6 @@ void SurfaceTexture::JNIInit(JNIEnv* env) {
       env->GetMethodID(SurfaceTextureClass.get(), "attachToGLContext", "(I)V");
   SurfaceTexture_detachFromGLContext =
       env->GetMethodID(SurfaceTextureClass.get(), "detachFromGLContext", "()V");
-  SurfaceTexture_getTransformMatrix =
-      env->GetMethodID(SurfaceTextureClass.get(), "getTransformMatrix", "([F)V");
   SurfaceTexture_release = env->GetMethodID(SurfaceTextureClass.get(), "release", "()V");
   SurfaceTexture_getDataSpace = env->GetMethodID(SurfaceTextureClass.get(), "getDataSpace", "()I");
   if (SurfaceTexture_getDataSpace == nullptr) {
@@ -204,36 +201,25 @@ void SurfaceTexture::notifyFrameAvailable() {
   condition.notify_all();
 }
 
-static ISize ComputeTextureSize(float matrix[16], int width, int height) {
-  Size size = {static_cast<float>(width), static_cast<float>(height)};
-  auto scaleX = fabsf(matrix[0]);
-  if (scaleX > 0) {
-    size.width = size.width / (scaleX + matrix[12] * 2);
-  }
-  float scaleY = fabsf(matrix[5]);
-  if (scaleY > 0) {
-    size.height = size.height / (scaleY + (matrix[13] - scaleY) * 2);
-  }
-  return size.toRound();
-}
-
 std::shared_ptr<TextureView> SurfaceTexture::onMakeTexture(Context* context, bool) {
   auto textureID = makeExternalOESTexture(context);
   if (textureID == 0) {
     return nullptr;
   }
-  auto textureSize = updateTexImage();
-  if (textureSize.isEmpty()) {
+  if (!updateTexImage()) {
     auto gl = static_cast<GLGPU*>(context->gpu())->functions();
     gl->deleteTextures(1, &textureID);
     return nullptr;
   }
-  TextureDescriptor descriptor = {textureSize.width,
-                                  textureSize.height,
-                                  PixelFormat::RGBA_8888,
-                                  false,
-                                  1,
-                                  TextureUsage::TEXTURE_BINDING};
+  // Use the video content size (width()/height()) for the texture descriptor rather than the
+  // hardware buffer's aligned size. Hardware decoders may pad the output buffer to a larger
+  // aligned size (e.g. 720x1560 -> 720x1568), and the extra rows hold unstable padding. Since
+  // getTextureCoord() maps content coordinates to UVs by dividing by these dimensions, using the
+  // content size preserves the "texture pixel coord == content coord" invariant and excludes the
+  // padding rows from sampling. Do not switch this back to the buffer-aligned size, which caused
+  // the edge-flicker regression this restores.
+  TextureDescriptor descriptor = {width(), height(), PixelFormat::RGBA_8888,
+                                  false,   1,        TextureUsage::TEXTURE_BINDING};
   auto gpu = static_cast<GLGPU*>(context->gpu());
   auto texture = gpu->makeResource<GLTexture>(
       descriptor, static_cast<unsigned>(GL_TEXTURE_EXTERNAL_OES), textureID);
@@ -241,8 +227,7 @@ std::shared_ptr<TextureView> SurfaceTexture::onMakeTexture(Context* context, boo
 }
 
 bool SurfaceTexture::onUpdateTexture(std::shared_ptr<TextureView>) {
-  auto size = updateTexImage();
-  return !size.isEmpty();
+  return updateTexImage();
 }
 
 unsigned SurfaceTexture::makeExternalOESTexture(Context* context) {
@@ -268,27 +253,27 @@ unsigned SurfaceTexture::makeExternalOESTexture(Context* context) {
   return textureID;
 }
 
-ISize SurfaceTexture::updateTexImage() {
+bool SurfaceTexture::updateTexImage() {
   std::unique_lock<std::mutex> autoLock(locker);
   if (!frameAvailable) {
     static const auto TIMEOUT = std::chrono::seconds(1);
     auto status = condition.wait_for(autoLock, TIMEOUT);
     if (status == std::cv_status::timeout) {
       LOGE("NativeImageReader::onUpdateTexture(): timeout when waiting for the frame available!");
-      return {};
+      return false;
     }
   }
   JNIEnvironment environment;
   auto env = environment.current();
   if (env == nullptr) {
-    return {};
+    return false;
   }
   frameAvailable = false;
   env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_updateTexImage);
   if (env->ExceptionCheck()) {
     env->ExceptionClear();
     LOGE("NativeImageReader::onUpdateTexture(): failed to updateTexImage!");
-    return {};
+    return false;
   }
   if (SurfaceTexture_getDataSpace) {
     jint dataSpace = env->CallIntMethod(surfaceTexture.get(), SurfaceTexture_getDataSpace);
@@ -298,12 +283,7 @@ ISize SurfaceTexture::updateTexImage() {
         env->CallStaticIntMethod(DataSpaceClass.get(), DataSpaceClass_getTransfer, dataSpace);
     _colorSpace = AndroidDataSpaceToColorSpace(standard, transfer);
   }
-  auto floatArray = env->NewFloatArray(16);
-  env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_getTransformMatrix, floatArray);
-  auto matrix = env->GetFloatArrayElements(floatArray, nullptr);
-  auto textureSize = ComputeTextureSize(matrix, width(), height());
-  env->ReleaseFloatArrayElements(floatArray, matrix, 0);
-  return textureSize;
+  return true;
 }
 
 }  // namespace tgfx

--- a/src/platform/android/SurfaceTexture.h
+++ b/src/platform/android/SurfaceTexture.h
@@ -77,7 +77,7 @@ class SurfaceTexture : public ImageStream {
 
   unsigned makeExternalOESTexture(Context* context);
 
-  ISize updateTexImage();
+  bool updateTexImage();
 
   friend class JNIInit;
 };


### PR DESCRIPTION
## 背景

修复 [Tencent/libpag#3689](https://github.com/Tencent/libpag/issues/3689) 反馈的视频边缘抖动/闪烁问题。

## 根因

感谢 @Hparty 在 review 中的分析（#722 移除 crop 钳制保护的根因判断），以下结论已通过真机日志验证确认：

1. 硬解码器输出的 buffer 会对齐到更大的尺寸（如 720x1560 -> 720x1568），底部多出的行是内容不稳定的 padding。
2. tgfx 中同一视频帧存在**两条 TextureProxy 路径**：
   - `ImageBuffer` 路径：proxy 尺寸 = 视频内容尺寸（1560）
   - `wrapExternalTexture` 路径：proxy 尺寸 = textureView 尺寸 = 描述符尺寸（原状为 buffer 对齐尺寸 1568）
3. 原状下两路 proxy 尺寸不一致（1560 / 1568），`getTextureCoord()` 的 UV 归一化分母不同，同一图像坐标的采样位置相差约 0.5%。两路逐帧交替渲染时表现为内容缩放跳变，即边缘抖动。
4. 同时 `TextureEffect::needSubset()` 仅靠 "proxy 尺寸 != textureView 尺寸" 判断（#722 之后），对 proxy == view 的路径（1568）返回 false，crop 钳制处于关闭状态。

真机日志（修复前）：

```
proxy=720x1568 texView=720x1568 subset=no ret=0   // 钳制关闭
proxy=720x1560 -> subsetRect=(0,0,720,1560)       // clamp 正确，排除 padding
proxy=720x1568 -> subsetRect=(0,0,720,1568)       // clamp 覆盖全 buffer（含 padding），无效
```

注：`onSetData` 中 `subsetRect` 无值时以 proxy 尺寸兜底，因此单纯启用 clamp 而不统一尺寸，proxy=1568 路径的 clamp 范围仍含 padding（已实测验证不生效）。

## 修复

两处改动正交互补，分头解决因果链上的两段，缺一不可：

1. **SurfaceTexture 描述符尺寸改用视频内容尺寸（`width()`/`height()`）**
   - 统一两路 proxy 的 UV 归一化分母，消除逐帧缩放跳变
   - 使内容精确铺满 UV [0,1]，padding 落在 UV>1，正常采样范围内结构性不可达
   - 顺带移除已无作用的 `ComputeTextureSize()`/`getTransformMatrix()` 读取路径，`updateTexImage()` 改为返回 `bool`（仅用于成功/失败判断）
2. **`TextureEffect::needSubset()` 对 External（OES）纹理恢复 crop 钳制**
   - 改动 1 只调整了 tgfx 侧的声明，底层 buffer 仍是对齐后的 1568
   - `CLAMP_TO_EDGE` 的 edge 是 buffer 边缘（1568）而非内容边缘（1560），且管不到 bilinear 采样核的内部溢出
   - 对 External 纹理无条件返回 true，强制开启 subset，用显式 clamp 把采样压在内容边界内，防止越界采样——恢复了 #722 之前被移除的钳制保护

只做任一项均不生效：只做 1 则 padding 仍会被采样核采到；只做 2 则 clamp 边界按 proxy（1568）兜底计算，区间内仍含 padding（已实测验证不生效）。

## 验证

真机（720x1560 硬解视频）确认：

- `needSubset()` 对 proxy=1568 路径由 ret=0 变为 ret=1（`TextureType::External` 判断生效）
- 两路 proxy 统一为内容尺寸后，clamp 范围统一为 (0,0,720,1560)，padding 被排除在采样外
- PAGView / PAGImageView 边缘抖动消失

软解码以及宽高为 16 倍数的视频不受影响（buffer 尺寸与内容尺寸一致，两版行为相同）。

## 影响范围

- Android `SurfaceTexture`（外部 OES 纹理路径）
- `TextureEffect::needSubset()`：所有 External 纹理（含 YUV hardware buffer 的 OES 路径）新增边缘 1 texel 的采样钳制，与 AOSP 对 YUV 外部纹理的 shrink 处理一致，无视觉影响

## 需回合到 release/2.1

该 bug 在 release/2.1 分支上同样存在，需要 backport（#1567）。注意 release/2.1 使用旧的 `GPUTextureDescriptor`/`TextureUsage` API，无法直接 cherry-pick，需按该分支接口单独适配。

## 后续优化议题（供讨论）

"纯 clamp 路线"若要独立成立，需要让 TextureView 携带内容尺寸（@Hparty 提议的基于 `getTextureCoord()` 边界检测的完整实现），且 `CoordTransform` 归一化分母需同步使用内容尺寸——完整实现后数学上与"描述符 = 内容尺寸"方案等价，但架构改动更大，可另行评估。

