### PR TITLE
Drain pending frames in SurfaceTexture updateTexImage to fix video jitter on Android

### DIFF
--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -301,6 +301,9 @@ ISize SurfaceTexture::updateTexImage() {
   // behind the most recently decoded frame with a fluctuating delay, which shows up as video
   // jitter (frames appearing to jump back and forth). Stop when the timestamp stops changing
   // (queue empty) or an exception is thrown, with a bounded number of iterations.
+  // The timestamp == lastTimestamp check is a heuristic that assumes each new frame carries a
+  // distinct timestamp; on streams that report duplicate or constant (e.g. always-0) timestamps
+  // the drain stops early and simply degrades to the previous single-frame behavior (no crash).
   if (SurfaceTexture_getTimestamp != nullptr) {
     // Safety cap on how many extra frames to drain per call so a runaway/mis-behaving queue
     // cannot spin this loop unboundedly.
@@ -309,6 +312,8 @@ ISize SurfaceTexture::updateTexImage() {
     for (int i = 0; i < MAX_DRAIN_FRAMES; i++) {
       env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_updateTexImage);
       if (env->ExceptionCheck()) {
+        // Best-effort drain: swallow the exception and stop, unlike the initial mandatory
+        // updateTexImage above whose failure logs via LOGE and hard-returns {}.
         env->ExceptionClear();
         break;
       }

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -309,7 +309,6 @@ ISize SurfaceTexture::updateTexImage() {
         env->ExceptionClear();
         break;
       }
-      frameAvailable = false;
       auto timestamp = env->CallLongMethod(surfaceTexture.get(), SurfaceTexture_getTimestamp);
       if (timestamp == lastTimestamp) {
         break;

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -302,8 +302,11 @@ ISize SurfaceTexture::updateTexImage() {
   // jitter (frames appearing to jump back and forth). Stop when the timestamp stops changing
   // (queue empty) or an exception is thrown, with a bounded number of iterations.
   if (SurfaceTexture_getTimestamp != nullptr) {
+    // Safety cap on how many extra frames to drain per call so a runaway/mis-behaving queue
+    // cannot spin this loop unboundedly.
+    constexpr int MAX_DRAIN_FRAMES = 8;
     auto lastTimestamp = env->CallLongMethod(surfaceTexture.get(), SurfaceTexture_getTimestamp);
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < MAX_DRAIN_FRAMES; i++) {
       env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_updateTexImage);
       if (env->ExceptionCheck()) {
         env->ExceptionClear();

--- a/src/platform/android/SurfaceTexture.cpp
+++ b/src/platform/android/SurfaceTexture.cpp
@@ -40,6 +40,7 @@ static jmethodID SurfaceTexture_detachFromGLContext;
 static jmethodID SurfaceTexture_getTransformMatrix;
 static jmethodID SurfaceTexture_release;
 static jmethodID SurfaceTexture_getDataSpace;
+static jmethodID SurfaceTexture_getTimestamp;
 static Global<jclass> SurfaceClass;
 static jmethodID Surface_Constructor;
 static Global<jclass> HandlerClass;
@@ -89,6 +90,10 @@ void SurfaceTexture::JNIInit(JNIEnv* env) {
   SurfaceTexture_release = env->GetMethodID(SurfaceTextureClass.get(), "release", "()V");
   SurfaceTexture_getDataSpace = env->GetMethodID(SurfaceTextureClass.get(), "getDataSpace", "()I");
   if (SurfaceTexture_getDataSpace == nullptr) {
+    env->ExceptionClear();
+  }
+  SurfaceTexture_getTimestamp = env->GetMethodID(SurfaceTextureClass.get(), "getTimestamp", "()J");
+  if (SurfaceTexture_getTimestamp == nullptr) {
     env->ExceptionClear();
   }
   SurfaceClass = env->FindClass("android/view/Surface");
@@ -289,6 +294,28 @@ ISize SurfaceTexture::updateTexImage() {
     env->ExceptionClear();
     LOGE("NativeImageReader::onUpdateTexture(): failed to updateTexImage!");
     return {};
+  }
+  // Drain any remaining pending frames so the texture always holds the latest decoded frame.
+  // Frames reach the SurfaceTexture asynchronously (releaseOutputBuffer hands them over through
+  // the BufferQueue). Consuming only one frame per call can leave the texture content lagging
+  // behind the most recently decoded frame with a fluctuating delay, which shows up as video
+  // jitter (frames appearing to jump back and forth). Stop when the timestamp stops changing
+  // (queue empty) or an exception is thrown, with a bounded number of iterations.
+  if (SurfaceTexture_getTimestamp != nullptr) {
+    auto lastTimestamp = env->CallLongMethod(surfaceTexture.get(), SurfaceTexture_getTimestamp);
+    for (int i = 0; i < 8; i++) {
+      env->CallVoidMethod(surfaceTexture.get(), SurfaceTexture_updateTexImage);
+      if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        break;
+      }
+      frameAvailable = false;
+      auto timestamp = env->CallLongMethod(surfaceTexture.get(), SurfaceTexture_getTimestamp);
+      if (timestamp == lastTimestamp) {
+        break;
+      }
+      lastTimestamp = timestamp;
+    }
   }
   if (SurfaceTexture_getDataSpace) {
     jint dataSpace = env->CallIntMethod(surfaceTexture.get(), SurfaceTexture_getDataSpace);


### PR DESCRIPTION
## 问题

关联 issue：Tencent/libpag#3689 (https://github.com/Tencent/libpag/issues/3689)

在 Android 端，4.5.x 版本播放特定 PAG 文件时出现画面抖动 / 跳帧（PAGView 抖动、PAGImageView 跳帧），而 4.4.35 版本表现正常。

## 根因

解码后的视频帧通过 BufferQueue 异步送达 `SurfaceTexture`。`SurfaceTexture::updateTexImage()` 每次调用只消费一帧，当解码速度快于消费速度时，纹理内容会滞后于最新解码帧，且滞后量不稳定，最终表现为画面抖动、来回跳帧。

## 修改

在 `SurfaceTexture::updateTexImage()` 中，于首次 `updateTexImage` 之后排空 BufferQueue 中积压的待处理帧，使纹理始终持有最新解码帧：

- 通过 JNI 绑定 `SurfaceTexture.getTimestamp()`，循环调用 `updateTexImage` 直到帧时间戳不再变化（队列已空）或发生异常为止。
- 引入上限常量 `MAX_DRAIN_FRAMES = 8`，防止异常队列导致循环无界自旋。
- 循环内异常按 best-effort 处理（吞掉并停止），区别于首次强制 `updateTexImage` 失败时的 LOGE 并返回。

时间戳相等的终止判断是启发式：假设每帧时间戳不同；对于重复或恒定（如恒 0）时间戳的流会提前停止，优雅退化为原先的单帧行为，不会崩溃。

## 影响范围

仅影响 Android 平台 `SurfaceTexture` 的取帧路径。
