### PR TITLE
Render each background style once per frame instead of once per tile.

### DIFF
--- a/include/tgfx/layers/DisplayList.h
+++ b/include/tgfx/layers/DisplayList.h
@@ -399,8 +399,9 @@ class DisplayList {
   void drawRootLayer(Surface* surface, const Rect& drawRect, const Matrix& viewMatrix,
                      bool autoClear, BackgroundSnapshotMap* snapshots) const;
 
-  std::unique_ptr<BackgroundSnapshotMap> captureBackgrounds(
-      Surface* surface, const std::vector<Rect>& renderRects) const;
+  std::unique_ptr<BackgroundSnapshotMap> captureBackgrounds(Surface* surface,
+                                                            const std::vector<Rect>& renderRects,
+                                                            bool shareStyleOutput) const;
 
   void updateMousePosition();
 };

--- a/include/tgfx/layers/Layer.h
+++ b/include/tgfx/layers/Layer.h
@@ -670,6 +670,11 @@ class Layer : public std::enable_shared_from_this<Layer> {
   void drawLayerStyleDefault(const DrawArgs& args, Canvas* canvas, float alpha, LayerStyle* style,
                              const LayerStyleSource* source);
 
+  std::shared_ptr<Image> renderBackgroundStyleToImage(const DrawArgs& args, LayerStyle* style,
+                                                      const LayerStyleSource* source,
+                                                      std::shared_ptr<Image> backgroundImage,
+                                                      const Point& backgroundOffset, Point* offset);
+
   // Walks ancestors and prior siblings, painting their content + Below styles into canvas. Used
   // by synthesizeBackgroundImage for the picture-canvas fallback. Returns the cumulative alpha
   // after the parent chain. Each frame passes its `this` to the parent as stopChild so siblings

--- a/src/layers/BackgroundHandler.cpp
+++ b/src/layers/BackgroundHandler.cpp
@@ -239,8 +239,18 @@ void BackgroundCapturer::drawBackgroundStyle(const DrawArgs& args, Canvas* canva
   if (image == nullptr) {
     return;
   }
+  if (snapshots->shareStyleOutput) {
+    Point styleOffset = {};
+    auto styleImage =
+        layer->renderBackgroundStyleToImage(args, style, source, image, offset, &styleOffset);
+    if (styleImage != nullptr) {
+      snapshots->snapshots[BackgroundSnapshotKey{layer, style}].push_back(
+          BackgroundSnapshotEntry{std::move(styleImage), styleOffset, true});
+      return;
+    }
+  }
   snapshots->snapshots[BackgroundSnapshotKey{layer, style}].push_back(
-      BackgroundSnapshotEntry{std::move(image), offset});
+      BackgroundSnapshotEntry{std::move(image), offset, false});
 }
 
 const LayerStyleSource* BackgroundCapturer::getCachedLayerStyleSource(Layer* layer) const {
@@ -310,6 +320,7 @@ void BackgroundConsumer::drawBackgroundStyle(const DrawArgs& args, Canvas* canva
   const auto& contentEntry = group->content;
   std::shared_ptr<Image> bgImage = nullptr;
   Point bgOffset = {};
+  bool isStyleOutput = false;
   if (snapshots != nullptr) {
     BackgroundSnapshotKey key{layer, style};
     auto it = snapshots->snapshots.find(key);
@@ -326,6 +337,7 @@ void BackgroundConsumer::drawBackgroundStyle(const DrawArgs& args, Canvas* canva
     auto& entry = it->second[cursor++];
     bgImage = entry.image;
     bgOffset = entry.offset;
+    isStyleOutput = entry.isStyleOutput;
   } else {
     // Picture-canvas path: capture was skipped because there is no GPU context. Synthesize the
     // backdrop on the fly by walking ancestors and prior siblings via PictureRecorder.
@@ -338,6 +350,16 @@ void BackgroundConsumer::drawBackgroundStyle(const DrawArgs& args, Canvas* canva
   auto matrix = Matrix::MakeScale(1.f / source->contentScale, 1.f / source->contentScale);
   matrix.preTranslate(contentEntry.offset.x, contentEntry.offset.y);
   canvas->concat(matrix);
+  if (isStyleOutput) {
+    // The capture pass already rendered the style; only compositing is left, and it must happen
+    // against the real destination, which may already hold earlier styles that the backdrop slice
+    // does not carry.
+    Paint paint = {};
+    paint.setAlpha(alpha);
+    paint.setBlendMode(style->blendMode());
+    canvas->drawImage(bgImage, bgOffset.x, bgOffset.y, &paint);
+    return;
+  }
   auto backgroundOffset = bgOffset - contentEntry.offset;
   LayerStyleInput styleInput = {};
   styleInput.content = contentEntry.image;

--- a/src/layers/BackgroundSnapshotMap.h
+++ b/src/layers/BackgroundSnapshotMap.h
@@ -30,13 +30,15 @@ class Layer;
 class LayerStyle;
 
 /**
- * A snapshot of the background image and its offset captured during the capture pass for a
- * specific (Layer, LayerStyle) pair. Consumed during the consume pass by LayerStyle::draw via
- * LayerStyleInput::extraSource.
+ * A snapshot produced during the capture pass for a specific (Layer, LayerStyle) pair. When
+ * isStyleOutput is true the image is the rendered style itself and every consume pass blits it
+ * instead of re-running LayerStyle::draw. Otherwise it is the raw backdrop slice and the consume
+ * pass renders the style as usual. Consumed by LayerStyle::draw via LayerStyleInput::extraSource.
  */
 struct BackgroundSnapshotEntry {
   std::shared_ptr<Image> image = nullptr;
   Point offset = Point::Zero();
+  bool isStyleOutput = false;
 };
 
 /**
@@ -97,6 +99,11 @@ struct BackgroundSnapshotMap {
                      BackgroundSnapshotKeyHash>
       snapshots = {};
   std::unordered_map<Layer*, std::unique_ptr<LayerStyleSource>> layerStyleSources = {};
+  // Set when one capture pass serves several consume passes (tiled rendering, multiple dirty
+  // rects). The capture pass then renders each background style into an image that every consume
+  // pass blits, instead of re-running the style per pass. Sub-handlers inherit it automatically
+  // because they share this map.
+  bool shareStyleOutput = false;
 };
 
 }  // namespace tgfx

--- a/src/layers/DisplayList.cpp
+++ b/src/layers/DisplayList.cpp
@@ -349,7 +349,7 @@ std::vector<Rect> DisplayList::renderDirect(Surface* surface, bool autoClear) co
   auto surfaceRect = Rect::MakeWH(surface->width(), surface->height());
   std::unique_ptr<BackgroundSnapshotMap> snapshotMap = nullptr;
   if (_root->hasBackgroundStyle()) {
-    snapshotMap = captureBackgrounds(surface, {surfaceRect});
+    snapshotMap = captureBackgrounds(surface, {surfaceRect}, false);
   }
   drawRootLayer(surface, surfaceRect, getViewMatrix(), autoClear, snapshotMap.get());
   return {Rect::MakeEmpty()};
@@ -410,7 +410,7 @@ std::vector<Rect> DisplayList::renderPartial(Surface* surface, bool autoClear,
   // gaps between scattered dirty regions get skipped.
   std::unique_ptr<BackgroundSnapshotMap> snapshotMap = nullptr;
   if (_root->hasBackgroundStyle()) {
-    snapshotMap = captureBackgrounds(surface, renderRects);
+    snapshotMap = captureBackgrounds(surface, renderRects, renderRects.size() > 1);
   }
   auto canvas = surface->getCanvas();
   for (auto& drawRect : renderRects) {
@@ -456,7 +456,7 @@ std::vector<Rect> DisplayList::renderTiled(Surface* surface, bool autoClear,
       captureRect.offset(_contentOffset.x, _contentOffset.y);
       captureRects.push_back(captureRect);
     }
-    snapshotMap = captureBackgrounds(surface, captureRects);
+    snapshotMap = captureBackgrounds(surface, captureRects, tileTasks.size() > 1);
   }
   std::vector<Rect> dirtyRects = {};
   auto surfaceRect = Rect::MakeWH(surface->width(), surface->height());
@@ -1177,7 +1177,7 @@ void DisplayList::drawRootLayer(Surface* surface, const Rect& drawRect, const Ma
 }
 
 std::unique_ptr<BackgroundSnapshotMap> DisplayList::captureBackgrounds(
-    Surface* surface, const std::vector<Rect>& renderRects) const {
+    Surface* surface, const std::vector<Rect>& renderRects, bool shareStyleOutput) const {
   DEBUG_ASSERT(surface != nullptr);
   if (!_root->hasBackgroundStyle()) {
     return nullptr;
@@ -1224,6 +1224,7 @@ std::unique_ptr<BackgroundSnapshotMap> DisplayList::captureBackgrounds(
     return nullptr;
   }
   auto snapshotMap = std::make_unique<BackgroundSnapshotMap>();
+  snapshotMap->shareStyleOutput = shareStyleOutput;
   // Draw backgroundColor before the layer tree so that the capture pass includes it as part of
   // the background for blur/backdrop effects.
   if (_backgroundColor != Color::Transparent()) {

--- a/src/layers/Layer.cpp
+++ b/src/layers/Layer.cpp
@@ -1948,6 +1948,70 @@ void Layer::drawLayerStyleDefault(const DrawArgs& /*args*/, Canvas* canvas, floa
   layerStyle->draw(canvas, styleInput, alpha);
 }
 
+std::shared_ptr<Image> Layer::renderBackgroundStyleToImage(const DrawArgs& args, LayerStyle* style,
+                                                           const LayerStyleSource* source,
+                                                           std::shared_ptr<Image> backgroundImage,
+                                                           const Point& backgroundOffset,
+                                                           Point* offset) {
+  if (args.context == nullptr || style == nullptr || source == nullptr ||
+      backgroundImage == nullptr || offset == nullptr) {
+    return nullptr;
+  }
+  auto groupIndex = static_cast<int>(style->excludeChildEffects());
+  auto* group = source->groups[groupIndex].get();
+  if (group == nullptr) {
+    return nullptr;
+  }
+  const auto& contentEntry = group->content;
+  auto contentScale = source->contentScale;
+  if (FloatNearlyZero(contentScale)) {
+    return nullptr;
+  }
+
+  PictureRecorder recorder = {};
+  auto* recording = recorder.beginRecording();
+  // Record at content-pixel resolution, then apply the same transform the consume pass uses, so
+  // the picture lands in the content image space the style draws into.
+  recording->scale(contentScale, contentScale);
+  auto matrix = Matrix::MakeScale(1.f / contentScale, 1.f / contentScale);
+  matrix.preTranslate(contentEntry.offset.x, contentEntry.offset.y);
+  recording->concat(matrix);
+
+  LayerStyleInput styleInput = {};
+  styleInput.content = contentEntry.image;
+  styleInput.contentOffset = contentEntry.offset;
+  styleInput.contentScale = contentScale;
+  styleInput.extraSources.push_back(std::make_shared<StyleInputSource>(
+      std::move(backgroundImage), backgroundOffset - contentEntry.offset));
+  auto sourceFlags = style->extraSourceType();
+  if (HasExtraSource(sourceFlags, LayerStyleExtraSourceType::Contour)) {
+    auto contourImage = group->contour.has_value() ? group->contour->image : nullptr;
+    auto contourOffset =
+        contourImage ? group->contour->offset - contentEntry.offset : Point::Zero();
+    styleInput.extraSources.push_back(std::make_shared<ContourInputSource>(
+        std::move(contourImage), contourOffset, source->contentShape));
+  }
+  // The style's own blend mode is skipped on purpose: it would blend against this transparent
+  // offscreen instead of the real destination, which may already hold earlier styles that the
+  // backdrop slice does not carry. Both the blend mode and the consume-time alpha are applied
+  // when the result is blitted.
+  style->onDraw(recording, styleInput, 1.0f, BlendMode::SrcOver);
+
+  auto picture = recorder.finishRecordingAsPicture();
+  if (picture == nullptr) {
+    return nullptr;
+  }
+  Point imageOffset = {};
+  auto image = ToImageWithOffset(std::move(picture), &imageOffset, nullptr, args.dstColorSpace);
+  if (image == nullptr) {
+    return nullptr;
+  }
+  // The recorded space is the content image space shifted by contentEntry.offset, so translate
+  // back to let the caller blit under the consume pass transform.
+  *offset = imageOffset - contentEntry.offset;
+  return image->makeTextureImage(args.context);
+}
+
 bool Layer::getLayersUnderPointInternal(float x, float y,
                                         std::vector<std::shared_ptr<Layer>>* results) {
   bool hasLayerUnderPoint = false;


### PR DESCRIPTION
## Problem

In tiled rendering every tile replays the whole layerStyle draw path, so a background style
(`BackgroundBlur`, `Glass`, ...) is re-rendered once per tile it overlaps — even though the backdrop
snapshot it consumes is already shared across all tiles. The style's input images
(`BackgroundSnapshotMap::layerStyleSources`) are shared per frame, but the rendered output is not.

## Change

The first consume pass that needs a background style renders it once into an image, cached in
`BackgroundSnapshotMap::styleResults` for the rest of the frame; every later consume pass blits that
image instead of re-running the style.

Three details worth calling out:

- **Rendering happens in the consume pass, not during capture.** The capture pass walks a different
  canvas transform (the offscreen content path leaves the canvas at the layer-local origin), so its
  `contentScale` can differ from the consume pass's. Rasterizing during capture produced visibly
  wrong results in tiled mode for that reason.
- **The style's own blend mode and the consume-time alpha are applied when blitting**, not when
  rendering: the offscreen destination is transparent, while the real destination may already hold
  earlier styles that the backdrop slice does not carry.
- **`renderDirect` keeps the old path.** With a single consume pass, rendering to an offscreen and
  blitting back is strictly more work than drawing directly.

## Known behavior difference

`BackgroundBlurStyle` clips its backdrop to the current canvas clip before running `makeWithFilter`.
Per-tile it therefore blurs a small (e.g. 62x62) slice, while the shared path blurs the whole
(225x225) backdrop at once. `makeWithFilter` is not size-invariant: the whole blurred region shifts
by up to **9/255** on ~10% of pixels. Blur radius and contentScale are identical on both paths, so
this comes purely from the input extent.

It is not visually perceptible, but it is not bit-identical, so background-style screenshot
baselines need updating.

## Measurements

1600x1200 surface, 12 `BackgroundBlurStyle` layers on a 4x3 grid, 30 frames with full redraw and
`flushAndSubmit(true)` per frame:

| | renderPasses | drawOps | encode |
|---|---|---|---|
| before | 315 | 432 | ~15.5 ms |
| after | 99 | 252 | ~7.0 ms |

Real-editor logs (same set of operations, heavy frames only): render passes -60%, draw ops -55%,
encode -33%. The pass/op reduction is the hard number — encode only covers CPU-side command
encoding, so the GPU-side saving is not fully reflected there.

## Testing

- Full `TGFXFullTest_OpenGL` suite passes (649 tests).
- Verified the shared path is actually taken and that it produces the visually identical result.