### PR TITLE
Fix a misplaced PDF vector mask by keeping the PictureImage crop matrix

### DIFF
--- a/src/pdf/PDFExportContext.cpp
+++ b/src/pdf/PDFExportContext.cpp
@@ -1397,6 +1397,9 @@ std::tuple<std::shared_ptr<Picture>, Matrix> MaskFilterToPicture(
       auto image = imageShader->image;
       if (Types::Get(image.get()) == Types::ImageType::Picture) {
         const auto pictureImage = static_cast<const PictureImage*>(imageShader->image.get());
+        if (pictureImage->matrix) {
+          matrix.preConcat(*pictureImage->matrix);
+        }
         return {pictureImage->picture, matrix};
       }
       return {nullptr, Matrix::I()};

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -411,7 +411,7 @@
         "NonRegularBlendMode": "bf721f63",
         "PendingRasterFlushOnPoll": "3b1fa4fa",
         "PendingRasterPlaceholder": "3b1fa4fa",
-        "PictureMask": "56f62a10",
+        "PictureMask": "f85f35d5",
         "ShapeNoiseStyle": "4b3579dc4",
         "SimpleText": "984e8f18",
         "SrcBlendOverlap": "bf721f63",

--- a/test/baseline/version.json
+++ b/test/baseline/version.json
@@ -411,6 +411,7 @@
         "NonRegularBlendMode": "bf721f63",
         "PendingRasterFlushOnPoll": "3b1fa4fa",
         "PendingRasterPlaceholder": "3b1fa4fa",
+        "PictureMask": "56f62a10",
         "ShapeNoiseStyle": "4b3579dc4",
         "SimpleText": "984e8f18",
         "SrcBlendOverlap": "bf721f63",

--- a/test/src/PDFExportTest.cpp
+++ b/test/src/PDFExportTest.cpp
@@ -28,6 +28,8 @@
 #include "tgfx/core/Image.h"
 #include "tgfx/core/ImageFilter.h"
 #include "tgfx/core/Paint.h"
+#include "tgfx/core/Picture.h"
+#include "tgfx/core/PictureRecorder.h"
 #include "tgfx/core/Point.h"
 #include "tgfx/core/RRect.h"
 #include "tgfx/core/Rect.h"
@@ -1013,6 +1015,53 @@ TGFX_TEST(PDFExportTest, BitmapMask) {
   PDFStream->flush();
 
   EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/BitmapMask"));
+}
+
+TGFX_TEST(PDFExportTest, PictureMask) {
+  ContextScope scope;
+  auto context = scope.getContext();
+  EXPECT_TRUE(context != nullptr);
+
+  // The mask picture draws a rounded rect (pill) at an offset inside a larger coordinate space,
+  // and it is cropped into a PictureImage the way layer content is wrapped by ToImageWithOffset.
+  // Masking a fill with it should reproduce the pill exactly; when the crop matrix is dropped
+  // (the bug this guards) the pill is torn into a hard-edged fragment instead, mirroring the
+  // production symptom. BitmapMask covers the bitmap path instead.
+  PictureRecorder recorder = {};
+  auto recordCanvas = recorder.beginRecording();
+  Paint shapePaint = {};
+  shapePaint.setColor(Color::White());
+  recordCanvas->drawRRect(RRect::MakeRectXY(Rect::MakeXYWH(40.f, 40.f, 120.f, 120.f), 24.f, 24.f),
+                          shapePaint);
+  auto picture = recorder.finishRecordingAsPicture();
+  EXPECT_TRUE(picture != nullptr);
+
+  // Crop the picture to (40, 40)-(160, 160): the pill lands at image (0, 0) exactly. A dropped
+  // crop matrix shifts it by 40 pixels on both axes.
+  auto cropMatrix = Matrix::MakeTrans(-40.f, -40.f);
+  auto maskImage = Image::MakeFrom(picture, 120, 120, &cropMatrix);
+  EXPECT_TRUE(maskImage != nullptr);
+
+  // Mirror the layer style construction: an image shader placed with a matrix, then wrapped in a
+  // ShaderMaskFilter.
+  auto maskShader = Shader::MakeImageShader(maskImage, TileMode::Decal, TileMode::Decal);
+  maskShader = maskShader->makeWithMatrix(Matrix::MakeScale(1.f, 1.f));
+  auto maskFilter = MaskFilter::MakeShader(maskShader);
+
+  auto PDFStream = MemoryWriteStream::Make();
+  auto document = PDFDocument::Make(PDFStream, context, PDFMetadata());
+  auto canvas = document->beginPage(300.f, 300.f);
+  canvas->drawColor(Color::White());
+  canvas->translate(50.f, 50.f);
+  Paint paint = {};
+  paint.setColor(Color::Red());
+  paint.setMaskFilter(maskFilter);
+  canvas->drawRect(Rect::MakeWH(120.f, 120.f), paint);
+  document->endPage();
+  document->close();
+  PDFStream->flush();
+
+  EXPECT_TRUE(ComparePDF(PDFStream, "PDFTest/PictureMask"));
 }
 
 TGFX_TEST(PDFExportTest, DropShadowLayer) {


### PR DESCRIPTION
## 概述

修复 PDF 导出中**矢量遮罩（`ShaderMaskFilter`）整体错位**的问题：`MaskFilterToPicture` 把 shader 链解包成原始 picture 时，丢失了 `PictureImage` 自带的裁剪矩阵，导致遮罩被画到图片原点而不是内容在图片中的真实位置。

症状（生产表现）：带玻璃/阴影效果的图层在 PDF 里可见内容正确，但**遮罩整体偏移**（偏移量等于内容的 tight-bounds 原点，例如玻璃描边的外扩量），形状被裁切成残片。

## 根因

`Image` 的契约是"一张 width×height 的像素网格"，`PictureImage::matrix` 是它内部把 picture 坐标映射到像素网格的变换（`ToImageWithOffset` 用 `MakeTrans(-bounds.x, -bounds.y)` 做紧凑裁剪）。

| 路径 | 是否处理该矩阵 |
|---|---|
| GPU：`PictureImage::asFragmentProcessor` → `drawPicture` | ✅ `totalMatrix.preConcat(*matrix)` |
| PDF：`MaskFilterToPicture` | ❌ **丢弃**（只收集 MatrixShader 链） |

因此绕过 Image 抽象、直接读 `pictureImage->picture` 的 PDF 降低逻辑必须自行补回该变换。

## 修复

`src/pdf/PDFExportContext.cpp` 中，在返回 picture 前把 `pictureImage->matrix` 并入放置矩阵（3 行）：

```cpp
if (pictureImage->matrix) {
  matrix.preConcat(*pictureImage->matrix);
}
```

组合方向与 GPU 路径（`PictureImage::drawPicture` 的 `preConcat`）一致。

## 测试

新增 `PDFExportTest.PictureMask`（原有 `BitmapMask` 只覆盖位图路径，注释中亦明确说明，向量 Picture 路径此前零覆盖）：

- 遮罩 picture 在裁剪范围内画一个圆角 pill，按 `ToImageWithOffset` 的方式裁剪成 `PictureImage`，再经 image shader + matrix 包装成 `ShaderMaskFilter`（与图层样式的构造一致），遮罩一个填满内容的矩形。
- 预期输出 = 完整的圆角 pill；缺陷态下遮罩偏移一个裁剪原点，pill 被撕裂成只剩一个圆角的残片——正是生产 bug 的形状撕裂症状，人眼与自动化比对都能直接识别。
- 已双向验证：含修复与还原修复的基线 md5 不同（覆盖该缺陷）。