### PR TITLE
Add PathMask support for layered path clipping.

### DIFF
--- a/include/tgfx/core/MaskFilter.h
+++ b/include/tgfx/core/MaskFilter.h
@@ -35,6 +35,14 @@ class MaskFilter {
   static std::shared_ptr<MaskFilter> MakeShader(std::shared_ptr<Shader> shader,
                                                 bool inverted = false);
 
+  /**
+   * Creates a mask filter whose effect is to first apply the inner filter and then apply the
+   * outer filter, so the drawn content is masked by the product of both mask coverages. Returns
+   * the non-null filter if one of them is null, and nullptr if both are null.
+   */
+  static std::shared_ptr<MaskFilter> Compose(std::shared_ptr<MaskFilter> inner,
+                                             std::shared_ptr<MaskFilter> outer);
+
   virtual ~MaskFilter() = default;
 
   /**
@@ -45,7 +53,7 @@ class MaskFilter {
   virtual std::shared_ptr<MaskFilter> makeWithMatrix(const Matrix& viewMatrix) const = 0;
 
  protected:
-  enum class Type { Shader, None };
+  enum class Type { Shader, Compose, None };
 
   /**
    * Returns the type of this mask filter.
@@ -62,6 +70,7 @@ class MaskFilter {
                                                               const Matrix* uvMatrix) const = 0;
 
   friend class OpsCompositor;
+  friend class ComposeMaskFilter;
   friend class Types;
 };
 }  // namespace tgfx

--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -27,6 +27,7 @@
 #include "tgfx/layers/LayerMaskType.h"
 #include "tgfx/layers/LayerRecorder.h"
 #include "tgfx/layers/LayerType.h"
+#include "tgfx/layers/PathMask.h"
 #include "tgfx/layers/filters/LayerFilter.h"
 #include "tgfx/layers/layerstyles/LayerStyle.h"
 #include "tgfx/layers/layerstyles/StyledShape.h"
@@ -329,6 +330,20 @@ class Layer : public std::enable_shared_from_this<Layer> {
    * Sets the mask type used by the layer.
    */
   void setMaskType(LayerMaskType value);
+
+  /**
+   * Returns the list of path masks applied to the layer. Path masks clip the layer's content with
+   * vector paths, combined in order using each mask's boolean operation. They are applied before
+   * the layer-level mask (see setMask()). The default value is an empty list.
+   */
+  const std::vector<std::shared_ptr<PathMask>>& pathMasks() const {
+    return _pathMasks;
+  }
+
+  /**
+   * Sets the list of path masks applied to the layer.
+   */
+  void setPathMasks(const std::vector<std::shared_ptr<PathMask>>& value);
 
   /**
    * Returns the scroll rectangle bounds of the layer. The layer is cropped to the size defined by
@@ -687,6 +702,9 @@ class Layer : public std::enable_shared_from_this<Layer> {
 
   bool prepareMask(const DrawArgs& args, Canvas* canvas, std::shared_ptr<MaskFilter>* maskFilter);
 
+  bool preparePathMasks(const DrawArgs& args, Canvas* canvas,
+                        std::shared_ptr<MaskFilter>* maskFilter) const;
+
   MaskData getMaskData(const DrawArgs& args, float scale,
                        const std::optional<Rect>& layerClipBounds);
 
@@ -766,6 +784,7 @@ class Layer : public std::enable_shared_from_this<Layer> {
   std::vector<std::shared_ptr<Layer>> _children = {};
   std::vector<std::shared_ptr<LayerFilter>> _filters = {};
   std::vector<std::shared_ptr<LayerStyle>> _layerStyles = {};
+  std::vector<std::shared_ptr<PathMask>> _pathMasks = {};
   std::unique_ptr<SubtreeCache> subtreeCache;
   std::shared_ptr<LayerContent> layerContent = nullptr;
   Rect renderBounds = {};                       // in global coordinates

--- a/include/tgfx/layers/PathMask.h
+++ b/include/tgfx/layers/PathMask.h
@@ -1,0 +1,147 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. see the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "tgfx/core/Path.h"
+#include "tgfx/layers/LayerProperty.h"
+
+namespace tgfx {
+
+/**
+ * PathMask clips a layer's content with a vector path. A layer can hold multiple path masks,
+ * which are combined in order using each mask's boolean operation to produce the final visible
+ * region of the content. Path masks are applied before the layer-level mask (see
+ * Layer::setMask()).
+ *
+ * Combination rules:
+ * - Masks with an empty path are skipped. The first effective mask initializes the combined
+ *   region with its own path (its operation is ignored), and each subsequent mask combines its
+ *   path into the region using its operation.
+ * - If the combined region is empty, the entire layer is hidden. Note this differs from PAG,
+ *   which treats an empty combined mask path as no mask and keeps the layer fully visible.
+ * - If all masks have zero feather and full opacity, the combined region is applied as a clip
+ *   path and opacity has no effect. Otherwise, boolean operations are ignored and each mask is
+ *   drawn with its own opacity, blurred by feather / 2, and composited in SrcOver order.
+ * - Expansion strokes the path outline by |expansion| * 2 and unions (positive) or subtracts
+ *   (negative) the stroked outline from the original path.
+ *
+ * PathMasks are mutable and can be changed at any time.
+ */
+class PathMask : public LayerProperty {
+ public:
+  /**
+   * Creates an empty path mask with default values: Union operation, not inverted, zero feather,
+   * full opacity, and zero expansion.
+   */
+  static std::shared_ptr<PathMask> Make();
+
+  /**
+   * Returns the path of the mask, in the coordinate space of the owning layer. The default value
+   * is an empty path.
+   */
+  const Path& path() const {
+    return _path;
+  }
+
+  /**
+   * Sets the path of the mask.
+   */
+  void setPath(const Path& path);
+
+  /**
+   * Returns the boolean operation used to combine this mask's path into the accumulated region of
+   * the owning layer. Only PathOp::Difference, PathOp::Intersect, PathOp::Union, and PathOp::XOR
+   * are supported; PathOp::Append and PathOp::Extend are treated as PathOp::Union. The default
+   * value is PathOp::Union.
+   */
+  PathOp op() const {
+    return _op;
+  }
+
+  /**
+   * Sets the boolean operation used to combine this mask's path.
+   */
+  void setOp(PathOp op);
+
+  /**
+   * Returns true if the mask region is inverted, making the area outside the path visible instead
+   * of the area inside. If the mask is the first effective mask of the owning layer and its
+   * operation is PathOp::Difference, this flag is flipped. The default value is false.
+   */
+  bool inverted() const {
+    return _inverted;
+  }
+
+  /**
+   * Sets whether the mask region is inverted.
+   */
+  void setInverted(bool value);
+
+  /**
+   * Returns the feather radius of the mask along the x and y axes. If any mask of the owning
+   * layer has a non-zero feather, all masks of that layer switch to the feathered compositing
+   * path described above. The default value is {0, 0}.
+   */
+  const Point& feather() const {
+    return _feather;
+  }
+
+  /**
+   * Sets the feather radius of the mask along the x and y axes.
+   */
+  void setFeather(const Point& value);
+
+  /**
+   * Returns the opacity of the mask, ranging from 0.0 (fully transparent) to 1.0 (fully opaque).
+   * Opacity only takes effect on the feathered compositing path. The default value is 1.0.
+   */
+  float opacity() const {
+    return _opacity;
+  }
+
+  /**
+   * Sets the opacity of the mask.
+   */
+  void setOpacity(float value);
+
+  /**
+   * Returns the expansion of the mask path in pixels. Positive values expand the path, negative
+   * values shrink it. The default value is 0.
+   */
+  float expansion() const {
+    return _expansion;
+  }
+
+  /**
+   * Sets the expansion of the mask path in pixels.
+   */
+  void setExpansion(float value);
+
+ private:
+  PathMask() = default;
+
+  Path _path = {};
+  PathOp _op = PathOp::Union;
+  bool _inverted = false;
+  Point _feather = {};
+  float _opacity = 1.0f;
+  float _expansion = 0.0f;
+};
+
+}  // namespace tgfx

