### PR TITLE
Extract a self-locked TaskQueue from TaskGroup to remove the cross-lock accounting races

### DIFF
--- a/include/tgfx/core/Task.h
+++ b/include/tgfx/core/Task.h
@@ -75,10 +75,12 @@ enum class TaskPriority {
 class Task {
  public:
   /**
-   * Sets the maximum number of worker threads that can be created for running tasks. Call this
-   * method before submitting any tasks to avoid thread creation races. A value of zero restores
-   * the default, which is based on the number of CPU cores and capped at 32. Lowering the limit
-   * releases the surplus worker threads.
+   * Sets the maximum number of worker threads that can be created for running tasks. A value of
+   * zero restores the default, which is based on the number of CPU cores. Values greater than 32
+   * are capped at 32. Lowering the limit releases the surplus worker threads: idle threads exit
+   * immediately, while busy threads exit once they become idle. The thread objects of the released
+   * threads are not reclaimed until ReleaseThreads() is called, so avoid adjusting the limit at a
+   * high frequency, such as once per frame.
    * @param maxThreadCount The maximum number of worker threads. Zero means use the default.
    */
   static void SetMaxThreadCount(size_t maxThreadCount);

--- a/src/core/utils/TaskGroup.cpp
+++ b/src/core/utils/TaskGroup.cpp
@@ -10,15 +10,15 @@
 //      https://opensource.org/licenses/BSD-3-Clause
 //
 //  unless required by applicable law or agreed to in writing, software distributed under the
-//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
-//  either express or implied. see the license for the specific language governing permissions
-//  and limitations under the license.
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include "TaskGroup.h"
+#include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include "MathExtra.h"
 #include "core/utils/Log.h"
 
@@ -27,18 +27,22 @@
 #endif
 
 namespace tgfx {
-static constexpr auto THREAD_TIMEOUT = std::chrono::seconds(10);
+// Workers wake up periodically to recheck the exit conditions, so a missed wakeAll() delays
+// shutdown or shrink by at most this long.
+static constexpr auto THREAD_TIMEOUT = std::chrono::milliseconds(10000);
 static constexpr size_t MAX_THREADS_SIZE = 32;
-static constexpr size_t TASK_PRIORITY_SIZE = 3;
 // 70% of max threads can run low priority tasks
 static constexpr float LOW_PRIORITY_THREAD_RATIO = 0.7f;
 
 static size_t GetDefaultMaxThreadCount() {
   size_t cpuCores = 0;
 #ifdef __APPLE__
-  size_t len = sizeof(cpuCores);
+  int cores = 0;
+  // hw.physicalcpu returns an int, so the buffer must be int-sized to avoid reading past it.
+  size_t len = sizeof(cores);
   // We can get the exact number of physical CPUs on apple platforms.
-  sysctlbyname("hw.physicalcpu", &cpuCores, &len, nullptr, 0);
+  sysctlbyname("hw.physicalcpu", &cores, &len, nullptr, 0);
+  cpuCores = cores > 0 ? static_cast<size_t>(cores) : 0;
 #else
   cpuCores = std::thread::hardware_concurrency();
 #endif
@@ -58,24 +62,28 @@ TaskGroup* TaskGroup::GetInstance() {
 
 void TaskGroup::RunLoop(TaskGroup* taskGroup) {
   while (true) {
-    auto task = taskGroup->popTask();
-    if (task == nullptr) {
-      if (taskGroup->exited) {
-        break;
-      }
-      if (taskGroup->shrinkThread()) {
-        break;
-      }
+    std::shared_ptr<Task> task = nullptr;
+    auto result = taskGroup->taskQueue.waitForTask(&task, taskGroup->totalThreads.load(),
+                                                   taskGroup->lowPriorityThreads.load(),
+                                                   THREAD_TIMEOUT.count());
+    if (result == TaskQueue::ClaimResult::Claimed) {
+      task->execute();
       continue;
     }
-    task->execute();
+    if (taskGroup->taskQueue.isClosed()) {
+      break;
+    }
+    if (taskGroup->shrinkSelf()) {
+      break;
+    }
+    // Timed out or woken with the pool under the limit: claim again.
   }
 }
 
 void OnAppExit() {
   // Forces all pending tasks to be finished when the app is exiting to prevent accessing wild
   // pointers.
-  TaskGroup::GetInstance()->exit();
+  TaskGroup::GetInstance()->releaseThreads(true);
 }
 
 TaskGroup::TaskGroup() : maxThreads(GetDefaultMaxThreadCount()) {
@@ -85,38 +93,30 @@ TaskGroup::TaskGroup() : maxThreads(GetDefaultMaxThreadCount()) {
     lowPriorityThreads = 1;
   }
   threads = new moodycamel::ConcurrentQueue<std::thread*>(maxThreads.load());
-  priorityQueues.reserve(TASK_PRIORITY_SIZE);
-  for (size_t i = 0; i < TASK_PRIORITY_SIZE; i++) {
-    auto queue = new moodycamel::ConcurrentQueue<std::shared_ptr<Task>>();
-    priorityQueues.push_back(queue);
-  }
   std::atexit(OnAppExit);
 }
 
 void TaskGroup::setMaxThreadCount(size_t maxThreadCount) {
   if (maxThreadCount == 0) {
     maxThreadCount = GetDefaultMaxThreadCount();
+  } else if (maxThreadCount > MAX_THREADS_SIZE) {
+    maxThreadCount = MAX_THREADS_SIZE;
   }
-  std::lock_guard<std::mutex> autoLock(locker);
   maxThreads = maxThreadCount;
   lowPriorityThreads = static_cast<size_t>(
       FloatRoundToInt(static_cast<float>(maxThreadCount) * LOW_PRIORITY_THREAD_RATIO));
   if (lowPriorityThreads < 1) {
     lowPriorityThreads = 1;
   }
-  // Wake up idle threads so they can exit if the pool exceeds the new limit.
-  condition.notify_all();
+  // Wake idle workers so they can exit if the pool exceeds the new limit.
+  taskQueue.wakeAll();
 }
 
 size_t TaskGroup::maxThreadCount() const {
   return maxThreads.load();
 }
 
-bool TaskGroup::shouldExit() const {
-  return exited || totalThreads.load() > maxThreads.load();
-}
-
-bool TaskGroup::shrinkThread() {
+bool TaskGroup::shrinkSelf() {
   size_t total = totalThreads.load();
   while (total > maxThreads.load()) {
     if (totalThreads.compare_exchange_weak(total, total - 1)) {
@@ -126,93 +126,44 @@ bool TaskGroup::shrinkThread() {
   return false;
 }
 
-bool TaskGroup::checkThreads() {
-  if (waitingThreads.load() == 0 && totalThreads.load() < maxThreads.load()) {
-    auto thread = new (std::nothrow) std::thread(TaskGroup::RunLoop, this);
-    if (thread) {
-      if (threads->enqueue(thread)) {
-        ++totalThreads;
-      } else {
-        delete thread;
-        return false;
-      }
-    }
-  } else {
-    return true;
+bool TaskGroup::spawnWorker() {
+  // Reserve the slot before starting the thread so concurrent pushes cannot spawn past the cap.
+  auto reserved = totalThreads.fetch_add(1) + 1;
+  if (reserved > maxThreads.load()) {
+    totalThreads.fetch_sub(1);
+    return false;
   }
-  return totalThreads > 0;
+  auto thread = new (std::nothrow) std::thread(TaskGroup::RunLoop, this);
+  if (thread == nullptr) {
+    totalThreads.fetch_sub(1);
+    return false;
+  }
+  if (!threads->enqueue(thread)) {
+    // The threads queue is unbounded, so this only happens on OOM. Detach the started thread
+    // so deleting the handle stays safe; it exits on the next close().
+    thread->detach();
+    delete thread;
+    totalThreads.fetch_sub(1);
+    return false;
+  }
+  return true;
 }
 
 bool TaskGroup::pushTask(std::shared_ptr<Task> task, TaskPriority priority) {
 #ifndef TGFX_USE_THREADS
   return false;
 #endif
-  if (exited || !checkThreads()) {
+  if (taskQueue.isClosed()) {
     return false;
   }
-  auto& queue = priorityQueues[static_cast<size_t>(priority)];
-  if (!queue->enqueue(task)) {
+  auto result = taskQueue.enqueue(task, priority);
+  if (result == TaskQueue::EnqueueResult::Rejected) {
     return false;
   }
-  std::lock_guard<std::mutex> autoLock(locker);
-  if (waitingThreads > 0) {
-    condition.notify_one();
+  if (result == TaskQueue::EnqueueResult::NeedsWorker && totalThreads.load() < maxThreads.load()) {
+    spawnWorker();
   }
   return true;
-}
-
-std::shared_ptr<Task> TaskGroup::tryDequeueTask() {
-  std::shared_ptr<Task> task = nullptr;
-  for (size_t i = 0; i < static_cast<size_t>(TaskPriority::Low); i++) {
-    if (priorityQueues[i]->try_dequeue(task)) {
-      return task;
-    }
-  }
-  if (totalThreads.load() - waitingThreads.load() < lowPriorityThreads.load()) {
-    auto& queue = priorityQueues[static_cast<size_t>(TaskPriority::Low)];
-    if (queue->try_dequeue(task)) {
-      return task;
-    }
-  }
-  return nullptr;
-}
-
-std::shared_ptr<Task> TaskGroup::popTask() {
-  while (!exited) {
-    auto task = tryDequeueTask();
-    if (task) {
-      return task;
-    }
-    if (shouldExit()) {
-      return nullptr;
-    }
-    ++waitingThreads;
-    {
-      std::unique_lock<std::mutex> autoLock(locker);
-      // Re-check the queues while holding the lock so a task pushed concurrently cannot be missed
-      // by a lost notification.
-      task = tryDequeueTask();
-      if (task) {
-        --waitingThreads;
-        return task;
-      }
-      if (shouldExit()) {
-        --waitingThreads;
-        return nullptr;
-      }
-      auto status = condition.wait_for(autoLock, THREAD_TIMEOUT);
-      if (status == std::cv_status::timeout) {
-        --waitingThreads;
-        return nullptr;
-      }
-    }
-    --waitingThreads;
-  }
-  return nullptr;
-}
-
-void TaskGroup::exit() {
-  releaseThreads(true);
 }
 
 static void ReleaseThread(std::thread* thread) {
@@ -223,28 +174,18 @@ static void ReleaseThread(std::thread* thread) {
 }
 
 void TaskGroup::releaseThreads(bool exit) {
-  // Set exited and notify while holding the lock, so a worker that has not entered its wait yet
-  // will observe exited in the locked section of popTask() instead of missing the notification
-  // and sleeping for the full THREAD_TIMEOUT.
-  {
-    std::lock_guard<std::mutex> autoLock(locker);
-    exited = true;
-    condition.notify_all();
-  }
+  // The queue closes and notifies while holding its lock, so a worker that has not entered its
+  // wait yet observes the closed flag instead of missing the notification and sleeping for the
+  // full THREAD_TIMEOUT.
+  taskQueue.close();
   std::thread* thread = nullptr;
   while (threads->try_dequeue(thread)) {
     ReleaseThread(thread);
   }
   totalThreads = 0;
-  DEBUG_ASSERT(waitingThreads == 0)
-  if (exit) {
-    delete threads;
-    for (auto& queue : priorityQueues) {
-      delete queue;
-    }
-    priorityQueues.clear();
-  } else {
-    exited = false;
+  DEBUG_ASSERT(taskQueue.sleeperCount() == 0)
+  if (!exit) {
+    taskQueue.reset();
   }
 }
 }  // namespace tgfx

--- a/src/core/utils/TaskGroup.h
+++ b/src/core/utils/TaskGroup.h
@@ -10,52 +10,47 @@
 //      https://opensource.org/licenses/BSD-3-Clause
 //
 //  unless required by applicable law or agreed to in writing, software distributed under the
-//  license is distributed on an "as is" basis, without warranties or conditions of any kind,
-//  either express or implied. see the license for the specific language governing permissions
-//  and limitations under the license.
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
 //
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
-#include <condition_variable>
-#include <list>
-#include <mutex>
+#include <atomic>
 #include <thread>
-#include <vector>
 #include "concurrentqueue.h"
+#include "core/utils/TaskQueue.h"
 #include "tgfx/core/Task.h"
 
 namespace tgfx {
 
+/**
+ * TaskGroup manages a pool of worker threads that claim tasks from an internal TaskQueue. The
+ * queue owns the scheduling counters and its own lock; this class only decides when to spawn,
+ * shrink, and release workers.
+ */
 class TaskGroup {
  private:
-  std::mutex locker = {};
+  TaskQueue taskQueue = {};
+  std::atomic_size_t totalThreads = 0;
   std::atomic_size_t maxThreads = 32;
   std::atomic_size_t lowPriorityThreads = 2;
-  std::condition_variable condition = {};
-  std::atomic_size_t totalThreads = 0;
-  std::atomic_bool exited = false;
-  std::atomic_size_t waitingThreads = 0;
-  std::vector<moodycamel::ConcurrentQueue<std::shared_ptr<Task>>*> priorityQueues = {};
   moodycamel::ConcurrentQueue<std::thread*>* threads = nullptr;
+
   static TaskGroup* GetInstance();
   static void RunLoop(TaskGroup* taskGroup);
 
   TaskGroup();
+  bool spawnWorker();
+  bool shrinkSelf();
   void setMaxThreadCount(size_t maxThreadCount);
   size_t maxThreadCount() const;
-  bool shouldExit() const;
-  bool shrinkThread();
-  bool checkThreads();
   bool pushTask(std::shared_ptr<Task> task, TaskPriority priority);
-  std::shared_ptr<Task> tryDequeueTask();
-  std::shared_ptr<Task> popTask();
-  void exit();
   void releaseThreads(bool exit);
 
   friend class Task;
-  friend class TaskThread;
   friend void OnAppExit();
 };
 }  // namespace tgfx

--- a/src/core/utils/TaskQueue.cpp
+++ b/src/core/utils/TaskQueue.cpp
@@ -1,0 +1,111 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "TaskQueue.h"
+#include <chrono>
+
+namespace tgfx {
+
+TaskQueue::EnqueueResult TaskQueue::enqueue(std::shared_ptr<Task> task, TaskPriority priority) {
+  if (!priorityQueues[static_cast<size_t>(priority)].enqueue(task)) {
+    return EnqueueResult::Rejected;
+  }
+  std::lock_guard<std::mutex> autoLock(locker);
+  if (priority != TaskPriority::Low) {
+    backlog++;
+  }
+  // A sleeping worker absorbs at most one task per wakeup. Comparing the claimable backlog
+  // against the exact sleeper count makes a push landing inside a worker's wakeup window still
+  // report the extra worker it needs.
+  auto needsWorker = backlog > waitingThreads;
+  if (waitingThreads > 0) {
+    condition.notify_one();
+  }
+  return needsWorker ? EnqueueResult::NeedsWorker : EnqueueResult::Enqueued;
+}
+
+TaskQueue::ClaimResult TaskQueue::waitForTask(std::shared_ptr<Task>* task, size_t totalThreads,
+                                              size_t lowPriorityThreads, uint64_t timeoutMs) {
+  std::unique_lock<std::mutex> autoLock(locker);
+  ++waitingThreads;
+  *task = claimLocked(totalThreads, lowPriorityThreads);
+  if (*task) {
+    --waitingThreads;
+    return ClaimResult::Claimed;
+  }
+  if (closed.load()) {
+    --waitingThreads;
+    return ClaimResult::Woken;
+  }
+  auto status = condition.wait_for(autoLock, std::chrono::milliseconds(timeoutMs));
+  --waitingThreads;
+  // Any wakeup hands control back to the caller, which re-evaluates the pool state (a task may
+  // have arrived, the limit may have changed, or the queue may have closed) before claiming again.
+  return status == std::cv_status::timeout ? ClaimResult::Timeout : ClaimResult::Woken;
+}
+
+std::shared_ptr<Task> TaskQueue::claimLocked(size_t totalThreads, size_t lowPriorityThreads) {
+  std::shared_ptr<Task> task = nullptr;
+  for (size_t i = 0; i < static_cast<size_t>(TaskPriority::Low); i++) {
+    if (priorityQueues[i].try_dequeue(task)) {
+      backlog--;
+      return task;
+    }
+  }
+  // Written in additive form (busy < low) so a stale totalThreads snapshot crossing a
+  // concurrent shrink cannot underflow the subtraction.
+  if (totalThreads < lowPriorityThreads + waitingThreads) {
+    priorityQueues[static_cast<size_t>(TaskPriority::Low)].try_dequeue(task);
+  }
+  return task;
+}
+
+void TaskQueue::wakeAll() {
+  std::lock_guard<std::mutex> autoLock(locker);
+  condition.notify_all();
+}
+
+void TaskQueue::close() {
+  std::lock_guard<std::mutex> autoLock(locker);
+  closed = true;
+  condition.notify_all();
+}
+
+void TaskQueue::reset() {
+  std::lock_guard<std::mutex> autoLock(locker);
+  closed = false;
+}
+
+bool TaskQueue::isClosed() const {
+  return closed.load();
+}
+
+size_t TaskQueue::sleeperCount() {
+  std::lock_guard<std::mutex> autoLock(locker);
+  return waitingThreads;
+}
+
+size_t TaskQueue::pendingCount() {
+  std::lock_guard<std::mutex> autoLock(locker);
+  size_t count = 0;
+  for (auto& queue : priorityQueues) {
+    count += queue.size_approx();
+  }
+  return count;
+}
+}  // namespace tgfx

--- a/src/core/utils/TaskQueue.h
+++ b/src/core/utils/TaskQueue.h
@@ -1,0 +1,138 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//  Tencent is pleased to support the open source community by making tgfx available.
+//
+//  Copyright (C) 2026 Tencent. All rights reserved.
+//
+//  Licensed under the BSD 3-Clause License (the "License"); you may not use this file except
+//  in compliance with the License. You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/BSD-3-Clause
+//
+//  unless required by applicable law or agreed to in writing, software distributed under the
+//  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//  either express or implied. See the License for the specific language governing permissions
+//  and limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include "concurrentqueue.h"
+#include "tgfx/core/Task.h"
+
+namespace tgfx {
+
+/**
+ * A self-synchronized priority task queue used by the TaskGroup thread pool. Producers enqueue
+ * concurrently; workers claim tasks through waitForTask(), which sleeps on an internal condition
+ * variable between claims. All scheduling counters live inside the queue's critical section, so
+ * callers never handle locks or counters.
+ */
+class TaskQueue {
+ public:
+  /**
+   * The outcome of enqueue().
+   */
+  enum class EnqueueResult {
+    /**
+     * The task was rejected, and the caller must execute it inline.
+     */
+    Rejected,
+    /**
+     * The task was enqueued; the existing workers are enough to absorb it.
+     */
+    Enqueued,
+    /**
+     * The task was enqueued, and the claimable backlog now exceeds the sleeping workers, so the
+     * caller should ensure another worker thread exists.
+     */
+    NeedsWorker,
+  };
+
+  /**
+   * The outcome of waitForTask().
+   */
+  enum class ClaimResult {
+    /**
+     * A task was claimed; the out parameter holds it.
+     */
+    Claimed,
+    /**
+     * No task was claimed before the timeout elapsed.
+     */
+    Timeout,
+    /**
+     * The wait was interrupted by wakeAll() or close().
+     */
+    Woken,
+  };
+
+  /**
+   * Enqueues a task at the given priority.
+   */
+  EnqueueResult enqueue(std::shared_ptr<Task> task, TaskPriority priority);
+
+  /**
+   * Claims a task from the queues, sleeping up to the timeout when none is available.
+   * @param task Set to the claimed task when returning Claimed.
+   * @param totalThreads The current number of live workers in the pool.
+   * @param lowPriorityThreads The maximum number of busy workers allowed before Low tasks can be
+   * claimed.
+   * @param timeoutMs The maximum duration in milliseconds to sleep when no task is available.
+   * @return The outcome of the claim attempt.
+   */
+  ClaimResult waitForTask(std::shared_ptr<Task>* task, size_t totalThreads,
+                          size_t lowPriorityThreads, uint64_t timeoutMs);
+
+  /**
+   * Wakes all sleeping workers without closing the queue. Used when the thread limit changes.
+   */
+  void wakeAll();
+
+  /**
+   * Closes the queue and wakes all sleeping workers. Further claims return immediately.
+   */
+  void close();
+
+  /**
+   * Reopens a closed queue, keeping any tasks that are still pending.
+   */
+  void reset();
+
+  /**
+   * Returns true if the queue has been closed and not reset.
+   */
+  bool isClosed() const;
+
+  /**
+   * Returns the number of workers currently sleeping inside waitForTask().
+   */
+  size_t sleeperCount();
+
+  /**
+   * Returns the approximate number of tasks still pending in the queues.
+   */
+  size_t pendingCount();
+
+ private:
+  std::mutex locker = {};
+  std::condition_variable condition = {};
+  std::atomic_bool closed = {false};
+  // Counters below are guarded by locker. Workers only change waitingThreads inside the
+  // critical section of waitForTask(), so producers reading it under the lock always see the
+  // exact number of sleepers: a notified-but-not-yet-awake worker no longer counts.
+  size_t waitingThreads = 0;
+  // High and Medium priority tasks enqueued but not yet claimed. Low priority tasks are not
+  // counted: the low priority gate can hold them for a long time by design, and counting them
+  // would report a backlog that workers are not allowed to take.
+  size_t backlog = 0;
+  moodycamel::ConcurrentQueue<std::shared_ptr<Task>> priorityQueues[3];
+
+  std::shared_ptr<Task> claimLocked(size_t totalThreads, size_t lowPriorityThreads);
+};
+}  // namespace tgfx

--- a/test/src/ResourceTest.cpp
+++ b/test/src/ResourceTest.cpp
@@ -39,13 +39,9 @@ TGFX_TEST(ResourceTest, TaskRelease) {
   Task::ReleaseThreads();
   TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance(); std::thread* thead = nullptr;
                       group->threads->try_dequeue(thead); EXPECT_EQ(thead, nullptr);
-                      EXPECT_EQ(group->waitingThreads, 0u); EXPECT_EQ(group->totalThreads, 0u);
-                      for (auto& queue
-                           : group->priorityQueues) {
-                        std::shared_ptr<Task> task = nullptr;
-                        queue->try_dequeue(task);
-                        EXPECT_EQ(task, nullptr);
-                      })
+                      EXPECT_EQ(group->taskQueue.sleeperCount(), 0u);
+                      EXPECT_EQ(group->totalThreads, 0u);
+                      EXPECT_EQ(group->taskQueue.pendingCount(), 0u);)
 }
 
 #ifdef TGFX_USE_THREADS
@@ -59,21 +55,25 @@ TGFX_TEST(ResourceTest, MaxThreadCountShrink) {
   auto blockTask = [&started, &finished, &release] {
     ++started;
     while (!release.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     ++finished;
   };
   Task::Run(blockTask);
   // Wait for the first worker thread to start, then submit more tasks. All existing threads are
   // busy with the blocking tasks, so each submission guarantees a new worker thread is created.
-  while (started.load() < 1) {
+  for (int i = 0; i < 1000 && started.load() < 1; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   for (int i = 0; i < 3; ++i) {
     Task::Run(blockTask);
   }
-  while (started.load() < 4) {
+  for (int i = 0; i < 1000 && started.load() < 4; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   release = true;
-  while (finished.load() < 4) {
+  for (int i = 0; i < 1000 && finished.load() < 4; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   // Give the threads a moment to become idle before lowering the limit.
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -83,6 +83,47 @@ TGFX_TEST(ResourceTest, MaxThreadCountShrink) {
                         std::this_thread::sleep_for(std::chrono::milliseconds(10));
                       } EXPECT_EQ(group->totalThreads, 1u););
   Task::SetMaxThreadCount(0);
+  Task::ReleaseThreads();
+}
+
+TGFX_TEST_PRIVATE(ResourceTest, TaskBacklogSpawnsThreads) {
+  // Regression test for the wakeup-window accounting race: a notified waiter absorbs at most one
+  // task, but waitingThreads keeps counting it until the woken thread rechecks the queues. When
+  // two tasks are pushed back to back while the only waiter is waking up, the second push used to
+  // read the stale count and neither notified a sleeper nor spawned a thread, leaving the second
+  // task stranded until some worker finished its current task.
+  Task::ReleaseThreads();
+  Task::SetMaxThreadCount(2);
+  std::atomic<int> started{0};
+  std::atomic<int> finished{0};
+  std::atomic_bool release{false};
+  auto blockTask = [&started, &finished, &release] {
+    ++started;
+    while (!release.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ++finished;
+  };
+  // Bring the first worker online and wait until it goes back to sleep on the empty queue, so the
+  // first blocking task is guaranteed to wake the sole sleeper.
+  Task::Run([] {});
+  TGFX_PRIVATE_ACCESS(auto group = TaskGroup::GetInstance();
+                      for (int i = 0; i < 1000 && group->taskQueue.sleeperCount() < 1; ++i) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                      } EXPECT_EQ(group->taskQueue.sleeperCount(), 1u););
+  Task::Run(blockTask);
+  Task::Run(blockTask);
+  for (int i = 0; i < 1000 && started.load() < 2; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  EXPECT_EQ(started.load(), 2);
+  release = true;
+  for (int i = 0; i < 1000 && finished.load() < 2; ++i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  EXPECT_EQ(finished.load(), 2);
+  Task::SetMaxThreadCount(0);
+  Task::ReleaseThreads();
 }
 #endif
 


### PR DESCRIPTION
## What

Moves the scheduling core of the task pool (queues, lock, condition variable, and all counters) into a new self-synchronized `TaskQueue`, leaving `TaskGroup` as a thin thread-pool shell that only decides when to spawn, shrink, and release workers.

## Motivation

The wakeup-window race family (`waitingThreads` reading stale while a notified worker is still waking up) has its root in `waitingThreads` being incremented and decremented **outside** the lock, a window opened by #1088. #1564 fixed two lost-notification variants; the starvation variant fixed on this branch's predecessor showed the pattern keeps recurring as long as the accounting lives in two domains (lock-free queues + out-of-lock atomics). With all counters confined to the queue's critical section, these races are structurally impossible to express rather than patched:

- `waitingThreads` changes only while holding the lock, so a producer reading it under the lock always sees the exact number of sleepers: a notified-but-not-yet-awake worker no longer counts, and `backlog > sleepers` becomes an exact spawn decision (equivalent to the `queuedTasks` fix, without the atomics).
- `enqueue` stays lock-free for the queue itself (producers only serialize on a nanosecond-scale accounting section), preserving the concurrency that #428 introduced the lock-free queue for.

## Changes

- New `src/core/utils/TaskQueue`:
  - `enqueue()`: lock-free enqueue, then in-lock accounting; returns `Rejected` / `Enqueued` / `NeedsWorker`.
  - `waitForTask()`: `waiting++`, queue recheck, and `wait_for` all inside one critical section; any wakeup hands control back to the caller, which re-evaluates the pool state (task arrived, limit changed, queue closed) before claiming again.
  - `wakeAll()` / `close()` / `reset()` for limit changes and shutdown; `sleeperCount()` / `pendingCount()` for tests and assertions.
  - Low-priority gate rewritten in additive form (`totalThreads < lowPriorityThreads + waitingThreads`) so a stale pool snapshot cannot underflow the subtraction.
- `TaskGroup` reduced to the pool shell:
  - `spawnWorker()` reserves its slot via `fetch_add` first, so concurrent pushes cannot spawn past the cap.
  - `shrinkSelf()` replaces `shrinkThread()` (same CAS protocol).
  - `pushTask()` no longer touches any lock; `releaseThreads()` = `close()` + join all + `reset()`.
  - Removed: 5 atomic counters (only `closed` remains, inside the queue), the CAS shrink loop, the four-phase `popTask`, the `+1` spawn semantics, and the underflow guard.
- Tests:
  - `TaskBacklogSpawnsThreads` regression test for the wakeup-window starvation (two back-to-back pushes while the sole waiter is waking up must spawn a second worker).
  - `TaskRelease` / `MaxThreadCountShrink` adapted to the queue-based counters; unbounded polling loops replaced with bounded ones.

## Verification

- `TGFXFullTest_OpenGL` on top of current `main`: 606 tests pass.
- Task pool tests (`TaskRelease`, `TaskBacklogSpawnsThreads`, `MaxThreadCountShrink`) repeated 20x: 0 failures.