--- a/src/core/Canvas.cpp
+++ b/src/core/Canvas.cpp
@@ -448,6 +448,19 @@ void Canvas::drawPath(const Path& path, const Paint& paint) {
 void Canvas::drawPath(const Path& path, const Matrix& matrix, const ClipStack& clip,
                       const Brush& brush, const Stroke* stroke) const {
   DEBUG_ASSERT(!path.isEmpty());
+  if (path.isInverseFillType()) {
+    // The rect/rrect fast paths below would drop the inverse fill semantics.
+    if (stroke == nullptr) {
+      drawContext->drawPath(path, matrix, clip, brush);
+      return;
+    }
+    auto inverseShape = Shape::MakeFrom(path);
+    if (inverseShape == nullptr) {
+      return;
+    }
+    drawContext->drawShape(inverseShape, matrix, clip, brush, stroke);
+    return;
+  }
   Point line[2] = {};
   if (path.isLine(line)) {
     if (!stroke) {

--- a/src/core/filters/ComposeMaskFilter.cpp
+++ b/src/core/filters/ComposeMaskFilter.cpp
@@ -1,0 +1,58 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. see the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ComposeMaskFilter.h"
+#include "core/utils/Types.h"
+#include "gpu/processors/FragmentProcessor.h"
+
+namespace tgfx {
+std::shared_ptr<MaskFilter> MaskFilter::Compose(std::shared_ptr<MaskFilter> inner,
+                                                std::shared_ptr<MaskFilter> outer) {
+  if (inner == nullptr) {
+    return outer;
+  }
+  if (outer == nullptr) {
+    return inner;
+  }
+  return std::make_shared<ComposeMaskFilter>(std::move(inner), std::move(outer));
+}
+
+std::shared_ptr<MaskFilter> ComposeMaskFilter::makeWithMatrix(const Matrix& viewMatrix) const {
+  auto newInner = inner->makeWithMatrix(viewMatrix);
+  auto newOuter = outer->makeWithMatrix(viewMatrix);
+  DEBUG_ASSERT(newInner != nullptr && newOuter != nullptr);
+  return MaskFilter::Compose(std::move(newInner), std::move(newOuter));
+}
+
+bool ComposeMaskFilter::isEqual(const MaskFilter* maskFilter) const {
+  auto type = Types::Get(maskFilter);
+  if (type != Types::MaskFilterType::Compose) {
+    return false;
+  }
+  auto other = static_cast<const ComposeMaskFilter*>(maskFilter);
+  return inner->isEqual(other->inner.get()) && outer->isEqual(other->outer.get());
+}
+
+PlacementPtr<FragmentProcessor> ComposeMaskFilter::asFragmentProcessor(
+    const FPArgs& args, const Matrix* uvMatrix) const {
+  auto innerProcessor = inner->asFragmentProcessor(args, uvMatrix);
+  auto outerProcessor = outer->asFragmentProcessor(args, uvMatrix);
+  return FragmentProcessor::Compose(args.context->drawingAllocator(), std::move(innerProcessor),
+                                    std::move(outerProcessor));
+}
+}  // namespace tgfx

--- a/src/core/filters/ComposeMaskFilter.h
+++ b/src/core/filters/ComposeMaskFilter.h
@@ -1,0 +1,46 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. see the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "tgfx/core/MaskFilter.h"
+
+namespace tgfx {
+class ComposeMaskFilter : public MaskFilter {
+ public:
+  ComposeMaskFilter(std::shared_ptr<MaskFilter> inner, std::shared_ptr<MaskFilter> outer)
+      : inner(std::move(inner)), outer(std::move(outer)) {
+  }
+
+  std::shared_ptr<MaskFilter> makeWithMatrix(const Matrix& viewMatrix) const override;
+
+ protected:
+  Type type() const override {
+    return Type::Compose;
+  }
+
+  bool isEqual(const MaskFilter* maskFilter) const override;
+
+  PlacementPtr<FragmentProcessor> asFragmentProcessor(const FPArgs& args,
+                                                      const Matrix* uvMatrix) const override;
+
+ private:
+  std::shared_ptr<MaskFilter> inner;
+  std::shared_ptr<MaskFilter> outer;
+};
+}  // namespace tgfx

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -18,6 +18,7 @@
 
 #include "tgfx/layers/Layer.h"
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cmath>
 #include <unordered_map>
@@ -44,7 +45,9 @@
 #include "layers/SubtreeCache.h"
 #include "layers/contents/LayerContent.h"
 #include "tgfx/core/ColorSpace.h"
+#include "tgfx/core/ImageFilter.h"
 #include "tgfx/core/PictureRecorder.h"
+#include "tgfx/core/Stroke.h"
 #include "tgfx/core/Surface.h"
 #include "tgfx/layers/ShapeLayer.h"
 
@@ -240,6 +243,10 @@ Layer::~Layer() {
     DEBUG_ASSERT(layerStyle != nullptr);
     layerStyle->detachFromLayer(this);
   }
+  for (const auto& pathMask : _pathMasks) {
+    DEBUG_ASSERT(pathMask != nullptr);
+    pathMask->detachFromLayer(this);
+  }
   if (_mask) {
     _mask->maskOwner = nullptr;
   }
@@ -424,6 +431,26 @@ void Layer::setMaskType(LayerMaskType value) {
   if (_mask) {
     invalidateTransform();
   }
+}
+
+void Layer::setPathMasks(const std::vector<std::shared_ptr<PathMask>>& value) {
+  if (_pathMasks.size() == value.size() &&
+      std::equal(_pathMasks.begin(), _pathMasks.end(), value.begin())) {
+    return;
+  }
+  for (const auto& pathMask : _pathMasks) {
+    DEBUG_ASSERT(pathMask != nullptr);
+    pathMask->detachFromLayer(this);
+  }
+  _pathMasks.clear();
+  for (const auto& pathMask : value) {
+    if (pathMask == nullptr) {
+      continue;
+    }
+    pathMask->attachToLayer(this);
+    _pathMasks.push_back(pathMask);
+  }
+  invalidateContent();
 }
 
 void Layer::setScrollRect(const Rect& rect) {
@@ -1189,23 +1216,166 @@ bool Layer::drawLayer(const DrawArgs& args, Canvas* canvas, float alpha, BlendMo
   return true;
 }
 
+static Path ExpandMaskPath(const Path& path, float expansion) {
+  auto result = path;
+  if (expansion == 0.0f) {
+    return result;
+  }
+  auto strokePath = path;
+  Stroke stroke(fabsf(expansion) * 2.0f, LineCap::Butt, LineJoin::Round);
+  stroke.applyToPath(&strokePath);
+  result.addPath(strokePath, expansion < 0.0f ? PathOp::Difference : PathOp::Union);
+  return result;
+}
+
 bool Layer::prepareMask(const DrawArgs& args, Canvas* canvas,
                         std::shared_ptr<MaskFilter>* maskFilter) {
-  if (!hasValidMask()) {
-    return true;
+  std::shared_ptr<MaskFilter> pathMaskFilter = nullptr;
+  if (!preparePathMasks(args, canvas, &pathMaskFilter)) {
+    return false;
   }
-  auto clipBounds = GetClipBounds(canvas);
-  auto contentScale = canvas->getMatrix().getMaxScale();
-  auto maskData = getMaskData(args, contentScale, clipBounds);
-  if (maskData.maskFilter == nullptr) {
-    if (maskData.clipPath.isEmpty() && !maskData.clipPath.isInverseFillType()) {
-      return false;
+  std::shared_ptr<MaskFilter> layerMaskFilter = nullptr;
+  if (hasValidMask()) {
+    auto clipBounds = GetClipBounds(canvas);
+    auto contentScale = canvas->getMatrix().getMaxScale();
+    auto maskData = getMaskData(args, contentScale, clipBounds);
+    if (maskData.maskFilter == nullptr) {
+      if (maskData.clipPath.isEmpty() && !maskData.clipPath.isInverseFillType()) {
+        return false;
+      }
+      canvas->clipPath(maskData.clipPath, _mask->bitFields.allowsEdgeAntialiasing);
+    } else {
+      layerMaskFilter = maskData.maskFilter;
     }
-    canvas->clipPath(maskData.clipPath, _mask->bitFields.allowsEdgeAntialiasing);
-    return true;
   }
   if (maskFilter) {
-    *maskFilter = maskData.maskFilter;
+    *maskFilter = MaskFilter::Compose(std::move(pathMaskFilter), std::move(layerMaskFilter));
+  }
+  return true;
+}
+
+bool Layer::preparePathMasks(const DrawArgs& args, Canvas* canvas,
+                             std::shared_ptr<MaskFilter>* maskFilter) const {
+  bool needFeather = false;
+  bool hasEffectiveMask = false;
+  for (const auto& mask : _pathMasks) {
+    if (mask->path().isEmpty()) {
+      continue;
+    }
+    hasEffectiveMask = true;
+    if (mask->feather() != Point::Zero() || mask->opacity() < 1.0f) {
+      needFeather = true;
+    }
+  }
+  if (!hasEffectiveMask) {
+    return true;
+  }
+  if (!needFeather) {
+    Path combined = {};
+    bool isFirst = true;
+    for (const auto& mask : _pathMasks) {
+      if (mask->path().isEmpty()) {
+        continue;
+      }
+      auto maskPath = ExpandMaskPath(mask->path(), mask->expansion());
+      auto op = mask->op();
+      if (op == PathOp::Append || op == PathOp::Extend) {
+        op = PathOp::Union;
+      }
+      auto inverted = mask->inverted();
+      if (isFirst && op == PathOp::Difference) {
+        inverted = !inverted;
+      }
+      if (inverted) {
+        maskPath.toggleInverseFillType();
+      }
+      if (isFirst) {
+        combined = maskPath;
+        isFirst = false;
+      } else {
+        combined.addPath(maskPath, op);
+      }
+    }
+    if (combined.isEmpty() && !combined.isInverseFillType()) {
+      return false;
+    }
+    canvas->clipPath(combined, bitFields.allowsEdgeAntialiasing);
+    return true;
+  }
+  // Feathered compositing: boolean operations are ignored. Each mask is drawn with its own
+  // opacity, blurred by feather / 2, and composited in SrcOver order.
+  auto scale = canvas->getMatrix().getMaxScale();
+  PictureRecorder recorder = {};
+  auto* recordingCanvas = recorder.beginRecording();
+  recordingCanvas->scale(scale, scale);
+  bool isFirst = true;
+  bool anyInverted = false;
+  for (const auto& mask : _pathMasks) {
+    if (mask->path().isEmpty()) {
+      continue;
+    }
+    auto maskPath = ExpandMaskPath(mask->path(), mask->expansion());
+    auto inverted = mask->inverted();
+    if (isFirst && mask->op() == PathOp::Difference) {
+      inverted = !inverted;
+    }
+    isFirst = false;
+    if (inverted) {
+      maskPath.toggleInverseFillType();
+      anyInverted = true;
+    }
+    Paint layerPaint = {};
+    layerPaint.setAlpha(mask->opacity());
+    const auto& feather = mask->feather();
+    if (feather != Point::Zero()) {
+      // The mask is recorded at `scale`, so the blur radius is scaled to stay in the mask's own
+      // coordinate space.
+      layerPaint.setImageFilter(
+          ImageFilter::Blur(feather.x * 0.5f * scale, feather.y * 0.5f * scale));
+    }
+    recordingCanvas->saveLayer(&layerPaint);
+    recordingCanvas->drawPath(maskPath, {});
+    recordingCanvas->restore();
+  }
+  auto picture = recorder.finishRecordingAsPicture();
+  if (picture == nullptr) {
+    return false;
+  }
+  auto clipBounds = GetClipBounds(canvas);
+  Rect maskBounds = {};
+  if (anyInverted) {
+    // Inverse-filled masks reveal the content outside their geometry, so the rasterized region
+    // must cover the whole visible area instead of the picture bounds.
+    if (clipBounds.has_value()) {
+      maskBounds = *clipBounds;
+      maskBounds.scale(scale, scale);
+    } else {
+      maskBounds = picture->getBounds();
+    }
+  } else {
+    maskBounds = picture->getBounds();
+    if (clipBounds.has_value()) {
+      auto scaledClipBounds = *clipBounds;
+      scaledClipBounds.scale(scale, scale);
+      if (!maskBounds.intersect(scaledClipBounds)) {
+        return false;
+      }
+    }
+  }
+  Point maskImageOffset = {};
+  auto maskContentImage =
+      ToImageWithOffset(std::move(picture), &maskImageOffset, &maskBounds, args.dstColorSpace);
+  if (maskContentImage == nullptr) {
+    return false;
+  }
+  auto maskMatrix = Matrix::MakeScale(1.0f / scale, 1.0f / scale);
+  maskMatrix.preTranslate(maskImageOffset.x, maskImageOffset.y);
+  auto shader = Shader::MakeImageShader(maskContentImage, TileMode::Decal, TileMode::Decal);
+  if (shader) {
+    shader = shader->makeWithMatrix(maskMatrix);
+  }
+  if (maskFilter) {
+    *maskFilter = MaskFilter::MakeShader(std::move(shader), false);
   }
   return true;
 }
@@ -1623,18 +1793,8 @@ bool Layer::drawContourInternal(const DrawArgs& args, Canvas* canvas, bool conte
 
   // Apply mask for child layers (not contentOnly)
   std::shared_ptr<MaskFilter> maskFilter = nullptr;
-  if (!contentOnly && hasValidMask()) {
-    auto contentScale = canvas->getMatrix().getMaxScale();
-    auto clipBounds = GetClipBounds(canvas);
-    auto maskData = getMaskData(args, contentScale, clipBounds);
-    if (maskData.maskFilter == nullptr) {
-      if (maskData.clipPath.isEmpty() && !maskData.clipPath.isInverseFillType()) {
-        return allMatch;
-      }
-      canvas->clipPath(maskData.clipPath, _mask->bitFields.allowsEdgeAntialiasing);
-    } else {
-      maskFilter = maskData.maskFilter;
-    }
+  if (!contentOnly && !prepareMask(args, canvas, &maskFilter)) {
+    return allMatch;
   }
 
   // Handle offscreen rendering for mask filter

--- a/src/layers/PathMask.cpp
+++ b/src/layers/PathMask.cpp
@@ -1,0 +1,77 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. see the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "tgfx/layers/PathMask.h"
+#include <algorithm>
+
+namespace tgfx {
+
+std::shared_ptr<PathMask> PathMask::Make() {
+  return std::shared_ptr<PathMask>(new PathMask());
+}
+
+void PathMask::setPath(const Path& path) {
+  if (_path == path) {
+    return;
+  }
+  _path = path;
+  invalidateContent();
+}
+
+void PathMask::setOp(PathOp op) {
+  if (_op == op) {
+    return;
+  }
+  _op = op;
+  invalidateContent();
+}
+
+void PathMask::setInverted(bool value) {
+  if (_inverted == value) {
+    return;
+  }
+  _inverted = value;
+  invalidateContent();
+}
+
+void PathMask::setFeather(const Point& value) {
+  if (_feather == value) {
+    return;
+  }
+  _feather = value;
+  invalidateContent();
+}
+
+void PathMask::setOpacity(float value) {
+  auto clampedValue = std::clamp(value, 0.0f, 1.0f);
+  if (_opacity == clampedValue) {
+    return;
+  }
+  _opacity = clampedValue;
+  invalidateContent();
+}
+
+void PathMask::setExpansion(float value) {
+  if (_expansion == value) {
+    return;
+  }
+  _expansion = value;
+  invalidateContent();
+}
+
+}  // namespace tgfx

--- a/src/pdf/PDFExportContext.cpp
+++ b/src/pdf/PDFExportContext.cpp
@@ -1419,13 +1419,25 @@ void PDFExportContext::drawPathWithFilter(const Matrix& matrix, const ClipStack&
 
   Brush paint(originPaint);
 
-  if (Types::Get(originPaint.maskFilter.get()) != Types::MaskFilterType::Shader) {
+  auto maskFilterType = Types::Get(originPaint.maskFilter.get());
+  if (maskFilterType != Types::MaskFilterType::Shader &&
+      maskFilterType != Types::MaskFilterType::Compose) {
     return;
   }
-  const auto shaderMaskFilter = static_cast<const ShaderMaskFilter*>(originPaint.maskFilter.get());
-  auto [picture, pictureMatrix] = MaskFilterToPicture(shaderMaskFilter);
-  // Inverted masks have no vector Picture representation — always rasterize as bitmap.
-  bool useBitmapMask = !picture || shaderMaskFilter->isInverted();
+  const ShaderMaskFilter* shaderMaskFilter = nullptr;
+  std::shared_ptr<Picture> maskPicture = nullptr;
+  Matrix maskPictureMatrix = {};
+  // Inverted and composed masks have no vector Picture representation — always rasterize them.
+  bool useBitmapMask = true;
+  if (maskFilterType == Types::MaskFilterType::Shader) {
+    shaderMaskFilter = static_cast<const ShaderMaskFilter*>(originPaint.maskFilter.get());
+    auto [picture, pictureMatrix] = MaskFilterToPicture(shaderMaskFilter);
+    useBitmapMask = !picture || shaderMaskFilter->isInverted();
+    if (!useBitmapMask) {
+      maskPicture = std::move(picture);
+      maskPictureMatrix = pictureMatrix;
+    }
+  }
 
   auto maskContext = makeCongruentDevice();
   if (useBitmapMask) {
@@ -1441,33 +1453,45 @@ void PDFExportContext::drawPathWithFilter(const Matrix& matrix, const ClipStack&
     Canvas* maskCanvas = surface->getCanvas();
     // The mask shader's coordinates are in the path's space, which starts at maskBound.x/y, while
     // the surface starts at (0, 0).
-    auto shader = shaderMaskFilter->getShader();
-    if (maskBound.x() != 0 || maskBound.y() != 0) {
-      shader = shader->makeWithMatrix(Matrix::MakeTrans(-maskBound.x(), -maskBound.y()));
-    }
-    // A PDF luminosity SMask reads the RGB brightness, so the shader alpha has to end up in RGB
-    // with the result opaque. Both variants below build that with blending rather than a color
-    // matrix: a matrix that lights up transparent pixels makes ColorFilterShader mask its own
-    // output with the original shader alpha (SrcIn), which crushes the antialiased edge.
+    auto maskOffset = Matrix::MakeTrans(-maskBound.x(), -maskBound.y());
     Paint maskPaint;
-    if (shaderMaskFilter->isInverted()) {
-      // DstOut over a white backdrop gives Cr = 1 - A, then DstOver with an opaque black restores
-      // A' = 1 without touching RGB. The region the shader never covers stays white, i.e. unmasked.
-      maskCanvas->clear(Color::White());
-      maskPaint.setShader(shader);
-      maskPaint.setBlendMode(BlendMode::DstOut);
-      maskCanvas->drawPaint(maskPaint);
-      Paint opaquePaint;
-      opaquePaint.setColor(Color::Black());
-      opaquePaint.setBlendMode(BlendMode::DstOver);
-      maskCanvas->drawPaint(opaquePaint);
-    } else {
-      // SrcOver of an opaque white with the shader alpha as coverage onto an opaque black backdrop
-      // yields Cr = A at Ar = 1. The uncovered region stays black, i.e. fully masked.
+    if (shaderMaskFilter == nullptr) {
+      // Composed mask filters have no single shader to extract. Draw opaque white through the
+      // compose filter onto an opaque black backdrop, so the combined coverage ends up in RGB
+      // with the result opaque.
       maskCanvas->clear(Color::Black());
       maskPaint.setColor(Color::White());
-      maskPaint.setMaskFilter(MaskFilter::MakeShader(shader));
+      maskPaint.setMaskFilter(originPaint.maskFilter->makeWithMatrix(maskOffset));
       maskCanvas->drawPaint(maskPaint);
+    } else {
+      auto shader = shaderMaskFilter->getShader();
+      if (maskBound.x() != 0 || maskBound.y() != 0) {
+        shader = shader->makeWithMatrix(maskOffset);
+      }
+      // A PDF luminosity SMask reads the RGB brightness, so the shader alpha has to end up in RGB
+      // with the result opaque. Both variants below build that with blending rather than a color
+      // matrix: a matrix that lights up transparent pixels makes ColorFilterShader mask its own
+      // output with the original shader alpha (SrcIn), which crushes the antialiased edge.
+      if (shaderMaskFilter->isInverted()) {
+        // DstOut over a white backdrop gives Cr = 1 - A, then DstOver with an opaque black
+        // restores A' = 1 without touching RGB. The region the shader never covers stays white,
+        // i.e. unmasked.
+        maskCanvas->clear(Color::White());
+        maskPaint.setShader(shader);
+        maskPaint.setBlendMode(BlendMode::DstOut);
+        maskCanvas->drawPaint(maskPaint);
+        Paint opaquePaint;
+        opaquePaint.setColor(Color::Black());
+        opaquePaint.setBlendMode(BlendMode::DstOver);
+        maskCanvas->drawPaint(opaquePaint);
+      } else {
+        // SrcOver of an opaque white with the shader alpha as coverage onto an opaque black
+        // backdrop yields Cr = A at Ar = 1. The uncovered region stays black, i.e. fully masked.
+        maskCanvas->clear(Color::Black());
+        maskPaint.setColor(Color::White());
+        maskPaint.setMaskFilter(MaskFilter::MakeShader(shader));
+        maskCanvas->drawPaint(maskPaint);
+      }
     }
 
     auto maskImage = surface->makeImageSnapshot();
@@ -1486,8 +1510,8 @@ void PDFExportContext::drawPathWithFilter(const Matrix& matrix, const ClipStack&
     }
   } else {
     Canvas canvas(maskContext.get());
-    canvas.concat(pictureMatrix);
-    canvas.drawPicture(picture);
+    canvas.concat(maskPictureMatrix);
+    canvas.drawPicture(maskPicture);
   }
 
   if (!matrix.isIdentity() && paint.shader) {

--- a/src/svg/ElementWriter.cpp
+++ b/src/svg/ElementWriter.cpp
@@ -1434,6 +1434,9 @@ void ElementWriter::addMaskResources(const std::shared_ptr<MaskFilter>& maskFilt
                                      SVGExportContext* svgContext,
                                      std::vector<PendingImage>* pendings) {
   if (Types::Get(maskFilter.get()) != Types::MaskFilterType::Shader) {
+    if (Types::Get(maskFilter.get()) == Types::MaskFilterType::Compose) {
+      reportUnsupportedElement("composed mask filter");
+    }
     return;
   }
 

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -60,6 +60,7 @@
         "EmptyRectStroke": "dc886da3",
         "FractalNoiseFreqOne": "a8bfb235",
         "GlyphBaseline": "40d85838c",
+        "InverseFillPath": "42d0b287",
         "LumaFilterToRec2020": "82494664",
         "LumaFilterToRec601": "82494664",
         "LumaFilterToSRGB": "82494664",
@@ -414,6 +415,17 @@
         "TextInnerShadow": "351c4df9",
         "TextLayerStyleAlignment": "351c4df9",
         "TextMultiNoiseTransforms": "2c4681a2"
+    },
+    "PathMaskTest": {
+        "Animation_End": "42d0b287",
+        "Animation_Start": "42d0b287",
+        "Combine": "42d0b287",
+        "Feather": "42d0b287",
+        "Invalidation_Cleared": "42d0b287",
+        "Invalidation_Masked": "42d0b287",
+        "ScrollRect": "42d0b287",
+        "Transform": "42d0b287",
+        "WithLayerMask": "42d0b287"
     },
     "PathShapeTest": {
         "AdaptiveDashEffect": "0448e0fe",

--- a/test/src/CanvasTest.cpp
+++ b/test/src/CanvasTest.cpp
@@ -289,6 +289,42 @@ TGFX_TEST(CanvasTest, saveLayer) {
   EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/saveLayer"));
 }
 
+TGFX_TEST(CanvasTest, InverseFillPath) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  ASSERT_TRUE(context != nullptr);
+  auto surface = Surface::Make(context, 200, 100);
+  auto canvas = surface->getCanvas();
+  canvas->clear(Color::White());
+  Paint paint = {};
+  paint.setColor(Color::FromRGBA(0, 180, 0));
+
+  // Plain draw: an inverse-filled oval paints everything except the oval.
+  canvas->save();
+  canvas->clipRect(Rect::MakeWH(100, 100));
+  Path path = {};
+  path.addOval(Rect::MakeXYWH(20, 20, 60, 60));
+  path.toggleInverseFillType();
+  canvas->drawPath(path, paint);
+  canvas->restore();
+
+  // Draw through a saveLayer with an image filter: the inverse fill must survive the offscreen
+  // layer bounds computation.
+  canvas->save();
+  canvas->clipRect(Rect::MakeXYWH(100, 0, 100, 100));
+  Paint layerPaint = {};
+  layerPaint.setImageFilter(ImageFilter::Blur(5, 5));
+  canvas->saveLayer(&layerPaint);
+  Path blurredPath = {};
+  blurredPath.addOval(Rect::MakeXYWH(120, 20, 60, 60));
+  blurredPath.toggleInverseFillType();
+  canvas->drawPath(blurredPath, paint);
+  canvas->restore();
+  canvas->restore();
+
+  EXPECT_TRUE(Baseline::Compare(surface, "CanvasTest/InverseFillPath"));
+}
+
 TGFX_TEST(CanvasTest, NothingToDraw) {
   ContextScope scope;
   auto context = scope.getContext();

--- a/test/src/PathMaskTest.cpp
+++ b/test/src/PathMaskTest.cpp
@@ -1,0 +1,332 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. see the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "tgfx/core/ImageFilter.h"
+#include "tgfx/core/PictureRecorder.h"
+#include "tgfx/layers/DisplayList.h"
+#include "tgfx/layers/ShapeLayer.h"
+#include "tgfx/layers/SolidLayer.h"
+#include "utils/TestUtils.h"
+
+namespace tgfx {
+
+static std::shared_ptr<ShapeLayer> MakeContent(const Rect& rect, const Color& color) {
+  auto content = ShapeLayer::Make();
+  Path path;
+  path.addRect(rect);
+  content->setPath(path);
+  content->setFillStyle(ShapeStyle::Make(color));
+  return content;
+}
+
+static std::shared_ptr<PathMask> MakeCircleMask(float x, float y, float radius) {
+  auto mask = PathMask::Make();
+  Path path;
+  path.addOval(Rect::MakeXYWH(x - radius, y - radius, radius * 2, radius * 2));
+  mask->setPath(path);
+  return mask;
+}
+
+TGFX_TEST(PathMaskTest, Combine) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  // Union: two overlapping circles.
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 80, 80), contentColor);
+  auto maskA = MakeCircleMask(40, 40, 30);
+  auto maskB = MakeCircleMask(70, 70, 30);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  // Subtract: the second circle cuts a bite out of the first one.
+  content = MakeContent(Rect::MakeXYWH(110, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(140, 40, 30);
+  maskB = MakeCircleMask(170, 70, 30);
+  maskB->setOp(PathOp::Difference);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  // Intersect: only the overlapping lens stays visible.
+  content = MakeContent(Rect::MakeXYWH(210, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(240, 40, 30);
+  maskB = MakeCircleMask(270, 70, 30);
+  maskB->setOp(PathOp::Intersect);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  // XOR: the overlapping area is cut out.
+  content = MakeContent(Rect::MakeXYWH(310, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(340, 40, 30);
+  maskB = MakeCircleMask(370, 70, 30);
+  maskB->setOp(PathOp::XOR);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  // Inverted: the content stays visible outside the circle.
+  content = MakeContent(Rect::MakeXYWH(410, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(450, 50, 30);
+  maskA->setInverted(true);
+  content->setPathMasks({maskA});
+  list.root()->addChild(content);
+
+  // First mask with Difference op flips its inverted flag: the visible region is everything
+  // outside circle A, unioned with circle B.
+  content = MakeContent(Rect::MakeXYWH(510, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(540, 40, 30);
+  maskA->setOp(PathOp::Difference);
+  maskB = MakeCircleMask(570, 70, 30);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  // Positive expansion enlarges the circle by 10 pixels.
+  content = MakeContent(Rect::MakeXYWH(610, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(650, 50, 30);
+  maskA->setExpansion(10);
+  content->setPathMasks({maskA});
+  list.root()->addChild(content);
+
+  // Negative expansion shrinks the circle by 10 pixels.
+  content = MakeContent(Rect::MakeXYWH(10, 110, 80, 80), contentColor);
+  maskA = MakeCircleMask(50, 150, 30);
+  maskA->setExpansion(-10);
+  content->setPathMasks({maskA});
+  list.root()->addChild(content);
+
+  // Masks with empty paths are skipped, so the content stays fully visible.
+  content = MakeContent(Rect::MakeXYWH(110, 110, 80, 80), contentColor);
+  content->setPathMasks({PathMask::Make()});
+  list.root()->addChild(content);
+
+  // Disjoint circles combined by Intersect produce an empty region, hiding the whole layer.
+  content = MakeContent(Rect::MakeXYWH(210, 110, 80, 80), contentColor);
+  maskA = MakeCircleMask(230, 130, 15);
+  maskB = MakeCircleMask(280, 180, 15);
+  maskB->setOp(PathOp::Intersect);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  auto surface = Surface::Make(context, 700, 200);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Combine"));
+}
+
+TGFX_TEST(PathMaskTest, Feather) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  auto background = SolidLayer::Make();
+  background->setWidth(400);
+  background->setHeight(100);
+  background->setColor(Color::White());
+  list.root()->addChild(background);
+
+  // Feathered circle with soft edges.
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 80, 80), contentColor);
+  auto maskA = MakeCircleMask(50, 50, 30);
+  maskA->setFeather(Point::Make(20, 20));
+  content->setPathMasks({maskA});
+  list.root()->addChild(content);
+
+  // Half-opacity mask, showing the white background through the content.
+  content = MakeContent(Rect::MakeXYWH(110, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(150, 50, 30);
+  maskA->setOpacity(0.5f);
+  content->setPathMasks({maskA});
+  list.root()->addChild(content);
+
+  // Two feathered masks are composited in SrcOver order, boolean ops are ignored.
+  content = MakeContent(Rect::MakeXYWH(210, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(240, 40, 30);
+  maskA->setFeather(Point::Make(10, 10));
+  auto maskB = MakeCircleMask(270, 70, 30);
+  maskB->setFeather(Point::Make(10, 10));
+  maskB->setOp(PathOp::Difference);
+  content->setPathMasks({maskA, maskB});
+  list.root()->addChild(content);
+
+  // Inverted feathered mask: soft edge, visible outside the circle.
+  content = MakeContent(Rect::MakeXYWH(310, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(350, 50, 30);
+  maskA->setFeather(Point::Make(10, 10));
+  maskA->setInverted(true);
+  content->setPathMasks({maskA});
+  list.root()->addChild(content);
+
+  auto surface = Surface::Make(context, 400, 100);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Feather"));
+}
+
+TGFX_TEST(PathMaskTest, WithLayerMask) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  // A clip-path path mask combined with an alpha layer mask: circle intersect right half.
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 80, 80), contentColor);
+  content->setPathMasks({MakeCircleMask(50, 50, 30)});
+  auto layerMask = ShapeLayer::Make();
+  Path halfPath;
+  halfPath.addRect(Rect::MakeXYWH(50, 0, 50, 100));
+  layerMask->setPath(halfPath);
+  layerMask->setFillStyle(ShapeStyle::Make(Color::White()));
+  content->setMask(layerMask);
+  list.root()->addChild(content);
+  list.root()->addChild(layerMask);
+
+  // A feathered path mask composed with a luminance layer mask at the shader level:
+  // soft circle intersect right half.
+  content = MakeContent(Rect::MakeXYWH(110, 10, 80, 80), contentColor);
+  auto maskA = MakeCircleMask(150, 50, 30);
+  maskA->setFeather(Point::Make(10, 10));
+  content->setPathMasks({maskA});
+  layerMask = ShapeLayer::Make();
+  halfPath = {};
+  halfPath.addRect(Rect::MakeXYWH(150, 0, 50, 100));
+  layerMask->setPath(halfPath);
+  layerMask->setFillStyle(ShapeStyle::Make(Color::White()));
+  content->setMask(layerMask);
+  content->setMaskType(LayerMaskType::Luminance);
+  list.root()->addChild(content);
+  list.root()->addChild(layerMask);
+
+  // A feathered path mask composed with an inverted luminance layer mask:
+  // soft circle with the right half removed.
+  content = MakeContent(Rect::MakeXYWH(210, 10, 80, 80), contentColor);
+  maskA = MakeCircleMask(250, 50, 30);
+  maskA->setFeather(Point::Make(10, 10));
+  content->setPathMasks({maskA});
+  layerMask = ShapeLayer::Make();
+  halfPath = {};
+  halfPath.addRect(Rect::MakeXYWH(250, 0, 50, 100));
+  layerMask->setPath(halfPath);
+  layerMask->setFillStyle(ShapeStyle::Make(Color::White()));
+  content->setMask(layerMask);
+  content->setMaskType(LayerMaskType::LuminanceInverted);
+  list.root()->addChild(content);
+  list.root()->addChild(layerMask);
+
+  auto surface = Surface::Make(context, 300, 100);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/WithLayerMask"));
+}
+
+TGFX_TEST(PathMaskTest, Animation) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 80, 80), contentColor);
+  auto mask = MakeCircleMask(35, 50, 20);
+  content->setPathMasks({mask});
+  list.root()->addChild(content);
+
+  auto surface = Surface::Make(context, 100, 100);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Animation_Start"));
+
+  // Changing the mask path invalidates the layer content and takes effect on the next frame.
+  Path newPath;
+  newPath.addOval(Rect::MakeXYWH(45, 30, 40, 40));
+  mask->setPath(newPath);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Animation_End"));
+}
+
+TGFX_TEST(PathMaskTest, Invalidation) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 80, 80), contentColor);
+  content->setPathMasks({MakeCircleMask(50, 50, 30)});
+  list.root()->addChild(content);
+
+  auto surface = Surface::Make(context, 100, 100);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Invalidation_Masked"));
+
+  // Clearing the path masks invalidates the layer, so the content renders in full again.
+  content->setPathMasks({});
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Invalidation_Cleared"));
+}
+
+TGFX_TEST(PathMaskTest, Transform) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  // The group matrix scales and translates both the content and its path masks, so the mask
+  // circle must stay centered on the content.
+  auto group = Layer::Make();
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 40, 40), contentColor);
+  content->setPathMasks({MakeCircleMask(30, 30, 15)});
+  group->addChild(content);
+  group->setMatrix(Matrix::MakeAll(2, 0, 20, 0, 2, 10));
+  list.root()->addChild(group);
+
+  // A feathered mask under a scaled group: the blur radius must scale with the content.
+  group = Layer::Make();
+  content = MakeContent(Rect::MakeXYWH(10, 10, 40, 40), contentColor);
+  auto featherMask = MakeCircleMask(30, 30, 15);
+  featherMask->setFeather(Point::Make(5, 5));
+  content->setPathMasks({featherMask});
+  group->addChild(content);
+  group->setMatrix(Matrix::MakeAll(2, 0, 120, 0, 2, 10));
+  list.root()->addChild(group);
+
+  auto surface = Surface::Make(context, 220, 110);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/Transform"));
+}
+
+TGFX_TEST(PathMaskTest, ScrollRect) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+  DisplayList list;
+  auto contentColor = Color::FromRGBA(0, 180, 0);
+
+  // The scroll rect crops the content to the left half, and the circle path mask crops it
+  // further: only the left half of the circle remains visible.
+  auto content = MakeContent(Rect::MakeXYWH(10, 10, 80, 80), contentColor);
+  content->setScrollRect(Rect::MakeXYWH(10, 10, 40, 80));
+  content->setPathMasks({MakeCircleMask(50, 50, 30)});
+  list.root()->addChild(content);
+
+  auto surface = Surface::Make(context, 100, 100);
+  list.render(surface.get());
+  EXPECT_TRUE(Baseline::Compare(surface, "PathMaskTest/ScrollRect"));
+}
+
+}  // namespace tgfx


### PR DESCRIPTION
  - 新增 `PathMask` 图层遮罩，支持路径、布尔运算、反选、羽化、透明度、扩展。
  - 一个图层可挂多个 `PathMask`，在图层级 mask 之前应用。
  - 无羽化/半透明时按布尔合并结果走 clip 路径；否则走羽化合成（各自透明度 + 羽化模糊，SrcOver 叠加）。
  - 新增 `MaskFilter::Compose`，把路径遮罩与图层级 mask 串联。